### PR TITLE
Make drawer buttons take up all horizontal space

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -26,8 +26,10 @@ import androidx.ui.core.Text
 import androidx.ui.core.dp
 import androidx.ui.foundation.shape.corner.RoundedCornerShape
 import androidx.ui.graphics.Color
+import androidx.ui.layout.Arrangement
 import androidx.ui.layout.Column
 import androidx.ui.layout.Expanded
+import androidx.ui.layout.ExpandedWidth
 import androidx.ui.layout.Gravity
 import androidx.ui.layout.HeightSpacer
 import androidx.ui.layout.Row
@@ -140,12 +142,16 @@ private fun DrawerButton(
     }
 
     Surface(
-        modifier = modifier wraps Spacing(left = 8.dp, top = 8.dp, right = 8.dp),
+        modifier = modifier wraps Spacing(
+            left = 8.dp,
+            top = 8.dp,
+            right = 8.dp
+        ),
         color = backgroundColor,
         shape = RoundedCornerShape(4.dp)
     ) {
         Button(onClick = action, style = TextButtonStyle()) {
-            Row {
+            Row(arrangement = Arrangement.Begin) {
                 VectorImage(
                     modifier = Gravity.Center,
                     id = icon,
@@ -156,7 +162,8 @@ private fun DrawerButton(
                     text = label,
                     style = (+MaterialTheme.typography()).body2.copy(
                         color = textIconColor
-                    )
+                    ),
+                    modifier = ExpandedWidth
                 )
             }
         }


### PR DESCRIPTION
This tiny PR makes the drawer buttons take up all horizontal space instead of the awkward left-aligned behaviour they have currently.

 Before | After
 --- | ---
 ![Screenshot_1578933836](https://user-images.githubusercontent.com/153802/72274357-49a17380-362c-11ea-91d5-5eef96c9066a.png) | ![Screenshot_1578933266](https://user-images.githubusercontent.com/153802/72274375-57ef8f80-362c-11ea-8981-9a185c3a57c2.png)

