### PR TITLE
README: Update AS Canary version & added download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more information, please [read the documentation](https://developer.android.
 
 💻 Requirements
 ------------
-To try out these sample apps, you need to use the latest Canary version of Android Studio 4.2.
+To try out these sample apps, you need to use the latest [Canary version of Android Studio Arctic Fox 2020.3.1](https://developer.android.com/studio/preview).
 You can clone this repository or import the
 project from Android Studio following the steps
 [here](https://developer.android.com/jetpack/compose/setup#sample).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more information, please [read the documentation](https://developer.android.
 
 💻 Requirements
 ------------
-To try out these sample apps, you need to use the latest [Canary version of Android Studio Arctic Fox 2020.3.1](https://developer.android.com/studio/preview).
+To try out these sample apps, you need to use the latest [Canary version of Android Studio](https://developer.android.com/studio/preview).
 You can clone this repository or import the
 project from Android Studio following the steps
 [here](https://developer.android.com/jetpack/compose/setup#sample).


### PR DESCRIPTION
Hello,

I want to propose 2 changes to the README:
- Updated recommended AS canary version to Arctic Fox 2020.3.1.
- Add a link that takes directly to the AS canary download page.

About the first point, in my opinion I'd completely remove the version from the text and just leave it as "the lastest Canary version of Android Studio).