### PR TITLE
Remove jcenter

### DIFF
--- a/Crane/app/build.gradle
+++ b/Crane/app/build.gradle
@@ -107,6 +107,12 @@ dependencies {
     implementation Libs.Kotlin.Coroutines.android
     implementation Libs.GoogleMaps.maps
     implementation Libs.GoogleMaps.mapsKtx
+    constraints {
+        // Volley is a transitive dependency of maps
+        implementation(Libs.Volley.volley) {
+            because("Only volley 1.2.0 or newer are available on maven.google.com")
+        }
+    }
 
     implementation Libs.Accompanist.coil
     implementation Libs.Accompanist.insets

--- a/Crane/build.gradle
+++ b/Crane/build.gradle
@@ -21,7 +21,6 @@ import com.example.crane.buildsrc.Versions
 buildscript {
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath Libs.androidGradlePlugin
@@ -37,7 +36,6 @@ plugins {
 subprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
 
         if (!Libs.AndroidX.Compose.snapshot.isEmpty()) {

--- a/Crane/buildSrc/build.gradle.kts
+++ b/Crane/buildSrc/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.gradle.kotlin.dsl.`kotlin-dsl`
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -29,6 +29,10 @@ object Libs {
         const val mapsKtx = "com.google.maps.android:maps-v3-ktx:2.2.0"
     }
 
+    object Volley {
+        const val volley = "com.android.volley:volley:1.2.0"
+    }
+
     object Accompanist {
         const val version = "0.11.0"
         const val coil = "com.google.accompanist:accompanist-coil:$version"

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -23,7 +23,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -40,7 +39,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     apply plugin: 'com.diffplug.spotless'

--- a/Jetcaster/build.gradle
+++ b/Jetcaster/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -38,7 +37,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
 
         // Jetpack Compose SNAPSHOTs
         if (!Libs.AndroidX.Compose.snapshot.isEmpty()) {

--- a/Jetcaster/buildSrc/build.gradle.kts
+++ b/Jetcaster/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {

--- a/Jetchat/build.gradle
+++ b/Jetchat/build.gradle
@@ -23,7 +23,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -40,7 +39,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
 
         if (!Libs.AndroidX.Compose.snapshot.isEmpty()) {
             maven { url Urls.composeSnapshotRepo }

--- a/Jetsnack/build.gradle
+++ b/Jetsnack/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath Libs.androidGradlePlugin
@@ -37,7 +36,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
 
         if (!Libs.AndroidX.Compose.snapshot.isEmpty()) {
             maven { url "https://androidx.dev/snapshots/builds/${Libs.AndroidX.Compose.snapshot}/artifacts/repository/" }

--- a/Jetsnack/buildSrc/build.gradle.kts
+++ b/Jetsnack/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {

--- a/Jetsurvey/build.gradle
+++ b/Jetsurvey/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath Libs.androidGradlePlugin
@@ -37,7 +36,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
 
         if (Libs.AndroidX.Compose.version.endsWith('SNAPSHOT')) {
             maven { url Libs.AndroidX.Compose.snapshotUrl }

--- a/Jetsurvey/buildSrc/build.gradle.kts
+++ b/Jetsurvey/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {

--- a/Owl/build.gradle
+++ b/Owl/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath Libs.androidGradlePlugin

--- a/Owl/buildSrc/build.gradle.kts
+++ b/Owl/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {

--- a/Rally/build.gradle
+++ b/Rally/build.gradle
@@ -22,7 +22,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -39,7 +38,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
 
         if (!Libs.AndroidX.Compose.snapshot.isEmpty()) {
             maven { url Urls.composeSnapshotRepo }

--- a/Rally/buildSrc/build.gradle.kts
+++ b/Rally/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {


### PR DESCRIPTION
Jcenter is now read only and no longer needed. 

Added maven central where needed.
Use Volley 1.2.0 which is available on maven.google.com (required as a dep of the Maps SDK)