### PR TITLE
[Jetsurvey] Implementing the redesign of the survey screen (part 1)

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
@@ -59,8 +59,7 @@ class SurveyFragment : Fragment() {
                             )
                             is SurveyState.Result -> SurveyResultScreen(
                                 result = surveyState,
-                                onDonePressed = { activity?.onBackPressedDispatcher?.onBackPressed() },
-                                onBackPressed = { activity?.onBackPressedDispatcher?.onBackPressed() }
+                                onDonePressed = { activity?.onBackPressedDispatcher?.onBackPressed() }
                             )
                         }
                     }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -188,7 +188,7 @@ private fun MultipleChoiceQuestion(
                         onAnswerSelected(option.value, selected)
                     },
                     colors = CheckboxConstants.defaultColors(
-                        checkmarkColor = MaterialTheme.colors.primary
+                        checkedColor = MaterialTheme.colors.primary
                     )
                 )
                 Text(

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -18,6 +18,7 @@ package com.example.compose.jetsurvey.survey
 
 import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.Text
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,10 +28,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxConstants
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProvideEmphasis
 import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonConstants
 import androidx.compose.material.Slider
@@ -43,7 +47,30 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.ui.tooling.preview.Preview
 import com.example.compose.jetsurvey.R
+import com.example.compose.jetsurvey.theme.JetsurveyTheme
+import com.example.compose.jetsurvey.theme.questionBackground
+
+@Preview
+@Composable
+fun QuestionPreview() {
+    val question = Question(
+        id = 2,
+        questionText = R.string.pick_superhero,
+        answer = PossibleAnswer.SingleChoice(
+            optionsStringRes = listOf(
+                R.string.spiderman,
+                R.string.ironman,
+                R.string.unikitty,
+                R.string.captain_planet
+            )
+        )
+    )
+    JetsurveyTheme {
+        Question(question = question, answer = null, onAnswer = {}, onAction = { _, _ -> })
+    }
+}
 
 @Composable
 fun Question(
@@ -58,11 +85,20 @@ fun Question(
         contentPadding = PaddingValues(start = 20.dp, end = 20.dp)
     ) {
         Spacer(modifier = Modifier.preferredHeight(44.dp))
-        Text(
-            text = stringResource(id = question.questionText),
-            style = MaterialTheme.typography.h4,
-            modifier = Modifier.fillMaxWidth()
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth().background(
+                color = MaterialTheme.colors.questionBackground,
+                shape = RoundedCornerShape(12.dp)
+            )
+        ) {
+            ProvideEmphasis(emphasis = AmbientEmphasisLevels.current.high) {
+                Text(
+                    text = stringResource(id = question.questionText),
+                    style = MaterialTheme.typography.subtitle1,
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp, horizontal = 16.dp)
+                )
+            }
+        }
         Spacer(modifier = Modifier.preferredHeight(24.dp))
         when (question.answer) {
             is PossibleAnswer.SingleChoice -> SingleChoiceQuestion(

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
@@ -88,7 +87,7 @@ fun Question(
         Row(
             modifier = Modifier.fillMaxWidth().background(
                 color = MaterialTheme.colors.questionBackground,
-                shape = RoundedCornerShape(12.dp)
+                shape = MaterialTheme.shapes.small
             )
         ) {
             ProvideEmphasis(emphasis = AmbientEmphasisLevels.current.high) {

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
@@ -41,14 +40,11 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.FiberManualRecord
-import androidx.compose.material.icons.outlined.FiberManualRecord
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.savedinstancestate.savedInstanceState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -233,23 +229,6 @@ private fun SurveyBottomBar(
                     Text(text = stringResource(id = R.string.next))
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun PageIndicator(pagesCount: Int, currentPageIndex: Int, modifier: Modifier = Modifier) {
-    Row(modifier = modifier.wrapContentSize(align = Alignment.Center)) {
-        for (pageIndex in 0 until pagesCount) {
-            val asset = if (currentPageIndex == pageIndex) {
-                Icons.Filled.FiberManualRecord
-            } else {
-                Icons.Outlined.FiberManualRecord
-            }
-            Icon(
-                asset = asset,
-                tint = MaterialTheme.colors.primary
-            )
         }
     }
 }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -105,8 +105,7 @@ fun SurveyQuestionsScreen(
 @Composable
 fun SurveyResultScreen(
     result: SurveyState.Result,
-    onDonePressed: () -> Unit,
-    onBackPressed: () -> Unit
+    onDonePressed: () -> Unit
 ) {
     Surface(modifier = Modifier.fillMaxSize()) {
         Scaffold(
@@ -208,35 +207,40 @@ private fun SurveyBottomBar(
     onNextPressed: () -> Unit,
     onDonePressed: () -> Unit
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 20.dp, end = 20.dp, bottom = 24.dp)
+    Surface(
+        elevation = 3.dp,
+        modifier = Modifier.fillMaxWidth()
     ) {
-        if (questionState.showPrevious) {
-            OutlinedButton(
-                modifier = Modifier.weight(1f),
-                onClick = onPreviousPressed
-            ) {
-                Text(text = stringResource(id = R.string.previous))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 20.dp)
+        ) {
+            if (questionState.showPrevious) {
+                OutlinedButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onPreviousPressed
+                ) {
+                    Text(text = stringResource(id = R.string.previous))
+                }
+                Spacer(modifier = Modifier.width(16.dp))
             }
-            Spacer(modifier = Modifier.width(16.dp))
-        }
-        if (questionState.showDone) {
-            Button(
-                modifier = Modifier.weight(1f),
-                onClick = onDonePressed,
-                enabled = questionState.enableNext
-            ) {
-                Text(text = stringResource(id = R.string.done))
-            }
-        } else {
-            Button(
-                modifier = Modifier.weight(1f),
-                onClick = onNextPressed,
-                enabled = questionState.enableNext
-            ) {
-                Text(text = stringResource(id = R.string.next))
+            if (questionState.showDone) {
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = onDonePressed,
+                    enabled = questionState.enableNext
+                ) {
+                    Text(text = stringResource(id = R.string.done))
+                }
+            } else {
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = onNextPressed,
+                    enabled = questionState.enableNext
+                ) {
+                    Text(text = stringResource(id = R.string.next))
+                }
             }
         }
     }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.ui.tooling.preview.Preview
 import com.example.compose.jetsurvey.R
 import com.example.compose.jetsurvey.theme.progressIndicatorBackground
 
@@ -150,12 +149,6 @@ private fun SurveyResult(result: SurveyState.Result, modifier: Modifier = Modifi
     }
 }
 
-@Preview
-@Composable
-fun Progress() {
-    SurveyTopAppBar(questionIndex = 2, totalQuestionsCount = 6, onBackPressed = {})
-}
-
 @OptIn(ExperimentalLayout::class)
 @Composable
 private fun SurveyTopAppBar(
@@ -164,10 +157,8 @@ private fun SurveyTopAppBar(
     onBackPressed: () -> Unit
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
-
         ConstraintLayout(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
             val (button, text) = createRefs()
-
             Text(
                 text = stringResource(
                     R.string.question_count,

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -16,28 +16,31 @@
 
 package com.example.compose.jetsurvey.survey
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.Text
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ConstraintLayout
+import androidx.compose.foundation.layout.ExperimentalLayout
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
-import androidx.compose.foundation.layout.preferredWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.AmbientEmphasisLevels
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
+import androidx.compose.material.ProvideEmphasis
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FiberManualRecord
 import androidx.compose.material.icons.outlined.FiberManualRecord
 import androidx.compose.runtime.Composable
@@ -48,9 +51,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.ui.tooling.preview.Preview
 import com.example.compose.jetsurvey.R
+import com.example.compose.jetsurvey.theme.progressIndicatorBackground
 
 @Composable
 fun SurveyQuestionsScreen(
@@ -65,7 +69,13 @@ fun SurveyQuestionsScreen(
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Scaffold(
-            topBar = { SurveyTopAppBar(questions.surveyTitle, onBackPressed) },
+            topBar = {
+                SurveyTopAppBar(
+                    questionIndex = questionState.questionIndex,
+                    totalQuestionsCount = questionState.totalQuestionsCount,
+                    onBackPressed = onBackPressed
+                )
+            },
             bodyContent = { innerPadding ->
                 Question(
                     question = questionState.question,
@@ -100,7 +110,6 @@ fun SurveyResultScreen(
 ) {
     Surface(modifier = Modifier.fillMaxSize()) {
         Scaffold(
-            topBar = { SurveyTopAppBar(result.surveyTitle, onBackPressed) },
             bodyContent = { innerPadding ->
                 val modifier = Modifier.padding(innerPadding)
                 SurveyResult(result = result, modifier = modifier)
@@ -142,31 +151,54 @@ private fun SurveyResult(result: SurveyState.Result, modifier: Modifier = Modifi
     }
 }
 
+@Preview
+@Composable
+fun Progress() {
+    SurveyTopAppBar(questionIndex = 2, totalQuestionsCount = 6, onBackPressed = {})
+}
+
+@OptIn(ExperimentalLayout::class)
 @Composable
 private fun SurveyTopAppBar(
-    @StringRes surveyTitle: Int,
+    questionIndex: Int,
+    totalQuestionsCount: Int,
     onBackPressed: () -> Unit
 ) {
-    TopAppBar(
-        title = {
+    Column(modifier = Modifier.fillMaxWidth()) {
+
+        ConstraintLayout(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+            val (button, text) = createRefs()
+
             Text(
-                text = stringResource(id = surveyTitle),
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
+                text = stringResource(
+                    R.string.question_count,
+                    questionIndex + 1,
+                    totalQuestionsCount
+                ),
+                style = MaterialTheme.typography.caption,
+                modifier = Modifier.constrainAs(text) {
+                    centerHorizontallyTo(parent)
+                    centerVerticallyTo(parent)
+                }
             )
-        },
-        navigationIcon = {
-            IconButton(onClick = onBackPressed) {
-                Icon(Icons.Filled.ChevronLeft)
+
+            ProvideEmphasis(emphasis = AmbientEmphasisLevels.current.medium) {
+                IconButton(
+                    onClick = onBackPressed,
+                    modifier = Modifier.padding(horizontal = 12.dp).constrainAs(button) {
+                        end.linkTo(parent.end)
+                    }
+                ) {
+                    Icon(Icons.Filled.Close)
+                }
             }
-        },
-        // We need to balance the navigation icon, so we add a spacer.
-        actions = {
-            Spacer(modifier = Modifier.preferredWidth(68.dp))
-        },
-        backgroundColor = MaterialTheme.colors.surface,
-        elevation = 0.dp
-    )
+        }
+        LinearProgressIndicator(
+            progress = (questionIndex + 1) / totalQuestionsCount.toFloat(),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+            backgroundColor = MaterialTheme.colors.progressIndicatorBackground
+        )
+    }
 }
 
 @Composable

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -26,15 +26,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredHeight
 import androidx.compose.foundation.layout.preferredWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
-import androidx.compose.material.TextButton
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronLeft
@@ -70,7 +70,10 @@ fun SurveyQuestionsScreen(
                 Question(
                     question = questionState.question,
                     answer = questionState.answer,
-                    onAnswer = { questionState.answer = it },
+                    onAnswer = {
+                        questionState.answer = it
+                        questionState.enableNext = true
+                    },
                     onAction = onAction,
                     modifier = Modifier
                         .fillMaxSize()
@@ -178,28 +181,28 @@ private fun SurveyBottomBar(
             .fillMaxWidth()
             .padding(start = 20.dp, end = 20.dp, bottom = 24.dp)
     ) {
-        TextButton(
-            modifier = Modifier.weight(1f).wrapContentWidth(align = Alignment.Start),
-            onClick = onPreviousPressed,
-            enabled = questionState.enablePrevious
-        ) {
-            Text(text = stringResource(id = R.string.previous))
+        if (questionState.showPrevious) {
+            OutlinedButton(
+                modifier = Modifier.weight(1f),
+                onClick = onPreviousPressed
+            ) {
+                Text(text = stringResource(id = R.string.previous))
+            }
+            Spacer(modifier = Modifier.width(16.dp))
         }
-        PageIndicator(
-            pagesCount = questionState.totalQuestionsCount,
-            currentPageIndex = questionState.questionIndex
-        )
         if (questionState.showDone) {
-            TextButton(
-                modifier = Modifier.weight(1f).wrapContentWidth(align = Alignment.End),
-                onClick = onDonePressed
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = onDonePressed,
+                enabled = questionState.enableNext
             ) {
                 Text(text = stringResource(id = R.string.done))
             }
         } else {
-            TextButton(
-                modifier = Modifier.weight(1f).wrapContentWidth(align = Alignment.End),
-                onClick = onNextPressed
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = onNextPressed,
+                enabled = questionState.enableNext
             ) {
                 Text(text = stringResource(id = R.string.next))
             }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -18,7 +18,6 @@ package com.example.compose.jetsurvey.survey
 
 import androidx.compose.foundation.ScrollableColumn
 import androidx.compose.foundation.Text
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ConstraintLayout
 import androidx.compose.foundation.layout.ExperimentalLayout
 import androidx.compose.foundation.layout.Row
@@ -152,36 +151,36 @@ private fun SurveyTopAppBar(
     totalQuestionsCount: Int,
     onBackPressed: () -> Unit
 ) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        ConstraintLayout(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
-            val (button, text) = createRefs()
-            Text(
-                text = stringResource(
-                    R.string.question_count,
-                    questionIndex + 1,
-                    totalQuestionsCount
-                ),
-                style = MaterialTheme.typography.caption,
-                modifier = Modifier.constrainAs(text) {
-                    centerHorizontallyTo(parent)
-                    centerVerticallyTo(parent)
-                }
-            )
+    ConstraintLayout(modifier = Modifier.fillMaxWidth()) {
+        val (button, text, progress) = createRefs()
+        Text(
+            text = stringResource(
+                R.string.question_count,
+                questionIndex + 1,
+                totalQuestionsCount
+            ),
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(vertical = 20.dp).constrainAs(text) {
+                centerHorizontallyTo(parent)
+            }
+        )
 
-            ProvideEmphasis(emphasis = AmbientEmphasisLevels.current.medium) {
-                IconButton(
-                    onClick = onBackPressed,
-                    modifier = Modifier.padding(horizontal = 12.dp).constrainAs(button) {
-                        end.linkTo(parent.end)
-                    }
-                ) {
-                    Icon(Icons.Filled.Close)
+        ProvideEmphasis(emphasis = AmbientEmphasisLevels.current.medium) {
+            IconButton(
+                onClick = onBackPressed,
+                modifier = Modifier.padding(horizontal = 12.dp).constrainAs(button) {
+                    end.linkTo(parent.end)
                 }
+            ) {
+                Icon(Icons.Filled.Close)
             }
         }
+
         LinearProgressIndicator(
             progress = (questionIndex + 1) / totalQuestionsCount.toFloat(),
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp).constrainAs(progress) {
+                bottom.linkTo(text.bottom)
+            },
             backgroundColor = MaterialTheme.colors.progressIndicatorBackground
         )
     }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyState.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyState.kt
@@ -27,9 +27,10 @@ class QuestionState(
     val question: Question,
     val questionIndex: Int,
     val totalQuestionsCount: Int,
-    val enablePrevious: Boolean,
+    val showPrevious: Boolean,
     val showDone: Boolean
 ) {
+    var enableNext by mutableStateOf(false)
     var answer by mutableStateOf<Answer<*>?>(null)
 }
 

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyViewModel.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyViewModel.kt
@@ -37,9 +37,15 @@ class SurveyViewModel(private val surveyRepository: SurveyRepository) : ViewMode
 
             // Create the default questions state based on the survey questions
             val questions: List<QuestionState> = survey.questions.mapIndexed { index, question ->
-                val enablePrevious = index > 0
+                val showPrevious = index > 0
                 val showDone = index == survey.questions.size - 1
-                QuestionState(question, index, survey.questions.size, enablePrevious, showDone)
+                QuestionState(
+                    question = question,
+                    questionIndex = index,
+                    totalQuestionsCount = survey.questions.size,
+                    showPrevious = showPrevious,
+                    showDone = showDone
+                )
             }
             surveyInitialState = SurveyState.Questions(survey.title, questions)
             _uiState.value = surveyInitialState
@@ -64,6 +70,7 @@ class SurveyViewModel(private val surveyRepository: SurveyRepository) : ViewMode
                     questionState.question.id == questionId
                 }
             question.answer = Answer.Action(result)
+            question.enableNext = true
         }
     }
 }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Color.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Color.kt
@@ -25,3 +25,6 @@ val Purple800 = Color(0xFF0000E1)
 
 val Red300 = Color(0xFFD00036)
 val Red800 = Color(0xFFEA6D7E)
+
+val Gray100 = Color(0xFFF5F5F5)
+val Gray900 = Color(0xFF212121)

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Theme.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Theme.kt
@@ -61,6 +61,10 @@ val Colors.progressIndicatorBackground: Color
     get() = if (isLight) Color.Black.copy(alpha = 0.12f) else Color.Black.copy(alpha = 0.24f)
 
 @Composable
+val Colors.questionBackground: Color
+    get() = if (isLight) Gray100 else Gray900
+
+@Composable
 fun JetsurveyTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {
     val colors = if (darkTheme) {
         DarkThemeColors

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Theme.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Theme.kt
@@ -57,6 +57,10 @@ val Colors.snackbarAction: Color
     get() = if (isLight) Purple300 else Purple700
 
 @Composable
+val Colors.progressIndicatorBackground: Color
+    get() = if (isLight) Color.Black.copy(alpha = 0.12f) else Color.Black.copy(alpha = 0.24f)
+
+@Composable
 fun JetsurveyTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {
     val colors = if (darkTheme) {
         DarkThemeColors

--- a/Jetsurvey/app/src/main/res/values/strings.xml
+++ b/Jetsurvey/app/src/main/res/values/strings.xml
@@ -31,12 +31,13 @@
         handle your data according to our Privacy Policy.</string>
     <string name="feature_not_available">Feature not available</string>
     <string name="dismiss">Dismiss</string>
-    <string name="next">Next</string>
-    <string name="previous">Previous</string>
-    <string name="done">Done</string>
+    <string name="next">NEXT</string>
+    <string name="previous">PREVIOUS</string>
+    <string name="done">DONE</string>
 
     <!-- survey-->
     <string name="which_jetpack_library">Which Jetpack library are you?</string>
+    <string name="question_count">%1$d of %2$d</string>
 
     <!-- question 1-->
     <string name="in_my_free_time">In my free time I like to …</string>

--- a/Jetsurvey/app/src/main/res/values/strings.xml
+++ b/Jetsurvey/app/src/main/res/values/strings.xml
@@ -21,16 +21,17 @@
     <string name="password">Password</string>
     <string name="confirm_password">Confirm password</string>
     <string name="sign_in">Sign in</string>
-    <string name="sign_in_guest">Sign in as guest</string>
+    <string name="sign_in_action">SIGN IN</string>
+    <string name="sign_in_guest">SIGN IN AS GUEST</string>
     <string name="sign_in_create_account">Sign in or create an account</string>
     <string name="or">or</string>
-    <string name="forgot_password">Forgot password</string>
-    <string name="user_continue">Continue</string>
-    <string name="create_account">Create account</string>
+    <string name="forgot_password">FORGOT PASSWORD?</string>
+    <string name="user_continue">CONTINUE</string>
+    <string name="create_account">CREATE ACCOUNT</string>
     <string name="terms_and_conditions">By continuing, you agree to our Terms of Service. We’ll
         handle your data according to our Privacy Policy.</string>
     <string name="feature_not_available">Feature not available</string>
-    <string name="dismiss">Dismiss</string>
+    <string name="dismiss">DISMISS</string>
     <string name="next">NEXT</string>
     <string name="previous">PREVIOUS</string>
     <string name="done">DONE</string>


### PR DESCRIPTION
* Changing the progress indicator, the previous and next buttons and the question text.
* The next button is now enabled only when an answer was selected
* Capitalising button texts throughout the app.

<img src="https://user-images.githubusercontent.com/2998890/97080799-00884200-15f6-11eb-9f28-37355815b50e.png"  width="300"/>
<img src="https://user-images.githubusercontent.com/2998890/97080800-0120d880-15f6-11eb-8c64-e0f02746971b.png" width="300"/>
