### PR TITLE
[Jetcaster] Remove AppCompat + MDC

### DIFF
--- a/Jetcaster/app/build.gradle
+++ b/Jetcaster/app/build.gradle
@@ -104,9 +104,7 @@ dependencies {
     implementation Libs.Coroutines.android
 
     implementation Libs.AndroidX.coreKtx
-    implementation Libs.AndroidX.appcompat
     implementation Libs.AndroidX.palette
-    implementation Libs.material
 
     implementation Libs.AndroidX.Lifecycle.viewmodel
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/MainActivity.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/MainActivity.kt
@@ -17,13 +17,13 @@
 package com.example.jetcaster.ui
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.platform.setContent
 import androidx.core.view.WindowCompat
 import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ProvideDisplayInsets
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/Jetcaster/app/src/main/res/values/themes.xml
+++ b/Jetcaster/app/src/main/res/values/themes.xml
@@ -16,7 +16,7 @@
   -->
 <resources>
 
-    <style name="Theme.Jetcaster" parent="Theme.MaterialComponents.NoActionBar">
+    <style name="Theme.Jetcaster" parent="android:Theme.Material.NoActionBar">
         <item name="colorPrimary">#ff00ff</item>
         <item name="colorAccent">#ff00ff</item>
         <item name="android:statusBarColor">@android:color/transparent</item>

--- a/Jetcaster/app/src/main/res/values/themes.xml
+++ b/Jetcaster/app/src/main/res/values/themes.xml
@@ -17,8 +17,8 @@
 <resources>
 
     <style name="Theme.Jetcaster" parent="android:Theme.Material.NoActionBar">
-        <item name="colorPrimary">#ff00ff</item>
-        <item name="colorAccent">#ff00ff</item>
+        <item name="android:colorPrimary">#ff00ff</item>
+        <item name="android:colorAccent">#ff00ff</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>


### PR DESCRIPTION
They're unnecessary since we're a Compose-only app