### PR TITLE
[Jetsurvey] UI polish bugs

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.paddingFromBaseline
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -39,6 +40,7 @@ import androidx.compose.material.OutlinedButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronLeft
@@ -253,7 +255,8 @@ fun OrSignInAsGuest(
             CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
                 Text(
                     text = stringResource(id = R.string.or),
-                    style = MaterialTheme.typography.subtitle2
+                    style = MaterialTheme.typography.subtitle2,
+                    modifier = Modifier.paddingFromBaseline(top = 25.dp)
                 )
             }
         }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/WelcomeScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/WelcomeScreen.kt
@@ -167,7 +167,7 @@ private fun SignInCreateAccount(
                 text = stringResource(id = R.string.sign_in_create_account),
                 style = MaterialTheme.typography.subtitle2,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(vertical = 24.dp)
+                modifier = Modifier.padding(top = 64.dp, bottom = 12.dp)
             )
         }
         val onSubmit = {
@@ -183,7 +183,7 @@ private fun SignInCreateAccount(
             onClick = onSubmit,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 28.dp)
+                .padding(top = 28.dp, bottom = 3.dp)
         ) {
             Text(
                 text = stringResource(id = R.string.user_continue),

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -79,7 +79,7 @@ fun Question(
         contentPadding = PaddingValues(start = 20.dp, end = 20.dp)
     ) {
         item {
-            Spacer(modifier = Modifier.height(44.dp))
+            Spacer(modifier = Modifier.height(32.dp))
             val backgroundColor = if (MaterialTheme.colors.isLight) {
                 MaterialTheme.colors.onSurface.copy(alpha = 0.04f)
             } else {
@@ -109,7 +109,7 @@ fun Question(
                         style = MaterialTheme.typography.caption,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = 24.dp, start = 8.dp, end = 8.dp)
+                            .padding(bottom = 18.dp, start = 8.dp, end = 8.dp)
                     )
                 }
             }
@@ -179,11 +179,22 @@ private fun SingleChoiceQuestion(
                 Unit
             }
             val optionSelected = text == selectedOption
+
+            val answerBorderColor = if (optionSelected) {
+                MaterialTheme.colors.primary.copy(alpha = 0.5f)
+            } else {
+                MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+            }
+            val answerBackgroundColor = if (optionSelected) {
+                MaterialTheme.colors.primary.copy(alpha = 0.12f)
+            } else {
+                MaterialTheme.colors.background
+            }
             Surface(
                 shape = MaterialTheme.shapes.small,
                 border = BorderStroke(
                     width = 1.dp,
-                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+                    color = answerBorderColor
                 ),
                 modifier = Modifier.padding(vertical = 8.dp)
             ) {
@@ -194,7 +205,8 @@ private fun SingleChoiceQuestion(
                             selected = optionSelected,
                             onClick = onClickHandle
                         )
-                        .padding(vertical = 16.dp, horizontal = 24.dp),
+                        .background(answerBackgroundColor)
+                        .padding(vertical = 16.dp, horizontal = 16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
@@ -229,24 +241,36 @@ private fun MultipleChoiceQuestion(
                 val selectedOption = answer?.answersStringRes?.contains(option.value)
                 mutableStateOf(selectedOption ?: false)
             }
+            val answerBorderColor = if (checkedState) {
+                MaterialTheme.colors.primary.copy(alpha = 0.5f)
+            } else {
+                MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+            }
+            val answerBackgroundColor = if (checkedState) {
+                MaterialTheme.colors.primary.copy(alpha = 0.12f)
+            } else {
+                MaterialTheme.colors.background
+            }
             Surface(
                 shape = MaterialTheme.shapes.small,
                 border = BorderStroke(
                     width = 1.dp,
-                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+                    color = answerBorderColor
                 ),
-                modifier = Modifier.padding(vertical = 4.dp)
+                modifier = Modifier
+                    .padding(vertical = 8.dp)
             ) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .background(answerBackgroundColor)
                         .clickable(
                             onClick = {
                                 checkedState = !checkedState
                                 onAnswerSelected(option.value, checkedState)
                             }
                         )
-                        .padding(vertical = 16.dp, horizontal = 24.dp),
+                        .padding(vertical = 16.dp, horizontal = 16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
@@ -357,6 +381,8 @@ private fun DateQuestion(
     onAction: (Int, SurveyActionType) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // val date = Date()
+    // val formatter = SimpleDateFormat("dd/MM/yyyy")
     Button(
         onClick = { onAction(questionId, SurveyActionType.PICK_DATE) },
         modifier = modifier.padding(vertical = 20.dp)

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -194,11 +194,14 @@ private fun SurveyTopAppBar(
             CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
                 IconButton(
                     onClick = onBackPressed,
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier
+                        .padding(horizontal = 20.dp, vertical = 20.dp)
+                        .fillMaxWidth()
                 ) {
                     Icon(
                         Icons.Filled.Close,
-                        contentDescription = stringResource(id = R.string.close)
+                        contentDescription = stringResource(id = R.string.close),
+                        modifier = Modifier.align(Alignment.CenterEnd)
                     )
                 }
             }
@@ -221,9 +224,10 @@ private fun SurveyBottomBar(
     onDonePressed: () -> Unit
 ) {
     Surface(
-        elevation = 3.dp,
-        modifier = Modifier.fillMaxWidth()
+        elevation = 7.dp,
+        modifier = Modifier.fillMaxWidth() // .border(1.dp, MaterialTheme.colors.primary)
     ) {
+
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -231,7 +235,9 @@ private fun SurveyBottomBar(
         ) {
             if (questionState.showPrevious) {
                 OutlinedButton(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp),
                     onClick = onPreviousPressed
                 ) {
                     Text(text = stringResource(id = R.string.previous))
@@ -240,7 +246,9 @@ private fun SurveyBottomBar(
             }
             if (questionState.showDone) {
                 Button(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp),
                     onClick = onDonePressed,
                     enabled = questionState.enableNext
                 ) {
@@ -248,7 +256,9 @@ private fun SurveyBottomBar(
                 }
             } else {
                 Button(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp),
                     onClick = onNextPressed,
                     enabled = questionState.enableNext
                 ) {

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Theme.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/theme/Theme.kt
@@ -58,7 +58,7 @@ val Colors.snackbarAction: Color
 
 val Colors.progressIndicatorBackground: Color
     @Composable
-    get() = if (isLight) Color.Black.copy(alpha = 0.12f) else Color.Black.copy(alpha = 0.24f)
+    get() = if (isLight) Color.Black.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.24f)
 
 @Composable
 fun JetsurveyTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {


### PR DESCRIPTION
Fixed first reported issues for Jetsurvey application

https://github.com/android/compose-samples/issues/460

**Login/signup screen**

•	 TextField corners on Login/Signup should be more round (12.dp versus 4.dp)
_Pending: Feature not yet implemented by Material component OutlinedTextField_
•	  Spacing above "Sign in" text should be 64.dp
•	  Space between "Sign in" and email text field should be 20.dp
_OutlinedTextField has an 8 dp top padding so I adjusted the space to 12 dp_
•	  Space between Continue button and "or" should be 28.dp (text baseline aligned)


Before
![image](https://user-images.githubusercontent.com/16503982/114886142-e96c2500-9dcc-11eb-866a-f17fcace9fb8.png)

After
![image](https://user-images.githubusercontent.com/16503982/114885297-1f5cd980-9dcc-11eb-9a27-5bd245a50f73.png)


**Base elements question polish**

•	  Close X mark should be on right
•	  Close X mark should be vertically centered with " of " text
•	  Close X mark edge should align with end of progress bar
•	  Spacing between progress bar and question should be 32.dp
•	  Options content should all be left-aligned with question text
•	  Next/Previous buttons should be taller to 48.dp
•	  Missing elevation divider above Next/Previous buttons
_Elevation doesn’t shows in the emulator in light theme_
•	  Vertical padding of description should be 24.dp
•	  Selected option should primary style
•	  Space between options should be 16.dp
•	  Progress bar background missing in dark theme

Before
![image](https://user-images.githubusercontent.com/16503982/114886073-da857280-9dcc-11eb-9154-76b9b0a880d1.png)
![image](https://user-images.githubusercontent.com/16503982/114885986-c9d4fc80-9dcc-11eb-9de3-2820f1cfed87.png)

After
![image](https://user-images.githubusercontent.com/16503982/114885712-8b3f4200-9dcc-11eb-9cf9-6795ede06a83.png)
![image](https://user-images.githubusercontent.com/16503982/114885777-9c884e80-9dcc-11eb-938c-b1cf75a72dfc.png)

