### PR TITLE
SwipeToRefreshLayout bug reproducible example

### DIFF
--- a/JetNews/app/src/androidTest/java/com/example/jetnews/ui/SwipeToRefreshLayoutTest.kt
+++ b/JetNews/app/src/androidTest/java/com/example/jetnews/ui/SwipeToRefreshLayoutTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetnews.ui
+
+import androidx.compose.foundation.ScrollableColumn
+import androidx.compose.foundation.Text
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.preferredSize
+import androidx.compose.foundation.lazy.LazyColumnFor
+import androidx.compose.foundation.lazy.LazyColumnForIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Surface
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.test.filters.MediumTest
+import androidx.ui.test.*
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.delay
+import org.junit.Rule
+import org.junit.Test
+
+
+@MediumTest
+class SwipeToRefreshLayoutTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule(disableTransitions = true)
+
+    @Test
+    fun testSwipeToRefreshGestureWithScrollableColumn() {
+        var refreshInvoked = false
+        renderScrollableColumnWithSwipeToRefreshLayout(onRefresh = {
+            refreshInvoked = true
+        })
+
+        swipeToRefresh()
+
+        assertTrue(refreshInvoked)
+    }
+
+    @Test
+    fun testSwipeToRefreshGestureWithLazyColumnFor() {
+        var refreshInvoked = false
+        renderLazyColumnForWithSwipeToRefreshLayout(onRefresh = {
+            refreshInvoked = true
+        })
+
+        swipeToRefresh()
+
+        assertTrue(refreshInvoked)
+    }
+
+    @Test
+    fun testSwipeToRefreshGestureWithLazyColumnForIndexed() {
+        var refreshInvoked = false
+        renderLazyColumnForIndexedWithSwipeToRefreshLayout(onRefresh = {
+            refreshInvoked = true
+        })
+
+        swipeToRefresh()
+
+        assertTrue(refreshInvoked)
+    }
+
+    private fun swipeToRefresh() {
+        composeTestRule.onNodeWithTag(swipeTestTag).performGesture {
+            swipeDown()
+            swipeUp()
+        }
+    }
+
+    private fun renderScrollableColumnWithSwipeToRefreshLayout(onRefresh: () -> Unit) {
+        composeTestRule.setContent {
+            CommonSwipeToRefreshLayout(onRefresh = onRefresh) {
+                ScrollableColumn {
+                    (0 until 10).forEach {
+                        Text(text = "Item $it")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun renderLazyColumnForIndexedWithSwipeToRefreshLayout(onRefresh: () -> Unit) {
+        composeTestRule.setContent {
+            CommonSwipeToRefreshLayout(onRefresh = onRefresh) {
+                val items = (0 until 10).toList()
+                LazyColumnForIndexed(items) { _, item ->
+                    Text(text = "Item $item")
+                }
+            }
+        }
+    }
+
+    private fun renderLazyColumnForWithSwipeToRefreshLayout(onRefresh: () -> Unit) {
+        composeTestRule.setContent {
+            CommonSwipeToRefreshLayout(onRefresh = onRefresh) {
+                val items = (0 until 10).toList()
+                LazyColumnFor(items) { item ->
+                    Text(text = "Item $item")
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun CommonSwipeToRefreshLayout(
+        onRefresh: () -> Unit,
+        content: @Composable() () -> Unit
+    ) {
+        SwipeToRefreshLayout(
+            refreshingState = false,
+            onRefresh = onRefresh,
+            refreshIndicator = { RefreshIndicator() },
+            content = {
+                content()
+            }
+        )
+    }
+
+    @Composable
+    private fun RefreshIndicator() {
+        Surface(elevation = 10.dp, shape = CircleShape) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .preferredSize(36.dp)
+                    .padding(4.dp)
+            )
+        }
+    }
+}

--- a/JetNews/app/src/androidTest/java/com/example/jetnews/ui/SwipeToRefreshLayoutTest.kt
+++ b/JetNews/app/src/androidTest/java/com/example/jetnews/ui/SwipeToRefreshLayoutTest.kt
@@ -25,13 +25,16 @@ import androidx.compose.foundation.lazy.LazyColumnForIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Surface
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.test.filters.MediumTest
-import androidx.ui.test.*
+import androidx.ui.test.createComposeRule
+import androidx.ui.test.onNodeWithTag
+import androidx.ui.test.swipeUp
+import androidx.ui.test.swipeDown
+import androidx.ui.test.performGesture
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.delay
 import org.junit.Rule
 import org.junit.Test
 

--- a/JetNews/app/src/androidTest/java/com/example/jetnews/ui/SwipeToRefreshLayoutTest.kt
+++ b/JetNews/app/src/androidTest/java/com/example/jetnews/ui/SwipeToRefreshLayoutTest.kt
@@ -31,13 +31,12 @@ import androidx.compose.ui.unit.dp
 import androidx.test.filters.MediumTest
 import androidx.ui.test.createComposeRule
 import androidx.ui.test.onNodeWithTag
-import androidx.ui.test.swipeUp
-import androidx.ui.test.swipeDown
 import androidx.ui.test.performGesture
+import androidx.ui.test.swipeDown
+import androidx.ui.test.swipeUp
 import junit.framework.TestCase.assertTrue
 import org.junit.Rule
 import org.junit.Test
-
 
 @MediumTest
 class SwipeToRefreshLayoutTest {
@@ -48,9 +47,11 @@ class SwipeToRefreshLayoutTest {
     @Test
     fun testSwipeToRefreshGestureWithScrollableColumn() {
         var refreshInvoked = false
-        renderScrollableColumnWithSwipeToRefreshLayout(onRefresh = {
-            refreshInvoked = true
-        })
+        renderScrollableColumnWithSwipeToRefreshLayout(
+            onRefresh = {
+                refreshInvoked = true
+            }
+        )
 
         swipeToRefresh()
 
@@ -60,9 +61,11 @@ class SwipeToRefreshLayoutTest {
     @Test
     fun testSwipeToRefreshGestureWithLazyColumnFor() {
         var refreshInvoked = false
-        renderLazyColumnForWithSwipeToRefreshLayout(onRefresh = {
-            refreshInvoked = true
-        })
+        renderLazyColumnForWithSwipeToRefreshLayout(
+            onRefresh = {
+                refreshInvoked = true
+            }
+        )
 
         swipeToRefresh()
 
@@ -72,9 +75,11 @@ class SwipeToRefreshLayoutTest {
     @Test
     fun testSwipeToRefreshGestureWithLazyColumnForIndexed() {
         var refreshInvoked = false
-        renderLazyColumnForIndexedWithSwipeToRefreshLayout(onRefresh = {
-            refreshInvoked = true
-        })
+        renderLazyColumnForIndexedWithSwipeToRefreshLayout(
+            onRefresh = {
+                refreshInvoked = true
+            }
+        )
 
         swipeToRefresh()
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/SwipeToRefresh.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/SwipeToRefresh.kt
@@ -28,8 +28,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.gesture.scrollorientationlocking.Orientation
 import androidx.compose.ui.platform.DensityAmbient
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
+val swipeTestTag = "SwipeToRefresh"
 private val RefreshDistance = 80.dp
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -48,7 +50,7 @@ fun SwipeToRefreshLayout(
     }
 
     Box(
-        modifier = Modifier.swipeable(
+        modifier = Modifier.testTag(swipeTestTag).swipeable(
             state = state,
             anchors = mapOf(
                 -refreshDistance to false,


### PR DESCRIPTION
While using a copy-pasted version of ``SwipeToRefreshLayout`` in my app I've noticed it does not work with ``LazyColumnFor`` and ``LazyColumnForIndexed`` components as expected. The swipe down gesture is ignored if the content inside ``SwipeToRefreshLayout`` is a ``LazyColumn``. However, works like a charm with other components.

I've created 3 tests to show you how to reproduce this bug. As you can see, the first test using a ``ScrollableColumn`` is passing, but the last 2 tests using lazy columns are failing. This component was working with Jetpack Compose alpha-04 but after updating to alpha-05 it stopped working.

Honestly, I have no idea how to fix it. Looks like something related to the touch management in the ``LazyColum`` implementation is not forwarding the touch event to the view wrapping the column, but I think there is no way I can fix it without having access to ``LazyColum`` code.

I hope this helps you to reproduce the bug and fix it 😃 