### PR TITLE
Fix custom notice in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -174,7 +174,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2020 The Android Open Source Project
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The LICENSE file should not contain the custom notice for Apache 2.0.
This commit replaces the custom notice with the templated version and
brings the contents of LICENSE file to match
https://www.apache.org/licenses/LICENSE-2.0.txt

Fixes #545.