### PR TITLE
[Jetsnack] Avoid mutating colors parameter

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt
@@ -234,6 +234,37 @@ class JetsnackColors(
         notificationBadge = other.notificationBadge
         isDark = other.isDark
     }
+
+    fun copy(): JetsnackColors = JetsnackColors(
+        gradient6_1 = gradient6_1,
+        gradient6_2 = gradient6_2,
+        gradient3_1 = gradient3_1,
+        gradient3_2 = gradient3_2,
+        gradient2_1 = gradient2_1,
+        gradient2_2 = gradient2_2,
+        gradient2_3 = gradient2_3,
+        brand = brand,
+        brandSecondary = brandSecondary,
+        uiBackground = uiBackground,
+        uiBorder = uiBorder,
+        uiFloated = uiFloated,
+        interactivePrimary = interactivePrimary,
+        interactiveSecondary = interactiveSecondary,
+        interactiveMask = interactiveMask,
+        textPrimary = textPrimary,
+        textSecondary = textSecondary,
+        textHelp = textHelp,
+        textInteractive = textInteractive,
+        textLink = textLink,
+        tornado1 = tornado1,
+        iconPrimary = iconPrimary,
+        iconSecondary = iconSecondary,
+        iconInteractive = iconInteractive,
+        iconInteractiveInactive = iconInteractiveInactive,
+        error = error,
+        notificationBadge = notificationBadge,
+        isDark = isDark,
+    )
 }
 
 @Composable
@@ -241,7 +272,11 @@ fun ProvideJetsnackColors(
     colors: JetsnackColors,
     content: @Composable () -> Unit
 ) {
-    val colorPalette = remember { colors }
+    val colorPalette = remember {
+        // Explicitly creating a new object here so we don't mutate the initial [colors]
+        // provided, and overwrite the values set in it.
+        colors.copy()
+    }
     colorPalette.update(colors)
     CompositionLocalProvider(LocalJetsnackColors provides colorPalette, content = content)
 }


### PR DESCRIPTION
Adds a `copy` method to `JetsnackColors`, which is used to copy the passed in `colors` when providing `JetsnackColors`.

This avoids `update()` mutating the `colors` passed in as a parameter, which would manifest itself as a bug where switching the system between dark theme and light theme would only work the first time, as `DarkColorPalette` and `LightColorPalette` would overwrite each other. (right now that bug doesn't occur, since `MainActivity` is being recreated upon configuration changes).

This fixes #584, which also has more context.