### PR TITLE
[Jetsnack] Create styles for different button states

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
@@ -107,15 +107,15 @@ fun FilterChip(
 
         val pressed by interactionSource.collectIsPressedAsState()
         val backgroundPressed =
-            if (pressed)
+            if (pressed) {
                 Modifier.offsetGradientBackground(
                     JetsnackTheme.colors.interactiveSecondary,
                     200f,
                     0f
                 )
-            else
+            } else {
                 Modifier.background(Color.Transparent)
-
+            }
         Box(
             modifier = Modifier
                 .toggleable(

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
@@ -18,9 +18,8 @@ package com.example.jetsnack.ui.components
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -38,9 +37,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FilterList
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import com.example.jetsnack.R
 import com.example.jetsnack.model.Filter
 import com.example.jetsnack.ui.theme.JetsnackTheme
-import kotlinx.coroutines.flow.collect
 
 @Composable
 fun FilterBar(filters: List<Filter>) {
@@ -108,24 +104,8 @@ fun FilterChip(
         elevation = 2.dp
     ) {
         val interactionSource = remember { MutableInteractionSource() }
-        val interactions = remember { mutableStateListOf<Interaction>() }
 
-        LaunchedEffect(interactionSource) {
-            interactionSource.interactions.collect { interaction ->
-                when (interaction) {
-                    is PressInteraction.Press -> {
-                        interactions.add(interaction)
-                    }
-                    is PressInteraction.Release -> {
-                        interactions.remove(interaction.press)
-                    }
-                    is PressInteraction.Cancel -> {
-                        interactions.remove(interaction.press)
-                    }
-                }
-            }
-        }
-        val pressed = interactions.any { it is PressInteraction.Press }
+        val pressed by interactionSource.collectIsPressedAsState()
         val backgroundPressed =
             if (pressed)
                 Modifier.offsetGradientBackground(
@@ -137,12 +117,13 @@ fun FilterChip(
                 Modifier.background(Color.Transparent)
 
         Box(
-            modifier = Modifier.toggleable(
-                value = selected,
-                onValueChange = setSelected,
-                interactionSource = interactionSource,
-                indication = null
-            )
+            modifier = Modifier
+                .toggleable(
+                    value = selected,
+                    onValueChange = setSelected,
+                    interactionSource = interactionSource,
+                    indication = null
+                )
                 .then(backgroundPressed)
                 .then(border),
         ) {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
@@ -18,15 +18,13 @@ package com.example.jetsnack.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,7 +32,6 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.example.jetsnack.ui.theme.JetsnackTheme
-import kotlinx.coroutines.flow.collect
 
 @Composable
 fun JetsnackGradientTintedIconButton(
@@ -45,30 +42,14 @@ fun JetsnackGradientTintedIconButton(
     colors: List<Color> = JetsnackTheme.colors.interactiveSecondary
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    val interactions = remember { mutableStateListOf<Interaction>() }
 
-    LaunchedEffect(interactionSource) {
-        interactionSource.interactions.collect { interaction ->
-            when (interaction) {
-                is PressInteraction.Press -> {
-                    interactions.add(interaction)
-                }
-                is PressInteraction.Release -> {
-                    interactions.remove(interaction.press)
-                }
-                is PressInteraction.Cancel -> {
-                    interactions.remove(interaction.press)
-                }
-            }
-        }
-    }
     // This should use a layer + srcIn but needs investigation
     val border = Modifier.fadeInDiagonalGradientBorder(
         showBorder = true,
         colors = JetsnackTheme.colors.interactiveSecondary,
         shape = CircleShape
     )
-    val pressed = interactions.any { it is PressInteraction.Press }
+    val pressed by interactionSource.collectIsPressedAsState()
     val background =
         if (pressed)
             Modifier.offsetGradientBackground(

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
@@ -50,30 +50,26 @@ fun JetsnackGradientTintedIconButton(
         shape = CircleShape
     )
     val pressed by interactionSource.collectIsPressedAsState()
-    val background =
-        if (pressed)
-            Modifier.offsetGradientBackground(
-                colors,
-                200f,
-                0f
-            )
-        else
-            Modifier.background(JetsnackTheme.colors.uiBackground)
+    val background = if (pressed) {
+        Modifier.offsetGradientBackground(colors, 200f, 0f)
+    } else {
+        Modifier.background(JetsnackTheme.colors.uiBackground)
+    }
     val blendMode = if (JetsnackTheme.colors.isDark) BlendMode.Darken else BlendMode.Plus
-    val modifierColor =
-        if (pressed)
-            Modifier.diagonalGradientTint(
-                colors = listOf(
-                    JetsnackTheme.colors.textSecondary,
-                    JetsnackTheme.colors.textSecondary
-                ),
-                blendMode = blendMode
-            )
-        else
-            Modifier.diagonalGradientTint(
-                colors = colors,
-                blendMode = blendMode
-            )
+    val modifierColor = if (pressed) {
+        Modifier.diagonalGradientTint(
+            colors = listOf(
+                JetsnackTheme.colors.textSecondary,
+                JetsnackTheme.colors.textSecondary
+            ),
+            blendMode = blendMode
+        )
+    } else {
+        Modifier.diagonalGradientTint(
+            colors = colors,
+            blendMode = blendMode
+        )
+    }
     Surface(
         modifier = modifier
             .clickable(

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
@@ -16,14 +16,25 @@
 
 package com.example.jetsnack.ui.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.example.jetsnack.ui.theme.JetsnackTheme
+import kotlinx.coroutines.flow.collect
 
 @Composable
 fun JetsnackGradientTintedIconButton(
@@ -33,16 +44,71 @@ fun JetsnackGradientTintedIconButton(
     modifier: Modifier = Modifier,
     colors: List<Color> = JetsnackTheme.colors.interactiveSecondary
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val interactions = remember { mutableStateListOf<Interaction>() }
+
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect { interaction ->
+            when (interaction) {
+                is PressInteraction.Press -> {
+                    interactions.add(interaction)
+                }
+                is PressInteraction.Release -> {
+                    interactions.remove(interaction.press)
+                }
+                is PressInteraction.Cancel -> {
+                    interactions.remove(interaction.press)
+                }
+            }
+        }
+    }
     // This should use a layer + srcIn but needs investigation
+    val border = Modifier.fadeInDiagonalGradientBorder(
+        showBorder = true,
+        colors = JetsnackTheme.colors.interactiveSecondary,
+        shape = CircleShape
+    )
+    val pressed = interactions.any { it is PressInteraction.Press }
+    val background =
+        if (pressed)
+            Modifier.offsetGradientBackground(
+                colors,
+                200f,
+                0f
+            )
+        else
+            Modifier.background(JetsnackTheme.colors.uiBackground)
     val blendMode = if (JetsnackTheme.colors.isDark) BlendMode.Darken else BlendMode.Plus
-    IconButton(onClick = onClick, modifier) {
-        Icon(
-            imageVector = imageVector,
-            contentDescription = contentDescription,
-            modifier = Modifier.diagonalGradientTint(
+    val modifierColor =
+        if (pressed)
+            Modifier.diagonalGradientTint(
+                colors = listOf(
+                    JetsnackTheme.colors.textSecondary,
+                    JetsnackTheme.colors.textSecondary
+                ),
+                blendMode = blendMode
+            )
+        else
+            Modifier.diagonalGradientTint(
                 colors = colors,
                 blendMode = blendMode
             )
+    Surface(
+        modifier = modifier
+            .clickable(
+                onClick = onClick,
+                interactionSource = interactionSource,
+                indication = null
+            )
+            .clip(CircleShape)
+            .then(border)
+            .then(background),
+        color = Color.Transparent
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            modifier = modifierColor
         )
     }
 }

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/QuantitySelector.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/QuantitySelector.kt
@@ -17,14 +17,15 @@
 package com.example.jetsnack.ui.components
 
 import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.AddCircleOutline
-import androidx.compose.material.icons.outlined.RemoveCircleOutline
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -53,14 +54,16 @@ fun QuantitySelector(
                 text = stringResource(R.string.quantity),
                 style = MaterialTheme.typography.subtitle1,
                 color = JetsnackTheme.colors.textSecondary,
-                modifier = Modifier.constrainAs(qty) {
-                    start.linkTo(parent.start)
-                    linkTo(top = parent.top, bottom = parent.bottom)
-                }
+                modifier = Modifier
+                    .padding(end = 18.dp)
+                    .constrainAs(qty) {
+                        start.linkTo(parent.start)
+                        linkTo(top = parent.top, bottom = parent.bottom)
+                    }
             )
         }
         JetsnackGradientTintedIconButton(
-            imageVector = Icons.Outlined.RemoveCircleOutline,
+            imageVector = Icons.Default.Remove,
             onClick = decreaseItemCount,
             contentDescription = stringResource(R.string.label_decrease),
             modifier = Modifier.constrainAs(minus) {
@@ -83,7 +86,7 @@ fun QuantitySelector(
             )
         }
         JetsnackGradientTintedIconButton(
-            imageVector = Icons.Outlined.AddCircleOutline,
+            imageVector = Icons.Default.Add,
             onClick = increaseItemCount,
             contentDescription = stringResource(R.string.label_increase),
             modifier = Modifier.constrainAs(plus) {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt
@@ -33,6 +33,7 @@ import com.example.jetsnack.ui.utils.LocalSysUiController
 
 private val LightColorPalette = JetsnackColors(
     brand = Shadow5,
+    brandSecondary = Ocean3,
     uiBackground = Neutral0,
     uiBorder = Neutral4,
     uiFloated = FunctionalGrey,
@@ -55,6 +56,7 @@ private val LightColorPalette = JetsnackColors(
 
 private val DarkColorPalette = JetsnackColors(
     brand = Shadow1,
+    brandSecondary = Ocean2,
     uiBackground = Neutral8,
     uiBorder = Neutral3,
     uiFloated = FunctionalDarkGrey,
@@ -73,7 +75,7 @@ private val DarkColorPalette = JetsnackColors(
     gradient3_1 = listOf(Shadow9, Ocean7, Shadow5),
     gradient3_2 = listOf(Rose8, Lavender7, Rose11),
     gradient2_1 = listOf(Ocean3, Shadow3),
-    gradient2_2 = listOf(Ocean7, Shadow7),
+    gradient2_2 = listOf(Ocean4, Shadow2, Shadow2),
     isDark = true
 )
 
@@ -119,6 +121,7 @@ class JetsnackColors(
     gradient2_1: List<Color>,
     gradient2_2: List<Color>,
     brand: Color,
+    brandSecondary: Color,
     uiBackground: Color,
     uiBorder: Color,
     uiFloated: Color,
@@ -152,6 +155,7 @@ class JetsnackColors(
         private set
     var brand by mutableStateOf(brand)
         private set
+    var brandSecondary by mutableStateOf(brandSecondary)
     var uiBackground by mutableStateOf(uiBackground)
         private set
     var uiBorder by mutableStateOf(uiBorder)
@@ -197,6 +201,7 @@ class JetsnackColors(
         gradient2_1 = other.gradient2_1
         gradient2_2 = other.gradient2_2
         brand = other.brand
+        brandSecondary = other.brandSecondary
         uiBackground = other.uiBackground
         uiBorder = other.uiBorder
         uiFloated = other.uiFloated


### PR DESCRIPTION
https://github.com/android/compose-samples/issues/487

**Home**

-  Filter chips "pressed" and "selected" state is not to spec
-  Incorrect gradient borders on chips in dark theme

Before
![image](https://user-images.githubusercontent.com/16503982/116473687-23154500-a83d-11eb-8737-e56540f49e85.png)
![image](https://user-images.githubusercontent.com/16503982/116473755-37f1d880-a83d-11eb-9468-2e75aef48280.png)

After
![image](https://user-images.githubusercontent.com/16503982/116473129-6f13ba00-a83c-11eb-9082-9de954139271.png)
![image](https://user-images.githubusercontent.com/16503982/116473080-5c998080-a83c-11eb-9282-4def1a503dd3.png)


**Cart**

-  The quantity + and - buttons should have same click state as filter chips

Before
![image](https://user-images.githubusercontent.com/16503982/116473659-12fd6580-a83d-11eb-885e-4eb9be7f1ffb.png)
![image](https://user-images.githubusercontent.com/16503982/116473602-fcefa500-a83c-11eb-8eb0-fddb96e3b0d6.png)

After

![image](https://user-images.githubusercontent.com/16503982/116473213-86eb3e00-a83c-11eb-8a39-f5d089ff1daa.png)
![image](https://user-images.githubusercontent.com/16503982/116473913-6b346780-a83d-11eb-9894-d90370e51c2a.png)

