### PR TITLE
Revert "[Owl] Nested navigation"

### DIFF
--- a/Owl/app/src/androidTest/java/com/example/owl/ui/NavigationTest.kt
+++ b/Owl/app/src/androidTest/java/com/example/owl/ui/NavigationTest.kt
@@ -17,6 +17,7 @@
 package com.example.owl.ui
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -26,6 +27,7 @@ import androidx.compose.ui.test.performClick
 import com.example.owl.R
 import com.example.owl.model.courses
 import com.example.owl.ui.fakes.ProvideTestImageLoader
+import com.example.owl.ui.utils.LocalBackDispatcher
 import dev.chrisbanes.accompanist.insets.ProvideWindowInsets
 import org.junit.Rule
 import org.junit.Test
@@ -45,16 +47,15 @@ class NavigationTest {
 
     private fun startActivity(startDestination: String? = null) {
         composeTestRule.setContent {
-            ProvideWindowInsets {
-                ProvideTestImageLoader {
-                    if (startDestination == null) {
-                        NavGraph(finishActivity = { })
-                    } else {
-                        NavGraph(
-                            finishActivity = { },
-                            startDestination = startDestination,
-                            showOnboardingInitially = false
-                        )
+            val backDispatcher = composeTestRule.activity.onBackPressedDispatcher
+            CompositionLocalProvider(LocalBackDispatcher provides backDispatcher) {
+                ProvideWindowInsets {
+                    ProvideTestImageLoader {
+                        if (startDestination == null) {
+                            NavGraph()
+                        } else {
+                            NavGraph(startDestination)
+                        }
                     }
                 }
             }

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -30,7 +30,7 @@ class MainActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
-            OwlApp { finish() }
+            OwlApp(onBackPressedDispatcher)
         }
     }
 }

--- a/Owl/app/src/main/java/com/example/owl/ui/OwlApp.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/OwlApp.kt
@@ -16,98 +16,21 @@
 
 package com.example.owl.ui
 
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.BottomNavigation
-import androidx.compose.material.BottomNavigationItem
-import androidx.compose.material.Icon
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.primarySurface
+import androidx.activity.OnBackPressedDispatcher
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import androidx.navigation.compose.KEY_ROUTE
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.navigate
-import androidx.navigation.compose.rememberNavController
-import com.example.owl.ui.courses.CourseTabs
-import com.example.owl.ui.theme.BlueTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import com.example.owl.ui.utils.LocalBackDispatcher
 import com.example.owl.ui.utils.ProvideImageLoader
 import dev.chrisbanes.accompanist.insets.ProvideWindowInsets
-import dev.chrisbanes.accompanist.insets.navigationBarsHeight
-import dev.chrisbanes.accompanist.insets.navigationBarsPadding
 
 @Composable
-fun OwlApp(finishActivity: () -> Unit) {
-    ProvideWindowInsets {
-        ProvideImageLoader {
-            BlueTheme {
-                val tabs = CourseTabs.values()
-                val navController = rememberNavController()
-                OwlScaffold(
-                    bottomBar = { OwlBottomBar(navController = navController, tabs) }
-                ) { innerPaddingModifier ->
-                    NavGraph(
-                        finishActivity = finishActivity,
-                        navController = navController,
-                        modifier = innerPaddingModifier
-                    )
-                }
+fun OwlApp(backDispatcher: OnBackPressedDispatcher) {
+
+    CompositionLocalProvider(LocalBackDispatcher provides backDispatcher) {
+        ProvideWindowInsets {
+            ProvideImageLoader {
+                NavGraph()
             }
         }
-    }
-}
-
-@Composable
-fun OwlBottomBar(navController: NavController, tabs: Array<CourseTabs>) {
-
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.arguments?.getString(KEY_ROUTE)
-        ?: CourseTabs.FEATURED.route
-
-    if (currentRoute in CourseTabs.values().map { it.route }) {
-        BottomNavigation(
-            Modifier.navigationBarsHeight(additional = 56.dp)
-        ) {
-            tabs.forEach { tab ->
-                BottomNavigationItem(
-                    icon = { Icon(painterResource(tab.icon), contentDescription = null) },
-                    label = { Text(stringResource(tab.title).toUpperCase()) },
-                    selected = currentRoute == tab.route,
-                    onClick = {
-                        if (tab.route != currentRoute) {
-                            navController.navigate(tab.route) {
-                                popUpTo = navController.graph.startDestination
-                                launchSingleTop = true
-                            }
-                        }
-                    },
-                    alwaysShowLabel = false,
-                    selectedContentColor = MaterialTheme.colors.secondary,
-                    unselectedContentColor = LocalContentColor.current,
-                    modifier = Modifier.navigationBarsPadding()
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun OwlScaffold(
-    bottomBar: @Composable () -> Unit,
-    content: @Composable (Modifier) -> Unit
-) {
-    Scaffold(
-        backgroundColor = MaterialTheme.colors.primarySurface,
-        bottomBar = bottomBar
-    ) { innerPadding ->
-        val modifier = Modifier.padding(innerPadding)
-        content(modifier)
     }
 }

--- a/Owl/app/src/main/java/com/example/owl/ui/course/CourseDetails.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/course/CourseDetails.kt
@@ -16,7 +16,6 @@
 
 package com.example.owl.ui.course
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -88,6 +87,7 @@ import com.example.owl.ui.theme.BlueTheme
 import com.example.owl.ui.theme.PinkTheme
 import com.example.owl.ui.theme.pink500
 import com.example.owl.ui.utils.NetworkImage
+import com.example.owl.ui.utils.backHandler
 import com.example.owl.ui.utils.lerp
 import com.example.owl.ui.utils.scrim
 import dev.chrisbanes.accompanist.insets.LocalWindowInsets
@@ -125,7 +125,7 @@ fun CourseDetails(
             val dragRange = constraints.maxHeight - fabSize
             val scope = rememberCoroutineScope()
 
-            BackHandler(
+            backHandler(
                 enabled = sheetState.currentValue == SheetState.Open,
                 onBack = {
                     scope.launch {

--- a/Owl/app/src/main/java/com/example/owl/ui/utils/Navigation.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/utils/Navigation.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.owl.ui.utils
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * An effect for handling presses of the device back button.
+ */
+@Composable
+fun backHandler(
+    enabled: Boolean = true,
+    onBack: () -> Unit
+) {
+    // Safely update the current `onBack` lambda when a new one is provided
+    val currentOnBack by rememberUpdatedState(onBack)
+    // Remember in Composition a back callback that calls the `onBack` lambda
+    val backCallback = remember {
+        object : OnBackPressedCallback(enabled) {
+            override fun handleOnBackPressed() {
+                currentOnBack()
+            }
+        }
+    }
+    // On every successful composition, update the callback with the `enabled` value
+    SideEffect {
+        backCallback.isEnabled = enabled
+    }
+    val backDispatcher = LocalBackDispatcher.current
+    // If `backDispatcher` changes, dispose and reset the effect
+    DisposableEffect(backDispatcher) {
+        // Add callback to the backDispatcher
+        backDispatcher.addCallback(backCallback)
+        // When the effect leaves the Composition, remove the callback
+        onDispose {
+            backCallback.remove()
+        }
+    }
+}
+
+/**
+ * An [androidx.compose.runtime.Ambient] providing the current [OnBackPressedDispatcher]. You must
+ * [provide][androidx.compose.runtime.Providers] a value before use.
+ */
+internal val LocalBackDispatcher = staticCompositionLocalOf<OnBackPressedDispatcher> {
+    error("No Back Dispatcher provided")
+}

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -50,11 +50,11 @@ object Libs {
 
     object AndroidX {
         const val coreKtx = "androidx.core:core-ktx:1.5.0-beta03"
-        const val navigation = "androidx.navigation:navigation-compose:1.0.0-SNAPSHOT"
+        const val navigation = "androidx.navigation:navigation-compose:1.0.0-alpha08"
 
         object Compose {
-            const val snapshot = "7179952"
-            const val version = "1.0.0-SNAPSHOT"
+            const val snapshot = ""
+            const val version = "1.0.0-beta02"
 
             const val animation = "androidx.compose.animation:animation:$version"
             const val foundation = "androidx.compose.foundation:foundation:$version"


### PR DESCRIPTION
Navigation was using a snapshot build (7187420) which is not out yet. To make the next release easier, I'm reverting as there's not reason to sync with it.