### PR TITLE
[Jetnews] UI polish bugs #458

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
@@ -35,8 +35,8 @@ import androidx.compose.material.TextButton
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.ThumbUpOffAlt
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -183,7 +183,7 @@ private fun BottomBar(
         ) {
             IconButton(onClick = onUnimplementedAction) {
                 Icon(
-                    imageVector = Icons.Filled.FavoriteBorder,
+                    imageVector = Icons.Filled.ThumbUpOffAlt,
                     contentDescription = stringResource(R.string.cd_add_to_favorites)
                 )
             }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/PostContent.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/PostContent.kt
@@ -267,7 +267,7 @@ private fun ParagraphType.getTextAndParagraphStyle(): ParagraphStyling {
             trailingPadding = 16.dp
         }
         ParagraphType.Text -> {
-            textStyle = typography.body1
+            textStyle = typography.body1.copy(lineHeight = 28.sp)
             paragraphStyle = paragraphStyle.copy(lineHeight = 28.sp)
         }
         ParagraphType.Header -> {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
@@ -59,17 +59,19 @@ fun PostCardTop(post: Post, modifier: Modifier = Modifier) {
 
         Text(
             text = post.title,
-            style = typography.h6
+            style = typography.h6,
+            modifier = Modifier.padding(bottom = 8.dp)
         )
         Text(
             text = post.metadata.author.name,
-            style = typography.body2
+            style = typography.subtitle2,
+            modifier = Modifier.padding(bottom = 4.dp)
         )
 
         CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
             Text(
                 text = "${post.metadata.date} - ${post.metadata.readTimeMinutes} min read",
-                style = typography.body2
+                style = typography.subtitle2
             )
         }
     }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -222,7 +222,11 @@ private fun TabContent(
 
         ) {
             tabContent.forEachIndexed { index, tabContent ->
-                val colorText = if (selectedTabIndex == index) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface.copy(alpha = 0.8f)
+                val colorText = if (selectedTabIndex == index) {
+                    MaterialTheme.colors.primary
+                } else {
+                    MaterialTheme.colors.onSurface.copy(alpha = 0.8f)
+                }
                 Tab(
                     text = {
                         Text(

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -216,16 +216,30 @@ private fun TabContent(
     val selectedTabIndex = tabContent.indexOfFirst { it.section == currentSection }
     Column {
         TabRow(
-            selectedTabIndex = selectedTabIndex
+            selectedTabIndex = selectedTabIndex,
+            backgroundColor = MaterialTheme.colors.onPrimary,
+            contentColor = MaterialTheme.colors.primary,
+
         ) {
             tabContent.forEachIndexed { index, tabContent ->
+                val colorText = if (selectedTabIndex == index) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface.copy(alpha = 0.8f)
                 Tab(
-                    text = { Text(tabContent.section.title) },
+                    text = {
+                        Text(
+                            text = tabContent.section.title,
+                            color = colorText
+                        )
+                    },
                     selected = selectedTabIndex == index,
-                    onClick = { updateSection(tabContent.section) }
+                    onClick = {
+                        updateSection(tabContent.section)
+                    }
                 )
             }
         }
+        Divider(
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.1f)
+        )
         Box(modifier = Modifier.weight(1f)) {
             // display the current tab content which is a @Composable () -> Unit
             tabContent[selectedTabIndex].content()
@@ -385,8 +399,8 @@ private fun TopicItem(itemTitle: String, selected: Boolean, onToggle: () -> Unit
 @Composable
 private fun TopicDivider() {
     Divider(
-        modifier = Modifier.padding(start = 72.dp, top = 8.dp, bottom = 8.dp),
-        color = MaterialTheme.colors.surface.copy(alpha = 0.08f)
+        modifier = Modifier.padding(start = 90.dp, top = 8.dp, bottom = 8.dp),
+        color = MaterialTheme.colors.onSurface.copy(alpha = 0.1f)
     )
 }
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
@@ -16,10 +16,11 @@
 
 package com.example.jetnews.ui.interests
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
@@ -27,6 +28,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.jetnews.ui.ThemedPreview
@@ -37,18 +39,23 @@ fun SelectTopicButton(
     selected: Boolean = false
 ) {
     val icon = if (selected) Icons.Filled.Done else Icons.Filled.Add
+    val iconColor = if (selected) MaterialTheme.colors.onPrimary else MaterialTheme.colors.primary
+    val borderColor = if (selected) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface.copy(alpha = 0.1f)
     val backgroundColor = if (selected) {
         MaterialTheme.colors.primary
     } else {
-        MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+        MaterialTheme.colors.onPrimary
     }
     Surface(
         color = backgroundColor,
         shape = CircleShape,
+        border = BorderStroke(1.dp, borderColor),
         modifier = modifier.size(36.dp, 36.dp)
     ) {
-        Icon(
+        Image(
             imageVector = icon,
+            colorFilter = ColorFilter.tint(iconColor),
+            modifier = Modifier.padding(8.dp),
             contentDescription = null // toggleable at higher level
         )
     }


### PR DESCRIPTION
Updated UI components to match current design

https://github.com/android/compose-samples/issues/458

- **Line height in article doesn't match spec**

Before
![image](https://user-images.githubusercontent.com/16503982/114098632-3dd04b80-9887-11eb-808e-e25e223ef2a7.png)

After
![image](https://user-images.githubusercontent.com/16503982/114097748-19c03a80-9886-11eb-9461-ef3fc7420453.png)

- **Spacing on article title on hero card on Home screen is off from spec**

Before
![image](https://user-images.githubusercontent.com/16503982/114098656-49237700-9887-11eb-88e4-347da8d13686.png)

After
![image](https://user-images.githubusercontent.com/16503982/114097865-41170780-9886-11eb-9a51-add4ca99cfcb.png)

- **Heart icon article bottom app bar should be a Like icon**

Before
![image](https://user-images.githubusercontent.com/16503982/114098692-56406600-9887-11eb-97d9-d1361e88041b.png)

After
![image](https://user-images.githubusercontent.com/16503982/114097967-5ab84f00-9886-11eb-9a62-e7b463388990.png)

- **Divider lines missing between Interest list items**

- **Spacing between Interest list items doesn't match spec**

- **Add interest button doesn't match spec**

Before
![image](https://user-images.githubusercontent.com/16503982/114098730-62c4be80-9887-11eb-92e1-ed681b2e00ae.png)

After
![image](https://user-images.githubusercontent.com/16503982/114098104-86d3d000-9886-11eb-8ebe-2e05e212f250.png)

- **EXTRA: Tab style doesn't match design**

Before
![image](https://user-images.githubusercontent.com/16503982/114098755-6d7f5380-9887-11eb-9381-e1d60c19bb41.png)

After
![image](https://user-images.githubusercontent.com/16503982/114098254-b8e53200-9886-11eb-87ef-946920b55bd3.png)





