### PR TITLE
[JetChat] Improve screen-reader behavior

### DIFF
--- a/Jetchat/app/src/androidTest/java/com/example/compose/jetchat/ConversationTest.kt
+++ b/Jetchat/app/src/androidTest/java/com/example/compose/jetchat/ConversationTest.kt
@@ -61,8 +61,7 @@ class ConversationTest {
                 JetchatTheme(isDarkTheme = themeIsDark.collectAsState(false).value) {
                     ConversationContent(
                         uiState = conversationTestUiState,
-                        navigateToProfile = { },
-                        onNavIconPressed = { }
+                        navigateToProfile = { }
                     )
                 }
             }

--- a/Jetchat/app/src/androidTest/java/com/example/compose/jetchat/UserInputTest.kt
+++ b/Jetchat/app/src/androidTest/java/com/example/compose/jetchat/UserInputTest.kt
@@ -65,8 +65,7 @@ class UserInputTest {
                 JetchatTheme {
                     ConversationContent(
                         uiState = exampleUiState,
-                        navigateToProfile = { },
-                        onNavIconPressed = { }
+                        navigateToProfile = { }
                     )
                 }
             }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/MainViewModel.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/MainViewModel.kt
@@ -16,7 +16,15 @@
 
 package com.example.compose.jetchat
 
+import androidx.compose.material.DrawerState
+import androidx.compose.material.DrawerValue
+import androidx.compose.material.ScaffoldState
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -24,14 +32,5 @@ import kotlinx.coroutines.flow.StateFlow
  * Used to communicate between screens.
  */
 class MainViewModel : ViewModel() {
-
-    private val _drawerShouldBeOpened = MutableStateFlow(false)
-    val drawerShouldBeOpened: StateFlow<Boolean> = _drawerShouldBeOpened
-
-    fun openDrawer() {
-        _drawerShouldBeOpened.value = true
-    }
-    fun resetOpenDrawerAction() {
-        _drawerShouldBeOpened.value = false
-    }
+    val drawerState by mutableStateOf(DrawerState(DrawerValue.Closed))
 }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
@@ -31,7 +31,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
-import com.example.compose.jetchat.components.JetchatScaffold
+import com.example.compose.jetchat.components.DrawerScaffold
 import com.example.compose.jetchat.conversation.BackPressHandler
 import com.example.compose.jetchat.conversation.LocalBackPressedDispatcher
 import com.example.compose.jetchat.databinding.ContentMainBinding
