### PR TITLE
[JetCaster] improve a11y

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -354,7 +353,8 @@ private fun FollowedPodcastCarouselItem(
             Modifier
                 .weight(1f)
                 .align(Alignment.CenterHorizontally)
-                .aspectRatio(1f)) {
+                .aspectRatio(1f)
+        ) {
             if (podcastImageUrl != null) {
                 Image(
                     painter = rememberImagePainter(data = podcastImageUrl),

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -328,6 +329,7 @@ fun FollowedPodcasts(
         val (podcast, lastEpisodeDate) = items[page]
         FollowedPodcastCarouselItem(
             podcastImageUrl = podcast.imageUrl,
+            podcastTitle = podcast.title,
             lastEpisodeDate = lastEpisodeDate,
             onUnfollowedClick = { onPodcastUnfollowed(podcast.uri) },
             modifier = Modifier
@@ -341,6 +343,7 @@ fun FollowedPodcasts(
 private fun FollowedPodcastCarouselItem(
     modifier: Modifier = Modifier,
     podcastImageUrl: String? = null,
+    podcastTitle: String? = null,
     lastEpisodeDate: OffsetDateTime? = null,
     onUnfollowedClick: () -> Unit,
 ) {
@@ -351,12 +354,11 @@ private fun FollowedPodcastCarouselItem(
             Modifier
                 .weight(1f)
                 .align(Alignment.CenterHorizontally)
-                .aspectRatio(1f)
-        ) {
+                .aspectRatio(1f)) {
             if (podcastImageUrl != null) {
                 Image(
                     painter = rememberImagePainter(data = podcastImageUrl),
-                    contentDescription = null,
+                    contentDescription = podcastTitle,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .fillMaxSize()

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -58,6 +58,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -111,18 +114,11 @@ private fun CategoryPodcasts(
     topPodcasts: List<PodcastWithExtraInfo>,
     viewModel: PodcastCategoryViewModel
 ) {
-    LazyRow(
-        contentPadding = PaddingValues(0.dp),
-        horizontalArrangement = Arrangement.Start
-    ) {
-        item {
-            CategoryPodcastRow(
-                podcasts = topPodcasts,
-                onTogglePodcastFollowed = viewModel::onTogglePodcastFollowed,
-                modifier = Modifier.fillParentMaxWidth()
-            )
-        }
-    }
+    CategoryPodcastRow(
+        podcasts = topPodcasts,
+        onTogglePodcastFollowed = viewModel::onTogglePodcastFollowed,
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable
@@ -236,6 +232,7 @@ fun EpisodeListItem(
                 ) { /* TODO */ }
                 .size(48.dp)
                 .padding(6.dp)
+                .semantics { role = Role.Button }
                 .constrainAs(playIcon) {
                     start.linkTo(parent.start, Keyline1)
                     top.linkTo(titleImageBarrier, margin = 10.dp)
@@ -335,7 +332,8 @@ private fun TopPodcastRowItem(
     onToggleFollowClicked: () -> Unit,
     podcastImageUrl: String? = null,
 ) {
-    Column(modifier) {
+    Column(
+        modifier.semantics(mergeDescendants = true){}) {
         Box(
             Modifier
                 .fillMaxWidth()

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -333,7 +333,8 @@ private fun TopPodcastRowItem(
     podcastImageUrl: String? = null,
 ) {
     Column(
-        modifier.semantics(mergeDescendants = true){}) {
+        modifier.semantics(mergeDescendants = true) {}
+    ) {
         Box(
             Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
fix : fixing the fact that we were no able to move from CategoryPodcast to EpisodeList with Talkback by removing unnecessary (?!) LazyRow

feat: merge podcast category image with podcast title, this way also podcast title is read before moving to the "follow button".

feat : improve UX by setting Button semantic role to play image button