### PR TITLE
[Owl] Fix tests never ending

### DIFF
--- a/Owl/app/src/androidTest/java/com/example/owl/ui/fakes/ProvideTestImageLoader.kt
+++ b/Owl/app/src/androidTest/java/com/example/owl/ui/fakes/ProvideTestImageLoader.kt
@@ -20,6 +20,7 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
 import coil.bitmap.BitmapPool
@@ -38,44 +39,43 @@ import com.google.accompanist.coil.LocalImageLoader
 @OptIn(ExperimentalCoilApi::class)
 @Composable
 fun ProvideTestImageLoader(content: @Composable () -> Unit) {
-
     // From https://coil-kt.github.io/coil/image_loaders/
-    val loader = object : ImageLoader {
-        private val drawable = ColorDrawable(Color.BLACK)
+    val loader = remember {
+        object : ImageLoader {
+            private val disposable = object : Disposable {
+                override val isDisposed get() = true
+                override fun dispose() {}
+                override suspend fun await() {}
+            }
 
-        private val disposable = object : Disposable {
-            override val isDisposed get() = true
-            override fun dispose() {}
-            override suspend fun await() {}
-        }
+            override val bitmapPool: BitmapPool = BitmapPool(0)
 
-        override val bitmapPool: BitmapPool = BitmapPool(0)
+            override val defaults: DefaultRequestOptions = DefaultRequestOptions()
+            override val memoryCache: MemoryCache
+                get() = TODO("Not yet implemented")
 
-        override val defaults: DefaultRequestOptions = DefaultRequestOptions()
-        override val memoryCache: MemoryCache
-            get() = TODO("Not yet implemented")
+            override fun enqueue(request: ImageRequest): Disposable {
+                // Always call onStart before onSuccess.
+                request.target?.onStart(placeholder = null)
+                request.target?.onSuccess(result = ColorDrawable(Color.BLACK))
+                return disposable
+            }
 
-        override fun enqueue(request: ImageRequest): Disposable {
-            // Always call onStart before onSuccess.
-            request.target?.onStart(drawable)
-            request.target?.onSuccess(drawable)
-            return disposable
-        }
-
-        override suspend fun execute(request: ImageRequest): ImageResult {
-            return SuccessResult(
-                drawable = drawable,
-                request = request,
-                metadata = ImageResult.Metadata(
-                    memoryCacheKey = MemoryCache.Key(""),
-                    isSampled = false,
-                    dataSource = DataSource.MEMORY_CACHE,
-                    isPlaceholderMemoryCacheKeyPresent = false
+            override suspend fun execute(request: ImageRequest): ImageResult {
+                return SuccessResult(
+                    drawable = ColorDrawable(Color.BLACK),
+                    request = request,
+                    metadata = ImageResult.Metadata(
+                        memoryCacheKey = MemoryCache.Key(""),
+                        isSampled = false,
+                        dataSource = DataSource.MEMORY_CACHE,
+                        isPlaceholderMemoryCacheKeyPresent = false
+                    )
                 )
-            )
-        }
+            }
 
-        override fun shutdown() {}
+            override fun shutdown() {}
+        }
     }
     CompositionLocalProvider(LocalImageLoader provides loader, content = content)
 }


### PR DESCRIPTION
The TestImageLoader was set to return the same drawable instance for every request. This causes issues though as Drawables are stateful, and therefore can't be used in multiple places at once.

Fixed by returning a new instance for each request. Also remembered the image loader for a small perf improvement.

Fixes #537 