### PR TITLE
[Jetsurvey] Photo was not showing with rememberCoilPainter

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -26,8 +26,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
@@ -345,7 +347,8 @@ private fun PhotoQuestion(
                     contentDescription = null,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(302.dp)
+                        .heightIn(96.dp)
+                        .aspectRatio(1.22f)
                 )
             } else {
                 PhotoDefaultImage(modifier = Modifier.padding(horizontal = 86.dp, vertical = 74.dp))

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -348,7 +348,7 @@ private fun PhotoQuestion(
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(96.dp)
-                        .aspectRatio(1.22f)
+                        .aspectRatio(4 / 3f)
                 )
             } else {
                 PhotoDefaultImage(modifier = Modifier.padding(horizontal = 86.dp, vertical = 74.dp))

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -344,7 +344,9 @@ private fun PhotoQuestion(
                 Image(
                     painter = rememberCoilPainter(answer.result.uri, fadeIn = true),
                     contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .height(302.dp)
+                        .fillMaxWidth(),
                 )
             } else {
                 PhotoDefaultImage(modifier = Modifier.padding(horizontal = 86.dp, vertical = 74.dp))

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding


### PR DESCRIPTION
Preview image stop showing after migrating to rememberCoilPainter

https://github.com/android/compose-samples/issues/460

Taken photo should be clipped, keep size of photo frame the same

Before
![image](https://user-images.githubusercontent.com/16503982/115634402-2f465300-a2cf-11eb-8f48-2afcf79b73c2.png)


After
![image](https://user-images.githubusercontent.com/16503982/115632193-cfe74380-a2cc-11eb-9e3a-7f0ae21d3884.png)
