### PR TITLE
Update Gradle cache version to jars-8

### DIFF
--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 
@@ -85,7 +85,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 

--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project
@@ -84,9 +84,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Run instrumentation tests

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 
@@ -85,7 +85,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project
@@ -84,9 +84,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Run instrumentation tests

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 
@@ -85,7 +85,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project
@@ -84,9 +84,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Run instrumentation tests

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 

--- a/.github/workflows/Rally.yaml
+++ b/.github/workflows/Rally.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-8
-            ~/.gradle/caches/build-cache-1
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Build project

--- a/.github/workflows/Rally.yaml
+++ b/.github/workflows/Rally.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/jars-8
             ~/.gradle/caches/build-cache-1
           key: gradle-${{ hashFiles('checksum.txt') }}
 


### PR DESCRIPTION
I have noticed that I do not have directory `~/.gradle/caches/jars-3` locally.
On my computer `ls ~/.gradle/caches/ | grep jars` returns jars-8 only.

Reference: https://github.com/gradle/gradle/blob/1e3ce9cf4394e3e0e290ef4a647ffb5e0d1343dc/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java#L46

All samples use Gradle 6.6 at the moment:

`grep -R distributionUrl`

> Owl/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
Jetsnack/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
JetNews/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
Jetchat/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
Jetsurvey/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
Crane/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
Rally/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
Jetcaster/gradle/wrapper/gradle-wrapper.properties:distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip