### PR TITLE
Update JetNews to alpha03.

### DIFF
--- a/JetNews/.gitignore
+++ b/JetNews/.gitignore
@@ -1,8 +1,15 @@
 *.iml
 .gradle
 /local.properties
-/.idea
+/.idea/caches
+/.idea/libraries
+/.idea/modules.xml
+/.idea/workspace.xml
+/.idea/navEditor.xml
+/.idea/assetWizardSettings.xml
 .DS_Store
 /build
 /captures
 .externalNativeBuild
+.cxx
+local.properties

--- a/JetNews/app/build.gradle
+++ b/JetNews/app/build.gradle
@@ -67,18 +67,18 @@ dependencies {
     implementation "androidx.compose.foundation:foundation:$compose_version"
     implementation "androidx.compose.animation:animation:$compose_version"
     implementation "androidx.ui:ui-tooling:$compose_version"
-    implementation 'androidx.appcompat:appcompat:1.3.0-alpha01'
-    implementation 'androidx.activity:activity-ktx:1.1.0'
-    implementation 'androidx.core:core-ktx:1.5.0-alpha01'
-
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
 
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.0-alpha06"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-alpha06"
+    implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
+    implementation 'androidx.activity:activity-ktx:1.1.0'
+    implementation 'androidx.core:core-ktx:1.5.0-alpha02'
+
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.0-alpha07"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-alpha07"
 
     androidTestImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation "androidx.ui:ui-test:$compose_version"
 }
 

--- a/JetNews/app/src/androidTest/java/com/example/jetnews/HomeScreenSnackbarTest.kt
+++ b/JetNews/app/src/androidTest/java/com/example/jetnews/HomeScreenSnackbarTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetnews
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.runtime.snapshots.snapshotFlow
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.ui.test.assertIsDisplayed
+import androidx.ui.test.createComposeRule
+import androidx.ui.test.onNodeWithText
+import com.example.jetnews.ui.home.HomeScreen
+import com.example.jetnews.ui.state.UiState
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Checks that the Snackbar is shown when the HomeScreen data contains an error.
+ */
+class HomeScreenSnackbarTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule(disableTransitions = true)
+
+    @OptIn(
+        ExperimentalMaterialApi::class,
+        ExperimentalComposeApi::class
+    )
+    @Test
+    fun postsContainError_snackbarShown() {
+        val snackbarHostState = SnackbarHostState()
+        composeTestRule.setContent {
+            val scaffoldState = rememberScaffoldState(snackbarHostState = snackbarHostState)
+
+            // When the Home screen receives data with an error
+            HomeScreen(
+                posts = UiState(exception = IllegalStateException()),
+                favorites = emptySet(),
+                onToggleFavorite = {},
+                onRefreshPosts = {},
+                onErrorDismiss = {},
+                navigateTo = {},
+                scaffoldState = scaffoldState
+            )
+        }
+
+        // Then the first message received in the Snackbar is an error message
+        val snackbarText = InstrumentationRegistry.getInstrumentation()
+            .targetContext.resources.getString(R.string.load_error)
+        runBlocking {
+            // snapshotFlow converts a State to a Kotlin Flow so we can observe it
+            // wait for the first a non-null `currentSnackbarData`
+            snapshotFlow { snackbarHostState.currentSnackbarData }.filterNotNull().first()
+            composeTestRule.onNodeWithText(snackbarText, false, false).assertIsDisplayed()
+        }
+    }
+}

--- a/JetNews/app/src/androidTest/java/com/example/jetnews/JetnewsUiTest.kt
+++ b/JetNews/app/src/androidTest/java/com/example/jetnews/JetnewsUiTest.kt
@@ -21,7 +21,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.ui.test.assertIsDisplayed
 import androidx.ui.test.createComposeRule
 import androidx.ui.test.hasSubstring
-import androidx.ui.test.onAllNodes
 import androidx.ui.test.onNodeWithText
 import androidx.ui.test.performClick
 import org.junit.Before
@@ -41,16 +40,16 @@ class JetnewsUiTest {
         composeTestRule.launchJetNewsApp(InstrumentationRegistry.getInstrumentation().targetContext)
     }
 
-    @Ignore // TODO Investigate why this passes locally but fail on CI
+    @Ignore("TODO Investigate why this passes locally but fail on CI")
     @Test
     fun app_launches() {
-        onNodeWithText("Jetnews").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Jetnews").assertIsDisplayed()
     }
 
-    @Ignore // TODO Investigate why this passes locally but fail on CI
+    @Ignore("TODO Investigate why this passes locally but fail on CI")
     @Test
     fun app_opensArticle() {
-        onAllNodes(hasSubstring("Manuel Vivo"))[0].performClick()
-        onAllNodes(hasSubstring("3 min read"))[0].assertIsDisplayed()
+        composeTestRule.onAllNodes(hasSubstring("Manuel Vivo"))[0].performClick()
+        composeTestRule.onAllNodes(hasSubstring("3 min read"))[0].assertIsDisplayed()
     }
 }

--- a/JetNews/app/src/androidTest/java/com/example/jetnews/TestHelper.kt
+++ b/JetNews/app/src/androidTest/java/com/example/jetnews/TestHelper.kt
@@ -19,14 +19,14 @@ package com.example.jetnews
 import android.content.Context
 import androidx.compose.runtime.remember
 import androidx.lifecycle.SavedStateHandle
-import androidx.ui.test.ComposeTestRule
+import androidx.ui.test.ComposeTestRuleJUnit
 import com.example.jetnews.ui.JetnewsApp
 import com.example.jetnews.ui.NavigationViewModel
 
 /**
  * Launches the app from a test context
  */
-fun ComposeTestRule.launchJetNewsApp(context: Context) {
+fun ComposeTestRuleJUnit.launchJetNewsApp(context: Context) {
     setContent {
         JetnewsApp(
             TestAppContainer(context),

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -180,7 +180,7 @@ private fun DrawerButton(
         ) {
             Row(
                 horizontalArrangement = Arrangement.Start,
-                verticalGravity = Alignment.CenterVertically,
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Image(

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
@@ -171,7 +171,7 @@ private fun BottomBar(
 ) {
     Surface(elevation = 2.dp) {
         Row(
-            verticalGravity = Alignment.CenterVertically,
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .preferredHeight(56.dp)
                 .fillMaxWidth()

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/PostContent.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/PostContent.kt
@@ -25,9 +25,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
-import androidx.compose.foundation.layout.preferredHeightIn
 import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.foundation.layout.preferredWidth
 import androidx.compose.foundation.shape.CircleShape
@@ -101,7 +101,7 @@ fun PostContent(post: Post, modifier: Modifier = Modifier) {
 private fun PostHeaderImage(post: Post) {
     post.image?.let { image ->
         val imageModifier = Modifier
-            .preferredHeightIn(minHeight = 180.dp)
+            .heightIn(min = 180.dp)
             .fillMaxWidth()
             .clip(shape = MaterialTheme.shapes.medium)
         Image(image, imageModifier, contentScale = ContentScale.Crop)

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
@@ -16,17 +16,12 @@
 
 package com.example.jetnews.ui.home
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Box
 import androidx.compose.foundation.Icon
 import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.ScrollableRow
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.contentColor
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -43,7 +38,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
 import androidx.compose.material.Scaffold
 import androidx.compose.material.ScaffoldState
-import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarResult
 import androidx.compose.material.Surface
 import androidx.compose.material.TextButton
@@ -73,9 +67,7 @@ import com.example.jetnews.ui.Screen
 import com.example.jetnews.ui.SwipeToRefreshLayout
 import com.example.jetnews.ui.ThemedPreview
 import com.example.jetnews.ui.state.UiState
-import com.example.jetnews.ui.theme.snackbarAction
 import com.example.jetnews.utils.launchUiStateProducer
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.Text
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.contentColor
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Stack
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredSize
@@ -38,12 +37,14 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.DrawerValue
 import androidx.compose.material.EmphasisAmbient
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
 import androidx.compose.material.Scaffold
 import androidx.compose.material.ScaffoldState
 import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarResult
 import androidx.compose.material.Surface
 import androidx.compose.material.TextButton
 import androidx.compose.material.TopAppBar
@@ -57,6 +58,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ContextAmbient
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -122,11 +124,13 @@ fun HomeScreen(
  * Stateless composable is not coupled to any specific state management.
  *
  * @param posts (state) the data to show on the screen
+ * @param favorites (state) favorite posts
+ * @param onToggleFavorite (event) toggles favorite for a post
  * @param onRefreshPosts (event) request a refresh of posts
  * @param onErrorDismiss (event) request the current error be dismissed
  * @param navigateTo (event) request navigation to [Screen]
- * @param scaffoldState (state) state for the [Scaffold] component on this screen
  */
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun HomeScreen(
     posts: UiState<List<Post>>,
@@ -137,6 +141,24 @@ fun HomeScreen(
     navigateTo: (Screen) -> Unit,
     scaffoldState: ScaffoldState
 ) {
+    if (posts.hasError) {
+        val errorMessage = stringResource(id = R.string.load_error)
+        val retryMessage = stringResource(id = R.string.retry)
+        // Show snackbar using a coroutine, when the coroutine is cancelled the snackbar will
+        // automatically dismiss. This coroutine will cancel whenever posts.hasError changes, and
+        // only start when posts.hasError is true (due to the above if-check).
+        launchInComposition(posts.hasError) {
+            val snackbarResult = scaffoldState.snackbarHostState.showSnackbar(
+                message = errorMessage,
+                actionLabel = retryMessage
+            )
+            when (snackbarResult) {
+                SnackbarResult.ActionPerformed -> onRefreshPosts()
+                SnackbarResult.Dismissed -> onErrorDismiss()
+            }
+        }
+    }
+
     Scaffold(
         scaffoldState = scaffoldState,
         drawerContent = {
@@ -147,8 +169,9 @@ fun HomeScreen(
             )
         },
         topBar = {
+            val title = stringResource(id = R.string.app_name)
             TopAppBar(
-                title = { Text(text = "Jetnews") },
+                title = { Text(text = title) },
                 navigationIcon = {
                     IconButton(onClick = { scaffoldState.drawerState.open() }) {
                         Icon(vectorResource(R.drawable.ic_jetnews_logo))
@@ -169,7 +192,6 @@ fun HomeScreen(
                         onRefresh = {
                             onRefreshPosts()
                         },
-                        onErrorDismiss = onErrorDismiss,
                         navigateTo = navigateTo,
                         favorites = favorites,
                         onToggleFavorite = onToggleFavorite,
@@ -223,35 +245,27 @@ private fun LoadingContent(
  *
  * @param posts (state) list of posts and error state to display
  * @param onRefresh (event) request to refresh data
- * @param onErrorDismiss (event) request that the current error be dismissed
  * @param navigateTo (event) request navigation to [Screen]
+ * @param favorites (state) all favorites
+ * @param onToggleFavorite (event) request a single favorite be toggled
  * @param modifier modifier for root element
  */
 @Composable
 private fun HomeScreenErrorAndContent(
     posts: UiState<List<Post>>,
     onRefresh: () -> Unit,
-    onErrorDismiss: () -> Unit,
     navigateTo: (Screen) -> Unit,
     favorites: Set<String>,
     onToggleFavorite: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Stack(modifier = modifier.fillMaxSize()) {
-        if (posts.data != null) {
-            PostList(posts.data, navigateTo, favorites, onToggleFavorite)
-        } else if (!posts.hasError) {
-            // if there are no posts, and no error, let the user refresh manually
-            TextButton(onClick = onRefresh, Modifier.fillMaxSize()) {
-                Text("Tap to load content", textAlign = TextAlign.Center)
-            }
+    if (posts.data != null) {
+        PostList(posts.data, navigateTo, favorites, onToggleFavorite, modifier)
+    } else if (!posts.hasError) {
+        // if there are no posts, and no error, let the user refresh manually
+        TextButton(onClick = onRefresh, modifier.fillMaxSize()) {
+            Text("Tap to load content", textAlign = TextAlign.Center)
         }
-        ErrorSnackbar(
-            showError = posts.hasError,
-            onErrorAction = onRefresh,
-            onDismiss = onErrorDismiss,
-            modifier = Modifier.gravity(Alignment.BottomCenter)
-        )
     }
 }
 
@@ -293,55 +307,6 @@ private fun PostList(
 private fun FullScreenLoading() {
     Box(modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center)) {
         CircularProgressIndicator()
-    }
-}
-
-/**
- * Display an error snackbar when network requests fail.
- *
- * @param showError (state) if true, this snackbar will display
- * @param modifier modifier for root element
- * @param onErrorAction (event) user has requested error action by clicking on it
- * @param onDismiss (event) request that this snackbar be dismissed.
- */
-@OptIn(ExperimentalAnimationApi::class)
-@Composable
-private fun ErrorSnackbar(
-    showError: Boolean,
-    modifier: Modifier = Modifier,
-    onErrorAction: () -> Unit = { },
-    onDismiss: () -> Unit = { }
-) {
-    // Make Snackbar disappear after 5 seconds if the user hasn't interacted with it
-    launchInComposition(showError) {
-        delay(timeMillis = 5000L)
-        if (showError) { onDismiss() }
-    }
-
-    AnimatedVisibility(
-        visible = showError,
-        enter = slideInVertically(initialOffsetY = { it }),
-        exit = slideOutVertically(targetOffsetY = { it }),
-        modifier = modifier
-    ) {
-        Snackbar(
-            modifier = Modifier.padding(16.dp),
-            text = { Text("Can't update latest news") },
-            action = {
-                TextButton(
-                    onClick = {
-                        onErrorAction()
-                        onDismiss()
-                    },
-                    contentColor = contentColor()
-                ) {
-                    Text(
-                        text = "RETRY",
-                        color = MaterialTheme.colors.snackbarAction
-                    )
-                }
-            }
-        )
     }
 }
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
@@ -21,9 +21,9 @@ import androidx.compose.foundation.Text
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
-import androidx.compose.foundation.layout.preferredHeightIn
 import androidx.compose.material.EmphasisAmbient
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
@@ -47,7 +47,7 @@ fun PostCardTop(post: Post, modifier: Modifier = Modifier) {
     Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
         post.image?.let { image ->
             val imageModifier = Modifier
-                .preferredHeightIn(minHeight = 180.dp)
+                .heightIn(min = 180.dp)
                 .fillMaxWidth()
                 .clip(shape = MaterialTheme.shapes.medium)
             Image(image, modifier = imageModifier, contentScale = ContentScale.Crop)

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -349,7 +349,7 @@ private fun TopicItem(itemTitle: String, selected: Boolean, onToggle: () -> Unit
         Image(
             image,
             Modifier
-                .gravity(Alignment.CenterVertically)
+                .align(Alignment.CenterVertically)
                 .preferredSize(56.dp, 56.dp)
                 .clip(RoundedCornerShape(4.dp))
         )
@@ -357,12 +357,12 @@ private fun TopicItem(itemTitle: String, selected: Boolean, onToggle: () -> Unit
             text = itemTitle,
             modifier = Modifier
                 .weight(1f)
-                .gravity(Alignment.CenterVertically)
+                .align(Alignment.CenterVertically)
                 .padding(16.dp),
             style = MaterialTheme.typography.subtitle1
         )
         SelectTopicButton(
-            modifier = Modifier.gravity(Alignment.CenterVertically),
+            modifier = Modifier.align(Alignment.CenterVertically),
             selected = selected
         )
     }

--- a/JetNews/app/src/main/res/values/strings.xml
+++ b/JetNews/app/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
   -->
 <resources>
     <string name="app_name">Jetnews</string>
+    <string name="load_error">Can\'t update latest news</string>
+    <string name="retry">Retry</string>
 </resources>

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext.kotlin_version = '1.4.0'
-    ext.compose_version = '1.0.0-alpha01'
+    ext.compose_version = '1.0.0-alpha03'
 
     repositories {
         google()
@@ -24,7 +24,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-alpha08'
+        classpath 'com.android.tools.build:gradle:4.2.0-alpha10'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/JetNews/gradle/wrapper/gradle-wrapper.properties
+++ b/JetNews/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 18 11:29:05 CET 2020
+#Wed Sep 16 10:20:00 PDT 2020
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update snackbar in [HomeScreen] to not restart when posts changes but
the error remains false (previously it would flicker due to a restart)

Change workaround in SwipeToRefresh to not crash in alpha03. This was
caused by the behavior change of [onCommit].

Various renames from alpha01-alpha03