### PR TITLE
[Jetsnack] Add an example ViewModel to SnackDetail

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetail.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetail.kt
@@ -60,10 +60,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.lerp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.jetsnack.R
 import com.example.jetsnack.model.Snack
 import com.example.jetsnack.model.SnackCollection
-import com.example.jetsnack.model.SnackRepo
 import com.example.jetsnack.ui.components.JetsnackButton
 import com.example.jetsnack.ui.components.JetsnackDivider
 import com.example.jetsnack.ui.components.JetsnackSurface
@@ -74,6 +74,7 @@ import com.example.jetsnack.ui.theme.JetsnackTheme
 import com.example.jetsnack.ui.theme.Neutral8
 import com.example.jetsnack.ui.utils.formatPrice
 import com.example.jetsnack.ui.utils.mirroringBackIcon
+import com.example.jetsnack.ui.utils.viewModelProviderFactoryOf
 import com.google.accompanist.insets.navigationBarsPadding
 import com.google.accompanist.insets.statusBarsPadding
 import kotlin.math.max
@@ -93,10 +94,13 @@ private val HzPadding = Modifier.padding(horizontal = 24.dp)
 @Composable
 fun SnackDetail(
     snackId: Long,
+    viewModel: SnackDetailViewModel = viewModel(
+        factory = viewModelProviderFactoryOf { SnackDetailViewModel(snackId) }
+    ),
     upPress: () -> Unit
 ) {
-    val snack = remember(snackId) { SnackRepo.getSnack(snackId) }
-    val related = remember(snackId) { SnackRepo.getRelated(snackId) }
+    val snack = viewModel.snack
+    val related = viewModel.related
 
     Box(Modifier.fillMaxSize()) {
         val scroll = rememberScrollState(0)
@@ -368,9 +372,12 @@ private fun CartBottomBar(modifier: Modifier = Modifier) {
 @Preview("large font", fontScale = 2f)
 @Composable
 private fun SnackDetailPreview() {
+    // Manually create a view model as the view model factory doesn't work with previews
+    val viewModel = SnackDetailViewModel(snackId = 1L)
     JetsnackTheme {
         SnackDetail(
             snackId = 1L,
+            viewModel = viewModel,
             upPress = { }
         )
     }

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetailViewModel.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetailViewModel.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetsnack.ui.snackdetail
+
+import androidx.lifecycle.ViewModel
+import com.example.jetsnack.model.SnackRepo
+
+/**
+ * This is a basic contrived example of a ViewModel that is scoped to the navigation graph.
+ * When navigating back from the SnackDetail screen this ViewModel would be cleared.
+ *
+ * In a real world app you would probably load the data from the repo and expose it via LiveData or
+ * Flow. For this example we just hold on to it in an immutable variable for simplicity.
+ **/
+class SnackDetailViewModel(
+    snackId: Long
+) : ViewModel() {
+    val snack = SnackRepo.getSnack(snackId)
+    val related = SnackRepo.getRelated(snackId)
+}

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/utils/ViewModel.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/utils/ViewModel.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetsnack.ui.utils
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+/**
+ * Returns a [ViewModelProvider.Factory] which will return the result of [create] when it's
+ * [ViewModelProvider.Factory.create] function is called.
+ *
+ * If the created [ViewModel] does not match the requested class, an [IllegalArgumentException]
+ * exception is thrown.
+ */
+fun <VM : ViewModel> viewModelProviderFactoryOf(
+    create: () -> VM
+): ViewModelProvider.Factory = SimpleFactory(create)
+
+/**
+ * This needs to be a named class currently to workaround a compiler issue: b/163807311
+ */
+private class SimpleFactory<VM : ViewModel>(
+    private val create: () -> VM
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        val vm = create()
+        if (modelClass.isInstance(vm)) {
+            @Suppress("UNCHECKED_CAST")
+            return vm as T
+        }
+        throw IllegalArgumentException("Can not create ViewModel for class: $modelClass")
+    }
+}


### PR DESCRIPTION
Fixes #565 

Implemented a contrived simple ViewModel for the SnackDetail screen. 

It is obviously up to you if you actually want this change merged in, I just did it as part of my learning and thought it might be useful for others. I would also be happy to convert it to using LiveData or StateFlow if that would be a better example but thought I would keep it simple in the first pass.

The ViewModelFactory code was taken straight from Jetcaster in order to be consistent.