### PR TITLE
add imeAction to email & password text field

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInScreen.kt
@@ -38,6 +38,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.ExperimentalFocus
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.ui.tooling.preview.Preview
@@ -87,18 +90,24 @@ fun SignIn(onNavigationEvent: (SignInEvent) -> Unit) {
     }
 }
 
+@OptIn(ExperimentalFocus::class)
 @Composable
-fun SignInContent(onSignInSubmitted: (email: String, password: String) -> Unit) {
+fun SignInContent(
+    onSignInSubmitted: (email: String, password: String) -> Unit,
+) {
     Column(modifier = Modifier.fillMaxWidth()) {
+        val focusRequester = remember { FocusRequester() }
         val emailState = remember { EmailState() }
-        Email(emailState)
+        Email(emailState, onImeAction = { focusRequester.requestFocus() })
 
         Spacer(modifier = Modifier.preferredHeight(16.dp))
 
         val passwordState = remember { PasswordState() }
         Password(
             label = stringResource(id = R.string.password),
-            passwordState = passwordState
+            passwordState = passwordState,
+            modifier = Modifier.focusRequester(focusRequester),
+            onImeAction = { onSignInSubmitted(emailState.text, passwordState.text) }
         )
         Spacer(modifier = Modifier.preferredHeight(16.dp))
         Button(

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.focus.ExperimentalFocus
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focusObserver
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
@@ -110,10 +111,16 @@ private fun SignInSignUpTopAppBar(topAppBarText: String, onBackPressed: () -> Un
 
 @OptIn(ExperimentalFocus::class)
 @Composable
-fun Email(emailState: TextFieldState = remember { EmailState() }) {
+fun Email(
+    emailState: TextFieldState = remember { EmailState() },
+    imeAction: ImeAction = ImeAction.Next,
+    onImeAction: () -> Unit = {}
+) {
     OutlinedTextField(
         value = emailState.text,
-        onValueChange = { emailState.text = it },
+        onValueChange = {
+            emailState.text = it
+        },
         label = {
             ProvideEmphasis(emphasis = EmphasisAmbient.current.medium) {
                 Text(
@@ -130,14 +137,27 @@ fun Email(emailState: TextFieldState = remember { EmailState() }) {
             }
         },
         textStyle = MaterialTheme.typography.body2,
-        isErrorValue = emailState.showErrors()
+        isErrorValue = emailState.showErrors(),
+        imeAction = imeAction,
+        onImeActionPerformed = { action, softKeyboardController ->
+            if (action == ImeAction.Done) {
+                softKeyboardController?.hideSoftwareKeyboard()
+            }
+            onImeAction()
+        }
     )
 
     emailState.getError()?.let { error -> TextFieldError(textError = error) }
 }
 
 @Composable
-fun Password(label: String, passwordState: TextFieldState) {
+fun Password(
+    label: String,
+    passwordState: TextFieldState,
+    modifier: Modifier = Modifier,
+    imeAction: ImeAction = ImeAction.Done,
+    onImeAction: () -> Unit = {}
+) {
     val showPassword = remember { mutableStateOf(false) }
     OutlinedTextField(
         value = passwordState.text,
@@ -145,7 +165,7 @@ fun Password(label: String, passwordState: TextFieldState) {
             passwordState.text = it
             passwordState.enableShowErrors()
         },
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         textStyle = MaterialTheme.typography.body2,
         label = {
             ProvideEmphasis(emphasis = EmphasisAmbient.current.medium) {
@@ -171,7 +191,14 @@ fun Password(label: String, passwordState: TextFieldState) {
         } else {
             PasswordVisualTransformation()
         },
-        isErrorValue = passwordState.showErrors()
+        isErrorValue = passwordState.showErrors(),
+        imeAction = imeAction,
+        onImeActionPerformed = { action, softKeyboardController ->
+            if (action == ImeAction.Done) {
+                softKeyboardController?.hideSoftwareKeyboard()
+            }
+            onImeAction()
+        }
     )
 
     passwordState.getError()?.let { error -> TextFieldError(textError = error) }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignUpScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignUpScreen.kt
@@ -28,7 +28,11 @@ import androidx.compose.material.ProvideEmphasis
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.ExperimentalFocus
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.ui.tooling.preview.Preview
 import com.example.compose.jetsurvey.R
@@ -59,24 +63,34 @@ fun SignUp(onNavigationEvent: (SignUpEvent) -> Unit) {
     }
 }
 
+@OptIn(ExperimentalFocus::class)
 @Composable
-fun SignUpContent(onSignUpSubmitted: (email: String, password: String) -> Unit) {
+fun SignUpContent(
+    onSignUpSubmitted: (email: String, password: String) -> Unit,
+) {
     Column(modifier = Modifier.fillMaxWidth()) {
+        val passwordFocusRequest = remember { FocusRequester() }
+        val confirmationPasswordFocusRequest = remember { FocusRequester() }
         val emailState = remember { EmailState() }
-        Email(emailState)
+        Email(emailState, onImeAction = { passwordFocusRequest.requestFocus() })
 
         Spacer(modifier = Modifier.preferredHeight(16.dp))
         val passwordState = remember { PasswordState() }
         Password(
             label = stringResource(id = R.string.password),
-            passwordState = passwordState
+            passwordState = passwordState,
+            imeAction = ImeAction.Next,
+            onImeAction = { confirmationPasswordFocusRequest.requestFocus() },
+            modifier = Modifier.focusRequester(passwordFocusRequest)
         )
 
         Spacer(modifier = Modifier.preferredHeight(16.dp))
         val confirmPasswordState = remember { ConfirmPasswordState(passwordState = passwordState) }
         Password(
             label = stringResource(id = R.string.confirm_password),
-            passwordState = confirmPasswordState
+            passwordState = confirmPasswordState,
+            onImeAction = { onSignUpSubmitted(emailState.text, passwordState.text) },
+            modifier = Modifier.focusRequester(confirmationPasswordFocusRequest)
         )
 
         Spacer(modifier = Modifier.preferredHeight(16.dp))

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/WelcomeScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/WelcomeScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.onPositioned
 import androidx.compose.ui.platform.DensityAmbient
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Constraints.Companion.Infinity
@@ -151,6 +152,7 @@ private fun SignInCreateAccount(
     onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val emailState = remember { EmailState() }
     Column(modifier = modifier, horizontalGravity = Alignment.CenterHorizontally) {
         ProvideEmphasis(emphasis = EmphasisAmbient.current.medium) {
             Text(
@@ -160,18 +162,17 @@ private fun SignInCreateAccount(
                 modifier = Modifier.padding(vertical = 24.dp)
             )
         }
-        val emailState = remember { EmailState() }
+        val onSubmit = {
+            if (emailState.isValid) {
+                onEvent(WelcomeEvent.SignInSignUp(emailState.text))
+            } else {
+                emailState.enableShowErrors()
+            }
+        }
         onFocusChange(emailState.isFocused)
-        Email(emailState)
-
+        Email(emailState = emailState, imeAction = ImeAction.Done, onImeAction = onSubmit)
         Button(
-            onClick = {
-                if (emailState.isValid) {
-                    onEvent(WelcomeEvent.SignInSignUp(emailState.text))
-                } else {
-                    emailState.enableShowErrors()
-                }
-            },
+            onClick = onSubmit,
             modifier = Modifier.fillMaxWidth().padding(vertical = 28.dp)
         ) {
             Text(


### PR DESCRIPTION
added imeAction for email & password text field on the Welcome screen, Signup screen, and Sign-in screen. 
1. Welcome Screen
    When you tap enter on the welcome screen it will perform the same action as tapping on continue.
2. Sign-in Screen
    When you tap enter on email it will transfer focus to the password text field. When you tap enter on the password text
    field it will call onSignInSubmitted
3. Signup Screen
    The first two text field will transfer focus, the last one will call onSignUpSubmitted

example on welcome screen.
<img src="https://user-images.githubusercontent.com/49428722/92267658-243ede00-ef0b-11ea-831b-de2b178e8db6.gif" width="256"/>
