### PR TITLE
Bump JetNews to alpha05

### DIFF
--- a/JetNews/app/build.gradle
+++ b/JetNews/app/build.gradle
@@ -85,10 +85,10 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
     implementation 'androidx.activity:activity-ktx:1.1.0'
-    implementation 'androidx.core:core-ktx:1.5.0-alpha02'
+    implementation 'androidx.core:core-ktx:1.5.0-alpha04'
 
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.0-alpha07"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-alpha07"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.0-beta01"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-beta01"
 
     androidTestImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test:rules:1.3.0'

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -192,8 +192,7 @@ private fun DrawerButton(
                 Text(
                     text = label,
                     style = MaterialTheme.typography.body2,
-                    color = textIconColor,
-                    modifier = Modifier.fillMaxWidth()
+                    color = textIconColor
                 )
             }
         }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/SwipeToRefresh.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/SwipeToRefresh.kt
@@ -16,8 +16,7 @@
 
 package com.example.jetnews.ui
 
-import androidx.compose.foundation.Box
-import androidx.compose.foundation.layout.Stack
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offsetPx
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FractionalThreshold
@@ -48,7 +47,7 @@ fun SwipeToRefreshLayout(
         true
     }
 
-    Stack(
+    Box(
         modifier = Modifier.swipeable(
             state = state,
             anchors = mapOf(

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
@@ -18,9 +18,9 @@ package com.example.jetnews.ui.article
 
 import android.content.Context
 import android.content.Intent
+import androidx.compose.foundation.AmbientContentColor
 import androidx.compose.foundation.Icon
 import androidx.compose.foundation.Text
-import androidx.compose.foundation.contentColor
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -57,12 +57,12 @@ import com.example.jetnews.data.posts.impl.post3
 import com.example.jetnews.model.Post
 import com.example.jetnews.ui.ThemedPreview
 import com.example.jetnews.ui.home.BookmarkButton
-import com.example.jetnews.utils.launchUiStateProducer
+import com.example.jetnews.utils.produceUiState
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**
- * Stateful Article Screen that manages state using [launchUiStateProducer]
+ * Stateful Article Screen that manages state using [produceUiState]
  *
  * @param postId (state) the post to show
  * @param postsRepository data source for this screen
@@ -75,7 +75,7 @@ fun ArticleScreen(
     postsRepository: PostsRepository,
     onBack: () -> Unit
 ) {
-    val (post) = launchUiStateProducer(postsRepository, postId) {
+    val (post) = produceUiState(postsRepository, postId) {
         getPost(postId)
     }
     // TODO: handle errors when the repository is capable of creating them
@@ -129,7 +129,7 @@ fun ArticleScreen(
                     Text(
                         text = "Published in: ${post.publication?.name}",
                         style = MaterialTheme.typography.subtitle2,
-                        color = contentColor()
+                        color = AmbientContentColor.current
                     )
                 },
                 navigationIcon = {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/PostContent.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/PostContent.kt
@@ -16,11 +16,12 @@
 
 package com.example.jetnews.ui.article
 
-import androidx.compose.foundation.Box
+import androidx.compose.foundation.AmbientContentColor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.Text
-import androidx.compose.foundation.contentColor
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -32,8 +33,8 @@ import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.foundation.layout.preferredWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.FirstBaseline
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.Colors
-import androidx.compose.material.EmphasisAmbient
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
 import androidx.compose.material.Surface
@@ -81,7 +82,7 @@ fun PostContent(post: Post, modifier: Modifier = Modifier) {
         Text(text = post.title, style = MaterialTheme.typography.h4)
         Spacer(Modifier.preferredHeight(8.dp))
         post.subtitle?.let { subtitle ->
-            ProvideEmphasis(EmphasisAmbient.current.medium) {
+            ProvideEmphasis(AmbientEmphasisLevels.current.medium) {
                 Text(
                     text = subtitle,
                     style = MaterialTheme.typography.body2,
@@ -116,19 +117,19 @@ private fun PostMetadata(metadata: Metadata) {
         Image(
             asset = Icons.Filled.AccountCircle,
             modifier = Modifier.preferredSize(40.dp),
-            colorFilter = ColorFilter.tint(contentColor()),
+            colorFilter = ColorFilter.tint(AmbientContentColor.current),
             contentScale = ContentScale.Fit
         )
         Spacer(Modifier.preferredWidth(8.dp))
         Column {
-            ProvideEmphasis(EmphasisAmbient.current.high) {
+            ProvideEmphasis(AmbientEmphasisLevels.current.high) {
                 Text(
                     text = metadata.author.name,
                     style = typography.caption,
                     modifier = Modifier.padding(top = 4.dp)
                 )
             }
-            ProvideEmphasis(EmphasisAmbient.current.medium) {
+            ProvideEmphasis(AmbientEmphasisLevels.current.medium) {
                 Text(
                     text = "${metadata.date} • ${metadata.readTimeMinutes} min read",
                     style = typography.caption
@@ -216,10 +217,9 @@ private fun BulletParagraph(
                     .alignWithSiblings {
                         // Add an alignment "baseline" 1sp below the bottom of the circle
                         9.sp.toIntPx()
-                    },
-                backgroundColor = contentColor(),
-                shape = CircleShape
-            )
+                    }
+                    .background(AmbientContentColor.current, CircleShape),
+            ) { /* no content */ }
         }
         Text(
             modifier = Modifier

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
@@ -253,15 +253,14 @@ private fun HomeScreenErrorAndContent(
 ) {
     if (posts.data != null) {
         PostList(posts.data, navigateTo, favorites, onToggleFavorite, modifier)
-    } else {
-        Box(Modifier.fillMaxSize()) {
-            if (!posts.hasError) {
-                // if there are no posts, and no error, let the user refresh manually
-                TextButton(onClick = onRefresh, modifier.fillMaxSize()) {
-                    Text("Tap to load content", textAlign = TextAlign.Center)
-                }
-            }
+    } else if (!posts.hasError) {
+        // if there are no posts, and no error, let the user refresh manually
+        TextButton(onClick = onRefresh, Modifier.fillMaxSize()) {
+            Text("Tap to load content", textAlign = TextAlign.Center)
         }
+    } else {
+        // there's currently an error showing, don't show any content
+        Box(modifier.fillMaxSize()) { /* empty screen */ }
     }
 }
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
@@ -255,7 +255,7 @@ private fun HomeScreenErrorAndContent(
         PostList(posts.data, navigateTo, favorites, onToggleFavorite, modifier)
     } else if (!posts.hasError) {
         // if there are no posts, and no error, let the user refresh manually
-        TextButton(onClick = onRefresh, Modifier.fillMaxSize()) {
+        TextButton(onClick = onRefresh, modifier.fillMaxSize()) {
             Text("Tap to load content", textAlign = TextAlign.Center)
         }
     } else {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreen.kt
@@ -16,22 +16,22 @@
 
 package com.example.jetnews.ui.home
 
-import androidx.compose.foundation.Box
 import androidx.compose.foundation.Icon
 import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.ScrollableRow
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.DrawerValue
-import androidx.compose.material.EmphasisAmbient
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -45,9 +45,9 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedTask
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.launchInComposition
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -67,12 +67,12 @@ import com.example.jetnews.ui.Screen
 import com.example.jetnews.ui.SwipeToRefreshLayout
 import com.example.jetnews.ui.ThemedPreview
 import com.example.jetnews.ui.state.UiState
-import com.example.jetnews.utils.launchUiStateProducer
+import com.example.jetnews.utils.produceUiState
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**
- * Stateful HomeScreen which manages state using [launchUiStateProducer]
+ * Stateful HomeScreen which manages state using [produceUiState]
  *
  * @param navigateTo (event) request navigation to [Screen]
  * @param postsRepository data source for this screen
@@ -84,7 +84,7 @@ fun HomeScreen(
     postsRepository: PostsRepository,
     scaffoldState: ScaffoldState = rememberScaffoldState()
 ) {
-    val (postUiState, refreshPost, clearError) = launchUiStateProducer(postsRepository) {
+    val (postUiState, refreshPost, clearError) = produceUiState(postsRepository) {
         getPosts()
     }
 
@@ -139,7 +139,7 @@ fun HomeScreen(
         // Show snackbar using a coroutine, when the coroutine is cancelled the snackbar will
         // automatically dismiss. This coroutine will cancel whenever posts.hasError changes, and
         // only start when posts.hasError is true (due to the above if-check).
-        launchInComposition(posts.hasError) {
+        LaunchedTask(posts.hasError) {
             val snackbarResult = scaffoldState.snackbarHostState.showSnackbar(
                 message = errorMessage,
                 actionLabel = retryMessage
@@ -253,10 +253,14 @@ private fun HomeScreenErrorAndContent(
 ) {
     if (posts.data != null) {
         PostList(posts.data, navigateTo, favorites, onToggleFavorite, modifier)
-    } else if (!posts.hasError) {
-        // if there are no posts, and no error, let the user refresh manually
-        TextButton(onClick = onRefresh, modifier.fillMaxSize()) {
-            Text("Tap to load content", textAlign = TextAlign.Center)
+    } else {
+        Box(Modifier.fillMaxSize()) {
+            if (!posts.hasError) {
+                // if there are no posts, and no error, let the user refresh manually
+                TextButton(onClick = onRefresh, modifier.fillMaxSize()) {
+                    Text("Tap to load content", textAlign = TextAlign.Center)
+                }
+            }
         }
     }
 }
@@ -310,7 +314,7 @@ private fun FullScreenLoading() {
  */
 @Composable
 private fun PostListTopSection(post: Post, navigateTo: (Screen) -> Unit) {
-    ProvideEmphasis(EmphasisAmbient.current.high) {
+    ProvideEmphasis(AmbientEmphasisLevels.current.high) {
         Text(
             modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
             text = "Top stories for you",
@@ -362,7 +366,7 @@ private fun PostListPopularSection(
     navigateTo: (Screen) -> Unit
 ) {
     Column {
-        ProvideEmphasis(EmphasisAmbient.current.high) {
+        ProvideEmphasis(AmbientEmphasisLevels.current.high) {
             Text(
                 modifier = Modifier.padding(16.dp),
                 text = "Popular on Jetnews",

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
@@ -24,7 +24,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
-import androidx.compose.material.EmphasisAmbient
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
 import androidx.compose.runtime.Composable
@@ -54,7 +54,7 @@ fun PostCardTop(post: Post, modifier: Modifier = Modifier) {
         }
         Spacer(Modifier.preferredHeight(16.dp))
 
-        val emphasisLevels = EmphasisAmbient.current
+        val emphasisLevels = AmbientEmphasisLevels.current
         ProvideEmphasis(emphasisLevels.high) {
             Text(
                 text = post.title,

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardYourNetwork.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardYourNetwork.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
 import androidx.compose.foundation.layout.preferredSize
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.Card
-import androidx.compose.material.EmphasisAmbient
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
 import androidx.compose.runtime.Composable
@@ -62,7 +62,7 @@ fun PostCardPopular(
                     .fillMaxWidth()
             )
             Column(modifier = Modifier.padding(16.dp)) {
-                val emphasisLevels = EmphasisAmbient.current
+                val emphasisLevels = AmbientEmphasisLevels.current
                 ProvideEmphasis(emphasisLevels.high) {
                     Text(
                         text = post.title,

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCards.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCards.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredSize
-import androidx.compose.material.EmphasisAmbient
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.IconToggleButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
@@ -52,7 +52,7 @@ fun AuthorAndReadTime(
     modifier: Modifier = Modifier
 ) {
     Row(modifier) {
-        ProvideEmphasis(EmphasisAmbient.current.medium) {
+        ProvideEmphasis(AmbientEmphasisLevels.current.medium) {
             val textStyle = MaterialTheme.typography.body2
             Text(
                 text = post.metadata.author.name,
@@ -79,7 +79,7 @@ fun PostImage(post: Post, modifier: Modifier = Modifier) {
 
 @Composable
 fun PostTitle(post: Post) {
-    ProvideEmphasis(EmphasisAmbient.current.high) {
+    ProvideEmphasis(AmbientEmphasisLevels.current.high) {
         Text(post.title, style = MaterialTheme.typography.subtitle1)
     }
 }
@@ -118,7 +118,7 @@ fun PostCardHistory(post: Post, navigateTo: (Screen) -> Unit) {
             modifier = Modifier.padding(end = 16.dp)
         )
         Column(Modifier.weight(1f)) {
-            ProvideEmphasis(EmphasisAmbient.current.medium) {
+            ProvideEmphasis(AmbientEmphasisLevels.current.medium) {
                 Text(
                     text = "BASED ON YOUR HISTORY",
                     style = MaterialTheme.typography.overline
@@ -130,7 +130,7 @@ fun PostCardHistory(post: Post, navigateTo: (Screen) -> Unit) {
                 modifier = Modifier.padding(top = 4.dp)
             )
         }
-        ProvideEmphasis(EmphasisAmbient.current.medium) {
+        ProvideEmphasis(AmbientEmphasisLevels.current.medium) {
             Icon(asset = Icons.Filled.MoreVert)
         }
     }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -16,13 +16,14 @@
 
 package com.example.jetnews.ui.interests
 
-import androidx.compose.foundation.Box
 import androidx.compose.foundation.Icon
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.Text
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.foundation.selection.toggleable
@@ -59,7 +60,7 @@ import com.example.jetnews.data.interests.impl.FakeInterestsRepository
 import com.example.jetnews.ui.AppDrawer
 import com.example.jetnews.ui.Screen
 import com.example.jetnews.ui.ThemedPreview
-import com.example.jetnews.utils.launchUiStateProducer
+import com.example.jetnews.utils.produceUiState
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -82,7 +83,7 @@ enum class Sections(val title: String) {
 class TabContent(val section: Sections, val content: @Composable () -> Unit)
 
 /**
- * Stateful InterestsScreen manages state using [launchUiStateProducer]
+ * Stateful InterestsScreen manages state using [produceUiState]
  *
  * @param navigateTo (event) request navigation to [Screen]
  * @param scaffoldState (state) state for screen Scaffold
@@ -101,7 +102,7 @@ fun InterestsScreen(
     // Describe the screen sections here since each section needs 2 states and 1 event.
     // Pass them to the stateless InterestsScreen using a tabContent.
     val topicsSection = TabContent(Sections.Topics) {
-        val (topics) = launchUiStateProducer(interestsRepository) {
+        val (topics) = produceUiState(interestsRepository) {
             getTopics()
         }
         // collectAsState will read a [Flow] in Compose
@@ -114,7 +115,7 @@ fun InterestsScreen(
     }
 
     val peopleSection = TabContent(Sections.People) {
-        val (people) = launchUiStateProducer(interestsRepository) {
+        val (people) = produceUiState(interestsRepository) {
             getPeople()
         }
         val selectedPeople by interestsRepository.observePeopleSelected().collectAsState(setOf())
@@ -126,7 +127,7 @@ fun InterestsScreen(
     }
 
     val publicationSection = TabContent(Sections.Publications) {
-        val (publications) = launchUiStateProducer(interestsRepository) {
+        val (publications) = produceUiState(interestsRepository) {
             getPublications()
         }
         val selectedPublications by interestsRepository.observePublicationSelected().collectAsState(setOf())
@@ -356,11 +357,11 @@ private fun TopicItem(itemTitle: String, selected: Boolean, onToggle: () -> Unit
         Text(
             text = itemTitle,
             modifier = Modifier
-                .weight(1f)
                 .align(Alignment.CenterVertically)
                 .padding(16.dp),
             style = MaterialTheme.typography.subtitle1
         )
+        Spacer(Modifier.weight(1f))
         SelectTopicButton(
             modifier = Modifier.align(Alignment.CenterVertically),
             selected = selected

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.Icon
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.EmphasisAmbient
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ProvideEmphasis
 import androidx.compose.material.Surface
@@ -49,7 +49,7 @@ fun SelectTopicButton(
         shape = CircleShape,
         modifier = modifier.preferredSize(36.dp, 36.dp)
     ) {
-        ProvideEmphasis(EmphasisAmbient.current.high) {
+        ProvideEmphasis(AmbientEmphasisLevels.current.high) {
             Icon(icon)
         }
     }

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext.kotlin_version = '1.4.10'
-    ext.compose_version = '1.0.0-alpha03'
+    ext.compose_version = '1.0.0-SNAPSHOT'
 
     repositories {
         google()
@@ -34,7 +34,11 @@ plugins {
 }
 
 subprojects {
+    def snapshot = "6891475"
     repositories {
+        maven {
+            url "https://androidx.dev/snapshots/builds/${snapshot}/artifacts/ui/repository/"
+        }
         google()
         jcenter()
     }
@@ -48,22 +52,6 @@ subprojects {
 
             ktlint("0.38.1")
             licenseHeaderFile rootProject.file('spotless/copyright.kt')
-        }
-    }
-}
-
-// JetNews uses Compose alpha03 and Android Gradle Plugin 4.2.0-alpha13 which are incompatible
-// TODO: Remove this workaround when updating to >alpha04
-subprojects {
-    configurations.configureEach {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            def group = details.requested.group
-            def module = details.requested.module.name
-            def version = details.requested.version
-
-            if (group == 'androidx.compose.compiler' && module == 'compiler') {
-                details.useTarget("androidx.compose:compose-compiler:$version")
-            }
         }
     }
 }


### PR DESCRIPTION
Changes:
- Use new produceState API in launchUiStateProducer
- Rename launchUiStateProducer to produceUiState to match naming
- Change launchInComposition to new API LaunchedTask
- Replace Box/Surface with new Box import
- Update modifiers for Text composable to work with new layout rules
- Update to use new AmbientContentColor and AmbientEmphasisLevels

Bugfix:
- Fix size of error case in [HomeScreenErrorAndContent], avoiding
  the swipe to refresh drawing in the incorrect place.