### PR TITLE
[Jetnews] Mark headings in interests screen for accessibility services

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.jetnews.R
@@ -329,7 +331,7 @@ private fun TabWithSections(
             item {
                 Text(
                     text = section,
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier.padding(16.dp).semantics { heading() },
                     style = MaterialTheme.typography.subtitle1
                 )
             }


### PR DESCRIPTION
To test: 
- Navigate to Interests screen
- Turn on Talkback
- Turn on navigation by headings, by swiping repeatedly with three fingers
- Swipe up & down to navigate from header to header