@@ -58,16 +58,7 @@ class NavActivity : AppCompatActivity() {
                 CompositionLocalProvider(
                     LocalBackPressedDispatcher provides this.onBackPressedDispatcher
                 ) {
-                    val scaffoldState = rememberScaffoldState()
-
-                    val drawerOpen by viewModel.drawerShouldBeOpened.collectAsState()
-                    if (drawerOpen) {
-                        // Open drawer and reset state in VM.
-                        LaunchedEffect(Unit) {
-                            scaffoldState.drawerState.open()
-                            viewModel.resetOpenDrawerAction()
-                        }
-                    }
+                    val scaffoldState = rememberScaffoldState(drawerState = viewModel.drawerState)
 
                     // Intercepts back navigation when the drawer is open
                     val scope = rememberCoroutineScope()
@@ -79,21 +70,9 @@ class NavActivity : AppCompatActivity() {
                         }
                     }
 
-                    JetchatScaffold(
+                    DrawerScaffold(
                         scaffoldState,
-                        onChatClicked = {
-                            findNavController().popBackStack(R.id.nav_home, true)
-                            scope.launch {
-                                scaffoldState.drawerState.close()
-                            }
-                        },
-                        onProfileClicked = {
-                            val bundle = bundleOf("userId" to it)
-                            findNavController().navigate(R.id.nav_profile, bundle)
-                            scope.launch {
-                                scaffoldState.drawerState.close()
-                            }
-                        }
+                        ::findNavController
                     ) {
                         AndroidViewBinding(ContentMainBinding::inflate)
                     }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
@@ -16,16 +16,70 @@
 
 package com.example.compose.jetchat.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.DrawerState
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.Scaffold
 import androidx.compose.material.ScaffoldState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
+import androidx.navigation.NavController
+import com.example.compose.jetchat.FunctionalityNotAvailablePopup
+import com.example.compose.jetchat.R
+import com.example.compose.jetchat.conversation.ChannelNameBar
+import com.example.compose.jetchat.data.exampleUiState
 import com.example.compose.jetchat.theme.JetchatTheme
+import com.google.accompanist.insets.statusBarsPadding
+import kotlinx.coroutines.launch
+
 
 @Composable
-fun JetchatScaffold(
-    scaffoldState: ScaffoldState = rememberScaffoldState(),
+fun DrawerScaffold(
+    scaffoldState: ScaffoldState,
+    findNavController: () -> NavController,
+    content: @Composable (PaddingValues) -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    DrawerScaffold(
+        scaffoldState,
+        onChatClicked = {
+            findNavController().popBackStack(R.id.nav_home, true)
+            scope.launch {
+                scaffoldState.drawerState.close()
+            }
+        },
+        onProfileClicked = {
+            val bundle = bundleOf("userId" to it)
+            findNavController().navigate(R.id.nav_profile, bundle)
+            scope.launch {
+                scaffoldState.drawerState.close()
+            }
+        },
+        content = content
+    )
+}
+
+@Composable
+private fun DrawerScaffold(
+    scaffoldState: ScaffoldState,
     onProfileClicked: (String) -> Unit,
     onChatClicked: (String) -> Unit,
     content: @Composable (PaddingValues) -> Unit
@@ -40,6 +94,73 @@ fun JetchatScaffold(
                 )
             },
             content = content
+        )
+    }
+}
+
+@Composable
+fun TopBarScaffold(
+    scaffoldState: ScaffoldState = rememberScaffoldState(),
+    drawerState: DrawerState,
+    complexTopBar: Boolean,
+    content: @Composable (PaddingValues) -> Unit
+) {
+    var functionalityNotAvailablePopupShown by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val onNavIconClicked: () -> Unit = {
+        scope.launch {
+            drawerState.open()
+        }
+    }
+
+    JetchatTheme {
+        Scaffold(
+            scaffoldState = scaffoldState,
+            topBar = {
+                if (complexTopBar) {
+                    ChannelNameBar(
+                        channelName = exampleUiState.channelName,
+                        channelMembers = exampleUiState.channelMembers,
+                        onNavIconPressed = onNavIconClicked,
+                        // Use statusBarsPadding() to move the app bar content below the status bar
+                        modifier = Modifier.statusBarsPadding(),
+                    )
+                } else {
+                    JetchatAppBar(
+                        // Use statusBarsPadding() to move the app bar content below the status bar
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .statusBarsPadding(),
+                        onNavIconPressed = onNavIconClicked,
+                        title = { },
+                        actions = {
+                            CompositionLocalProvider(
+                                LocalContentAlpha provides ContentAlpha.medium
+                            ) {
+                                // More icon
+                                Icon(
+                                    imageVector = Icons.Outlined.MoreVert,
+                                    modifier = Modifier
+                                        .clickable(
+                                            onClick = {
+                                                functionalityNotAvailablePopupShown = true
+                                            }
+                                        )
+                                        .padding(horizontal = 12.dp, vertical = 16.dp)
+                                        .height(24.dp),
+                                    contentDescription = stringResource(id = R.string.more_options)
+                                )
+                            }
+                        }
+                    )
+                }
+            },
+            content = {
+                if (functionalityNotAvailablePopupShown) {
+                    FunctionalityNotAvailablePopup { functionalityNotAvailablePopupShown = false }
+                }
+                content(it)
+            }
         )
     }
 }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
@@ -79,23 +79,21 @@ import com.example.compose.jetchat.theme.elevatedSurface
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.navigationBarsWithImePadding
 import com.google.accompanist.insets.rememberInsetsPaddingValues
