### PR TITLE
[Jetsurvey] Add ScrollableColumn to SurveyResult

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -18,9 +18,8 @@ package com.example.compose.jetsurvey.survey
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Icon
+import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.Text
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope.weight
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope.gravity
 import androidx.compose.foundation.layout.Spacer
@@ -117,7 +116,7 @@ fun SurveyResultScreen(
 
 @Composable
 private fun SurveyResult(result: SurveyState.Result, modifier: Modifier = Modifier) {
-    Column(modifier = modifier.fillMaxSize()) {
+    ScrollableColumn(modifier = modifier.fillMaxSize()) {
         Spacer(modifier = Modifier.preferredHeight(44.dp))
         Text(
             text = result.surveyResult.library,
@@ -135,7 +134,7 @@ private fun SurveyResult(result: SurveyState.Result, modifier: Modifier = Modifi
         Text(
             text = stringResource(result.surveyResult.description),
             style = MaterialTheme.typography.body1,
-            modifier = Modifier.weight(1f).padding(horizontal = 20.dp)
+            modifier = Modifier.padding(horizontal = 20.dp)
         )
     }
 }


### PR DESCRIPTION
The Jetsurvey result is not scrollable on landscape or split-screen mode, so I replaced Column with ScrollableColumn and now it's scrollable.

like this.
![Screenshot_20200908-221737](https://user-images.githubusercontent.com/49428722/92496352-3928b380-f222-11ea-8a17-8c10ed150c62.png)


