### PR TITLE
[JetNews] Fix state saving with drawer

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -17,16 +17,16 @@
 package com.example.jetnews.ui
 
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.padding
+import androidx.compose.material.DrawerState
+import androidx.compose.material.DrawerValue
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material.ModalDrawer
+import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -54,42 +54,51 @@ fun JetnewsApp(
             val navigationActions = remember(navController) { JetnewsNavigationActions(navController) }
 
             val coroutineScope = rememberCoroutineScope()
-            // This top level scaffold contains the app drawer, which needs to be accessible
+            // This top level composable contains the app drawer, which needs to be accessible
             // from multiple screens. An event to open the drawer is passed down to each
             // screen that needs it.
-            val scaffoldState = rememberScaffoldState()
+            val drawerState = rememberDrawerState(DrawerValue.Closed)
 
             val navBackStackEntry by navController.currentBackStackEntryAsState()
             val currentRoute = navBackStackEntry?.destination?.route ?: JetnewsDestinations.HOME_ROUTE
 
             BoxWithConstraints {
                 val windowSize = getWindowSize(maxWidth)
-                Scaffold(
-                    scaffoldState = scaffoldState,
-                    // If the window size is Compact, show the AppDrawer.
-                    // Otherwise, a NavRail will be shown in individual screens
-                    drawerContent = if (windowSize == WindowSize.Compact) {
-                        {
-                            AppDrawer(
-                                currentRoute = currentRoute,
-                                navigateToHome = navigationActions.navigateToHome,
-                                navigateToInterests = navigationActions.navigateToInterests,
-                                closeDrawer = {
-                                    coroutineScope.launch { scaffoldState.drawerState.close() }
-                                }
-                            )
-                        }
-                    } else {
-                        null
-                    }
-                ) { innerPaddingModifier ->
+
+                val allowDrawerToBeShown = windowSize == WindowSize.Compact
+
+                // Determine the drawer state to pass to the modal drawer.
+                val sizeAwareDrawerState = if (allowDrawerToBeShown) {
+                    // If we want to allow showing the drawer, we use the real, remembered drawer
+                    // state defined above
+                    drawerState
+                } else {
+                    // If we don't want to allow the drawer to be shown, we provide a drawer state
+                    // that is locked closed. This is intentionally not remembered, because we
+                    // don't want to keep track of any changes and always keep it closed
+                    DrawerState(DrawerValue.Closed)
+                }
+
+                ModalDrawer(
+                    drawerContent = {
+                        AppDrawer(
+                            currentRoute = currentRoute,
+                            navigateToHome = navigationActions.navigateToHome,
+                            navigateToInterests = navigationActions.navigateToInterests,
+                            closeDrawer = { coroutineScope.launch { drawerState.close() } }
+                        )
+                    },
+                    drawerState = sizeAwareDrawerState,
+                    // Only enable opening the drawer via gestures if we allow showing it
+                    gesturesEnabled = allowDrawerToBeShown
+                ) {
                     JetnewsNavGraph(
                         appContainer = appContainer,
-                        showNavRail = windowSize != WindowSize.Compact,
+                        // Either allow showing the drawer, or show the nav rail
+                        showNavRail = !allowDrawerToBeShown,
                         navController = navController,
-                        scaffoldState = scaffoldState,
+                        openDrawer = { coroutineScope.launch { drawerState.open() } },
                         navigationActions = navigationActions,
-                        modifier = Modifier.padding(innerPaddingModifier)
                     )
                 }
             }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavGraph.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavGraph.kt
@@ -16,10 +16,7 @@
 
 package com.example.jetnews.ui
 
-import androidx.compose.material.ScaffoldState
-import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
@@ -31,7 +28,6 @@ import com.example.jetnews.ui.home.HomeRoute
 import com.example.jetnews.ui.home.HomeViewModel
 import com.example.jetnews.ui.interests.InterestsRoute
 import com.example.jetnews.ui.interests.InterestsViewModel
-import kotlinx.coroutines.launch
 
 @Composable
 fun JetnewsNavGraph(
@@ -40,12 +36,9 @@ fun JetnewsNavGraph(
     navigationActions: JetnewsNavigationActions,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
-    scaffoldState: ScaffoldState = rememberScaffoldState(),
+    openDrawer: () -> Unit = {},
     startDestination: String = JetnewsDestinations.HOME_ROUTE
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val openDrawer: () -> Unit = { coroutineScope.launch { scaffoldState.drawerState.open() } }
-
     NavHost(
         navController = navController,
         startDestination = startDestination,


### PR DESCRIPTION
Fixes the state saving (via `rememberSaveable`) throughout the app.

Per the design, we conditionally want to allow the drawer to be shown based on the size of the screen. With the current approach we conditionally passed `null` or the drawer content to a top-level `Scaffold`, which would then allow the drawer to be hidden or shown. If we don't want the drawer to be shown, we instead show the nav rail.

This approach has a subtle problem due to the [implementation of `Scaffold`](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material/material/src/commonMain/kotlin/androidx/compose/material/Scaffold.kt;l=194;drc=0868ad90686faea3d86e395fb3758e8a1bbbeaac): when we switch the drawer content between `null` and non-null, we are changing the location of where the content lambda (containing everything else in the app) is called.

This changes all of the keys that `rememberSaveable` automatically uses, which is seen as scroll positions not being saved when switching between orientations that allow or disallow showing the drawer.

To workaround this, I replaced the top-level `Scaffold` with a `ModalDrawer` (since that was the only functionality we were using via the top-level `Scaffold` directly anyway). Crucially, this `ModalDrawer` is always called, even if we don't want to allow showing the drawer. This allows calling the content for the rest of the app in exactly one source location. To avoid showing the drawer when we want to show the nav rail instead, we switch between a real, remembered `DrawerState` and a fixed-to-closed drawer state.

