### PR TITLE
[Jetsnack] Provide default value for `InsetsAmbient`. 

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/utils/Insets.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/utils/Insets.kt
@@ -118,7 +118,7 @@ class Insets {
         internal set
 }
 
-val InsetsAmbient = staticAmbientOf<DisplayInsets>()
+val InsetsAmbient = staticAmbientOf { DisplayInsets() }
 
 /**
  * Applies any [WindowInsetsCompat] values to [InsetsAmbient], which are then available


### PR DESCRIPTION
Fixes #130 