### PR TITLE
Set label field to transition animation PropKeys

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/home/MainActivity.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/home/MainActivity.kt
@@ -95,9 +95,9 @@ private fun MainContent(
 
 enum class SplashState { Shown, Completed }
 
-private val splashAlphaKey = FloatPropKey()
-private val contentAlphaKey = FloatPropKey()
-private val contentTopPaddingKey = DpPropKey()
+private val splashAlphaKey = FloatPropKey("Splash alpha")
+private val contentAlphaKey = FloatPropKey("Content alpha")
+private val contentTopPaddingKey = DpPropKey("Top padding")
 
 private val splashTransitionDefinition = transitionDefinition<SplashState> {
     state(SplashState.Shown) {

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/home/SearchUserInput.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/home/SearchUserInput.kt
@@ -35,8 +35,10 @@ import androidx.compose.samples.crane.base.CraneUserInput
 import androidx.compose.samples.crane.base.ServiceLocator
 import androidx.compose.samples.crane.home.PeopleUserInputAnimationState.Invalid
 import androidx.compose.samples.crane.home.PeopleUserInputAnimationState.Valid
+import androidx.compose.samples.crane.ui.CraneTheme
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.ui.tooling.preview.Preview
 
 class PeopleUserInputState {
     var people by mutableStateOf(1)
@@ -122,7 +124,15 @@ fun DatesUserInput(onDateSelectionClicked: () -> Unit) {
     )
 }
 
-private val tintKey = ColorPropKey()
+@Preview
+@Composable
+fun PeopleUserInputPreview() {
+    CraneTheme {
+        PeopleUserInput(onPeopleChanged = {})
+    }
+}
+
+private val tintKey = ColorPropKey(label = "tint")
 
 enum class PeopleUserInputAnimationState { Valid, Invalid }
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
@@ -177,8 +177,8 @@ private fun ChoiceChipContent(
     }
 }
 
-private val Alpha = FloatPropKey()
-private val Offset = FloatPropKey()
+private val Alpha = FloatPropKey("alpha")
+private val Offset = FloatPropKey("offset")
 
 @Composable
 private fun getChoiceChipTransitionDefinition(

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/AnimatingFabContent.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/AnimatingFabContent.kt
@@ -106,8 +106,8 @@ private fun IconAndTextRow(
     }
 }
 
-private val FabWidthFactor = FloatPropKey()
-private val TextOpacity = FloatPropKey()
+private val FabWidthFactor = FloatPropKey("Width")
+private val TextOpacity = FloatPropKey("Text Opacity")
 
 private enum class ExpandableFabStates { Collapsed, Extended }
 

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/JumpToBottom.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/JumpToBottom.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.ui.tooling.preview.Preview
 import com.example.compose.jetchat.R
 
-private val bottomOffset = DpPropKey()
+private val bottomOffset = DpPropKey("Bottom Offset")
 
 private val definition = transitionDefinition<Visibility> {
     state(Visibility.GONE) {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
@@ -273,3 +273,11 @@ fun ConvPreview480MeDefault() {
         ProfileScreen(colleagueProfile)
     }
 }
+
+@Preview
+@Composable
+fun ProfileFabPreview() {
+    JetchatTheme {
+        ProfileFab(extended = true, userIsMe = false)
+    }
+}

--- a/Owl/app/src/main/java/com/example/owl/ui/onboarding/Onboarding.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/onboarding/Onboarding.kt
@@ -155,9 +155,9 @@ private fun TopicsGrid(modifier: Modifier = Modifier) {
 
 private enum class SelectionState { Unselected, Selected }
 
-private val CornerRadius = DpPropKey()
-private val SelectedAlpha = FloatPropKey()
-private val CheckScale = FloatPropKey()
+private val CornerRadius = DpPropKey("Corner Radius")
+private val SelectedAlpha = FloatPropKey("Selected Alpha")
+private val CheckScale = FloatPropKey("Check Scale")
 
 private val TopicSelect = transitionDefinition<SelectionState> {
     state(SelectionState.Selected) {

--- a/Rally/app/src/main/java/com/example/compose/rally/ui/components/RallyAnimatedCircle.kt
+++ b/Rally/app/src/main/java/com/example/compose/rally/ui/components/RallyAnimatedCircle.kt
@@ -33,8 +33,8 @@ import androidx.compose.ui.platform.DensityAmbient
 import androidx.compose.ui.unit.dp
 
 private const val DividerLengthInDegrees = 1.8f
-private val AngleOffset = FloatPropKey()
-private val Shift = FloatPropKey()
+private val AngleOffset = FloatPropKey("angle")
+private val Shift = FloatPropKey("shift")
 
 /**
  * A donut chart that animates when loaded.


### PR DESCRIPTION
The label field is used to identify the PropKeys when inspecting the
animations in the Animation Preview.

Also add a couple of previews to Crane and Jetchat that contain
transition animations, which can be open in the Animation Preview.

![image](https://user-images.githubusercontent.com/673690/96160414-d48e0200-0f0d-11eb-93ad-fa5e749a3aa0.png)
