### PR TITLE
Enable R8 for all sample apps

### DIFF
--- a/Crane/app/build.gradle
+++ b/Crane/app/build.gradle
@@ -65,7 +65,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/Crane/app/proguard-rules.pro
+++ b/Crane/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -37,7 +37,7 @@ object Libs {
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
 
         object Coroutines {
-            private const val version = "1.4.0"
+            private const val version = "1.4.1"
             const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
             const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"
         }

--- a/Crane/gradle.properties
+++ b/Crane/gradle.properties
@@ -40,3 +40,6 @@ android.enableJetifier=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true

--- a/JetNews/app/build.gradle
+++ b/JetNews/app/build.gradle
@@ -45,7 +45,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -77,6 +77,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     implementation "androidx.compose.runtime:runtime:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/JetNews/app/proguard-rules.pro
+++ b/JetNews/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -17,6 +17,7 @@
 buildscript {
     ext.kotlin_version = '1.4.10'
     ext.compose_version = '1.0.0-SNAPSHOT'
+    ext.coroutines_version = '1.4.1'
 
     repositories {
         google()

--- a/JetNews/gradle.properties
+++ b/JetNews/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true

--- a/Jetcaster/app/proguard-rules.pro
+++ b/Jetcaster/app/proguard-rules.pro
@@ -14,8 +14,25 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses
+
+# Rome reflectively loads classes referenced in com/rometools/rome/rome.properties.
+-adaptresourcefilecontents com/rometools/rome/rome.properties
+-keep,allowobfuscation class * implements com.rometools.rome.feed.synd.Converter
+-keep,allowobfuscation class * implements com.rometools.rome.io.ModuleParser
+-keep,allowobfuscation class * implements com.rometools.rome.io.WireFeedParser
+
+# Disable warnings for missing classes from OkHttp.
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+
+# Disable warnings for missing classes from JDOM.
+-dontwarn org.jaxen.DefaultNavigator
+-dontwarn org.jaxen.NamespaceContext
+-dontwarn org.jaxen.VariableContext

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -42,14 +42,14 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.4.0"
+        private const val version = "1.4.1"
         const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"
     }
 
     object OkHttp {
-        private const val version = "4.7.2"
+        private const val version = "4.9.0"
         const val okhttp = "com.squareup.okhttp3:okhttp:$version"
         const val logging = "com.squareup.okhttp3:logging-interceptor:$version"
     }

--- a/Jetcaster/gradle.properties
+++ b/Jetcaster/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true

--- a/Jetchat/app/build.gradle
+++ b/Jetchat/app/build.gradle
@@ -51,7 +51,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/Jetchat/app/proguard-rules.pro
+++ b/Jetchat/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -36,7 +36,7 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.3.9"
+        private const val version = "1.4.1"
         const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"

--- a/Jetchat/gradle.properties
+++ b/Jetchat/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true

--- a/Jetsnack/app/build.gradle
+++ b/Jetsnack/app/build.gradle
@@ -50,7 +50,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -77,8 +77,8 @@ android {
 }
 
 dependencies {
-
     implementation Libs.Kotlin.stdlib
+    implementation Libs.Coroutines.android
 
     implementation Libs.Coroutines.core
 

--- a/Jetsnack/app/proguard-rules.pro
+++ b/Jetsnack/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -37,7 +37,7 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.4.0"
+        private const val version = "1.4.1"
         const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"

--- a/Jetsnack/gradle.properties
+++ b/Jetsnack/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true

--- a/Jetsurvey/app/build.gradle
+++ b/Jetsurvey/app/build.gradle
@@ -49,7 +49,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -87,6 +87,7 @@ android {
 
 dependencies {
     implementation Libs.Kotlin.stdlib
+    implementation Libs.Coroutines.android
 
     implementation Libs.AndroidX.coreKtx
     implementation Libs.AndroidX.appcompat

--- a/Jetsurvey/app/proguard-rules.pro
+++ b/Jetsurvey/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -40,6 +40,13 @@ object Libs {
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
     }
 
+    object Coroutines {
+        private const val version = "1.4.1"
+        const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
+        const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
+        const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"
+    }
+
     object AndroidX {
         const val appcompat = "androidx.appcompat:appcompat:1.2.0-rc01"
         const val coreKtx = "androidx.core:core-ktx:1.5.0-alpha01"

--- a/Jetsurvey/gradle.properties
+++ b/Jetsurvey/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true

--- a/Owl/app/build.gradle
+++ b/Owl/app/build.gradle
@@ -50,7 +50,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -78,6 +78,7 @@ android {
 
 dependencies {
     implementation Libs.Kotlin.stdlib
+    implementation Libs.Coroutines.android
 
     implementation Libs.AndroidX.coreKtx
 

--- a/Owl/app/proguard-rules.pro
+++ b/Owl/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -38,7 +38,7 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.4.0"
+        private const val version = "1.4.1"
         const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"

--- a/Owl/gradle.properties
+++ b/Owl/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true

--- a/Rally/app/build.gradle
+++ b/Rally/app/build.gradle
@@ -51,7 +51,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/Rally/app/proguard-rules.pro
+++ b/Rally/app/proguard-rules.pro
@@ -14,8 +14,11 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile
+
+# Repackage classes into the top-level.
+-repackageclasses

--- a/Rally/buildSrc/src/main/java/com/example/compose/rally/buildsrc/dependencies.kt
+++ b/Rally/buildSrc/src/main/java/com/example/compose/rally/buildsrc/dependencies.kt
@@ -36,7 +36,7 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.3.9"
+        private const val version = "1.4.1"
         const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"

--- a/Rally/gradle.properties
+++ b/Rally/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Enable R8 full mode.
+android.enableR8.fullMode=true


### PR DESCRIPTION
This enables R8 (in full mode) for all sample apps.

The version of kotlinx.coroutines is bumped to 1.4.1 to fix some warnings about missing classes (https://github.com/Kotlin/kotlinx.coroutines/commit/d2ed1d809805d9eadd8e8379427971f0e14380ce).

The version of OkHttp is bumped to 4.9.0 in Jetcaster to allow repackaging into the top-level (https://github.com/square/okhttp/pull/6094/commits/e18aa1aadf0c4e4f39e9ce1d4fedd5b44dd66a11).