-import com.google.accompanist.insets.statusBarsPadding
 import kotlinx.coroutines.launch
 
 /**
  * Entry point for a conversation screen.
  *
  * @param uiState [ConversationUiState] that contains messages to display
- * @param navigateToProfile User action when navigation to a profile is requested
  * @param modifier [Modifier] to apply to this layout node
+ * @param navigateToProfile User action when navigation to a profile is requested
  * @param onNavIconPressed Sends an event up when the user clicks on the menu
  */
 @Composable
 fun ConversationContent(
     uiState: ConversationUiState,
-    navigateToProfile: (String) -> Unit,
     modifier: Modifier = Modifier,
-    onNavIconPressed: () -> Unit = { }
+    navigateToProfile: (String) -> Unit
 ) {
     val authorMe = stringResource(R.string.author_me)
     val timeNow = stringResource(id = R.string.now)
@@ -104,37 +102,27 @@ fun ConversationContent(
     val scope = rememberCoroutineScope()
 
     Surface(modifier = modifier) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Column(Modifier.fillMaxSize()) {
-                Messages(
-                    messages = uiState.messages,
-                    navigateToProfile = navigateToProfile,
-                    modifier = Modifier.weight(1f),
-                    scrollState = scrollState
-                )
-                UserInput(
-                    onMessageSent = { content ->
-                        uiState.addMessage(
-                            Message(authorMe, content, timeNow)
-                        )
-                    },
-                    resetScroll = {
-                        scope.launch {
-                            scrollState.scrollToItem(0)
-                        }
-                    },
-                    // Use navigationBarsWithImePadding(), to move the input panel above both the
-                    // navigation bar, and on-screen keyboard (IME)
-                    modifier = Modifier.navigationBarsWithImePadding(),
-                )
-            }
-            // Channel name bar floats above the messages
-            ChannelNameBar(
-                channelName = uiState.channelName,
-                channelMembers = uiState.channelMembers,
-                onNavIconPressed = onNavIconPressed,
-                // Use statusBarsPadding() to move the app bar content below the status bar
-                modifier = Modifier.statusBarsPadding(),
+        Column(Modifier.fillMaxSize()) {
+            Messages(
+                messages = uiState.messages,
+                navigateToProfile = navigateToProfile,
+                modifier = Modifier.weight(1f),
+                scrollState = scrollState
+            )
+            UserInput(
+                onMessageSent = { content ->
+                    uiState.addMessage(
+                        Message(authorMe, content, timeNow)
+                    )
+                },
+                resetScroll = {
+                    scope.launch {
+                        scrollState.scrollToItem(0)
+                    }
+                },
+                // Use navigationBarsWithImePadding(), to move the input panel above both the
+                // navigation bar, and on-screen keyboard (IME)
+                modifier = Modifier.navigationBarsWithImePadding(),
             )
         }
     }
@@ -311,7 +299,7 @@ fun Message(
                     .align(Alignment.Top),
                 painter = painterResource(id = msg.authorImage),
                 contentScale = ContentScale.Crop,
-                contentDescription = null,
+                contentDescription = "Navigate to profile page",
             )
         } else {
             // Space under avatar

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/ConversationFragment.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/ConversationFragment.kt
@@ -23,6 +23,7 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
@@ -31,6 +32,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.findNavController
 import com.example.compose.jetchat.MainViewModel
 import com.example.compose.jetchat.R
+import com.example.compose.jetchat.components.TopBarScaffold
 import com.example.compose.jetchat.data.exampleUiState
 import com.example.compose.jetchat.theme.JetchatTheme
 import com.google.accompanist.insets.ExperimentalAnimatedInsets
@@ -60,28 +62,30 @@ class ConversationFragment : Fragment() {
             .start(windowInsetsAnimationsEnabled = true)
 
         setContent {
-            CompositionLocalProvider(
-                LocalBackPressedDispatcher provides requireActivity().onBackPressedDispatcher,
-                LocalWindowInsets provides windowInsets,
+            TopBarScaffold(
+                drawerState = activityViewModel.drawerState,
+                complexTopBar = false,
             ) {
-                JetchatTheme {
-                    ConversationContent(
-                        uiState = exampleUiState,
-                        navigateToProfile = { user ->
-                            // Click callback
-                            val bundle = bundleOf("userId" to user)
-                            findNavController().navigate(
-                                R.id.nav_profile,
-                                bundle
-                            )
-                        },
-                        onNavIconPressed = {
-                            activityViewModel.openDrawer()
-                        },
-                        // Add padding so that we are inset from any left/right navigation bars
-                        // (usually shown when in landscape orientation)
-                        modifier = Modifier.navigationBarsPadding(bottom = false)
-                    )
+                CompositionLocalProvider(
+                    LocalBackPressedDispatcher provides requireActivity().onBackPressedDispatcher,
+                    LocalWindowInsets provides windowInsets,
+                ) {
+                    JetchatTheme {
+                        ConversationContent(
+                            uiState = exampleUiState,
+                            navigateToProfile = { user ->
+                                // Click callback
+                                val bundle = bundleOf("userId" to user)
+                                findNavController().navigate(
+                                    R.id.nav_profile,
+                                    bundle
+                                )
+                            },
+                            // Add padding so that we are inset from any left/right navigation bars
+                            // (usually shown when in landscape orientation)
+                            modifier = Modifier.navigationBarsPadding(bottom = false)
+                        )
+                    }
                 }
             }
         }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
@@ -395,45 +395,51 @@ private fun UserInputText(
         horizontalArrangement = Arrangement.End
     ) {
         Surface {
-            Box(
+            var lastFocusState by remember { mutableStateOf(false) }
+            BasicTextField(
+                value = textFieldValue,
+                onValueChange = { onTextChanged(it) },
                 modifier = Modifier
-                    .height(48.dp)
-                    .weight(1f)
-                    .align(Alignment.Bottom)
-            ) {
-                var lastFocusState by remember { mutableStateOf(false) }
-                BasicTextField(
-                    value = textFieldValue,
-                    onValueChange = { onTextChanged(it) },
+                    .onFocusChanged { state ->
+                        if (lastFocusState != state.isFocused) {
+                            onTextFieldFocused(state.isFocused)
+                        }
+                        lastFocusState = state.isFocused
+                    },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = keyboardType,
+                    imeAction = ImeAction.Send
+                ),
+                maxLines = 1,
+                cursorBrush = SolidColor(LocalContentColor.current),
+                textStyle = LocalTextStyle.current.copy(color = LocalContentColor.current)
+            ) { innerTextField ->
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 16.dp)
-                        .align(Alignment.CenterStart)
-                        .onFocusChanged { state ->
-                            if (lastFocusState != state.isFocused) {
-                                onTextFieldFocused(state.isFocused)
-                            }
-                            lastFocusState = state.isFocused
-                        },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = keyboardType,
-                        imeAction = ImeAction.Send
-                    ),
-                    maxLines = 1,
-                    cursorBrush = SolidColor(LocalContentColor.current),
-                    textStyle = LocalTextStyle.current.copy(color = LocalContentColor.current)
-                )
-
-                val disableContentColor =
-                    MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.disabled)
-                if (textFieldValue.text.isEmpty() && !focusState) {
-                    Text(
-                        modifier = Modifier
+                        .height(48.dp)
+                        .weight(1f)
+                        .align(Alignment.Bottom)
+                ) {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(start = 16.dp)
                             .align(Alignment.CenterStart)
-                            .padding(start = 16.dp),
-                        text = stringResource(id = R.string.textfield_hint),
-                        style = MaterialTheme.typography.body1.copy(color = disableContentColor)
-                    )
+                    ) {
+                        innerTextField()
+                    }
+
+                    val disableContentColor =
+                        MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.disabled)
+                    if (textFieldValue.text.isEmpty() && !focusState) {
+                        Text(
+                            modifier = Modifier
+                                .align(Alignment.CenterStart)
+                                .padding(start = 16.dp),
+                            text = stringResource(id = R.string.textfield_hint),
+                            style = MaterialTheme.typography.body1.copy(color = disableContentColor)
+                        )
+                    }
                 }
             }
         }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
@@ -18,7 +18,6 @@ package com.example.compose.jetchat.profile
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -41,7 +40,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Chat
 import androidx.compose.material.icons.outlined.Create
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -61,18 +59,15 @@ import androidx.compose.ui.unit.dp
 import com.example.compose.jetchat.FunctionalityNotAvailablePopup
 import com.example.compose.jetchat.R
 import com.example.compose.jetchat.components.AnimatingFabContent
-import com.example.compose.jetchat.components.JetchatAppBar
 import com.example.compose.jetchat.components.baselineHeight
 import com.example.compose.jetchat.data.colleagueProfile
 import com.example.compose.jetchat.data.meProfile
 import com.example.compose.jetchat.theme.JetchatTheme
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.insets.navigationBarsPadding
-import com.google.accompanist.insets.statusBarsPadding
 
 @Composable
 fun ProfileScreen(userData: ProfileScreenState, onNavIconPressed: () -> Unit = { }) {
-
     var functionalityNotAvailablePopupShown by remember { mutableStateOf(false) }
     if (functionalityNotAvailablePopupShown) {
         FunctionalityNotAvailablePopup { functionalityNotAvailablePopupShown = false }
@@ -81,27 +76,6 @@ fun ProfileScreen(userData: ProfileScreenState, onNavIconPressed: () -> Unit = {
     val scrollState = rememberScrollState()
 
     Column(modifier = Modifier.fillMaxSize()) {
-        JetchatAppBar(
-            // Use statusBarsPadding() to move the app bar content below the status bar
-            modifier = Modifier
-                .fillMaxWidth()
-                .statusBarsPadding(),
-            onNavIconPressed = onNavIconPressed,
-            title = { },
-            actions = {
-                CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                    // More icon
-                    Icon(
-                        imageVector = Icons.Outlined.MoreVert,
-                        modifier = Modifier
-                            .clickable(onClick = { functionalityNotAvailablePopupShown = true })
-                            .padding(horizontal = 12.dp, vertical = 16.dp)
-                            .height(24.dp),
-                        contentDescription = stringResource(id = R.string.more_options)
-                    )
-                }
-            }
-        )
         BoxWithConstraints(modifier = Modifier.weight(1f)) {
             Surface {
                 Column(

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/ProfileFragment.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/ProfileFragment.kt
@@ -22,13 +22,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.navigation.findNavController
 import com.example.compose.jetchat.MainViewModel
+import com.example.compose.jetchat.components.TopBarScaffold
 import com.example.compose.jetchat.theme.JetchatTheme
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.ViewWindowInsetObserver
@@ -61,19 +64,21 @@ class ProfileFragment : Fragment() {
         val windowInsets = ViewWindowInsetObserver(this).start()
 
         setContent {
-            val userData by viewModel.userData.observeAsState()
+            TopBarScaffold(
+                drawerState = activityViewModel.drawerState,
+                complexTopBar = false,
+            ) {
+                val userData by viewModel.userData.observeAsState()
 
-            CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
-                JetchatTheme {
-                    if (userData == null) {
-                        ProfileError()
-                    } else {
-                        ProfileScreen(
-                            userData = userData!!,
-                            onNavIconPressed = {
-                                activityViewModel.openDrawer()
-                            }
-                        )
+                CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
+                    JetchatTheme {
+                        if (userData == null) {
+                            ProfileError()
+                        } else {
+                            ProfileScreen(
+                                userData = userData!!
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
1) Refactor top app bars into the topAppBar parameter of a nested Scaffold.
   This correctly clips accessibility focus rects that overlap with the top
   of the screen.

2) Refactor the text field's padding and placeholder text into the
   decorationBox parameter of BasicTextField.  This merges the text
   field into a single, correctly-sized a11y-focusable element.

3) Add contentDescription to the profile icons.