### PR TITLE
[JetNews] Convert navrail/drawer decision to use currentWindowMetrics

### DIFF
--- a/JetNews/app/build.gradle
+++ b/JetNews/app/build.gradle
@@ -117,6 +117,8 @@ dependencies {
 
     implementation 'androidx.navigation:navigation-compose:2.4.0-alpha07'
 
+    implementation "androidx.window:window:1.0.0-beta02"
+
     androidTestImplementation 'androidx.test:core:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -16,9 +16,6 @@
 
 package com.example.jetnews.ui
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import androidx.compose.material.DrawerState
 import androidx.compose.material.DrawerValue
 import androidx.compose.material.MaterialTheme
@@ -26,24 +23,16 @@ import androidx.compose.material.ModalDrawer
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
-import androidx.window.layout.WindowMetrics
-import androidx.window.layout.WindowMetricsCalculator
 import com.example.jetnews.data.AppContainer
 import com.example.jetnews.ui.theme.JetnewsTheme
 import com.example.jetnews.utils.WindowSize
-import com.example.jetnews.utils.getWindowSize
+import com.example.jetnews.utils.rememberWindowSizeState
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlinx.coroutines.launch
@@ -100,48 +89,6 @@ fun JetnewsApp(
         }
     }
 }
-
-/**
- * Returns the [WindowMetrics] corresponding to the current activities
- * [WindowInfoRepository.currentWindowMetrics] as [State].
- */
-@Composable
-private fun rememberCurrentWindowMetrics(): State<WindowMetrics> {
-    val activity = LocalContext.current.findActivity()
-    val currentWindowMetricsFlow = remember(activity) {
-        activity.windowInfoRepository().currentWindowMetrics
-    }
-    return currentWindowMetricsFlow.collectAsState(
-        WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity)
-    )
-}
-
-/**
- * Remembers the [WindowSize] corresponding to the current window metrics.
- */
-@Composable
-private fun rememberWindowSizeState(): WindowSize {
-    val windowMetrics by rememberCurrentWindowMetrics()
-    val density = LocalDensity.current
-
-    return remember(windowMetrics, density) {
-        with(density) {
-            getWindowSize(windowMetrics.bounds.width().toDp())
-        }
-    }
-}
-
-/**
- * Find the closest Activity in a given Context.
- */
-private tailrec fun Context.findActivity(): Activity =
-    when (this) {
-        is Activity -> this
-        is ContextWrapper -> baseContext.findActivity()
-        else -> throw IllegalStateException(
-            "findActivity should be called in the context of an Activity"
-        )
-    }
 
 /**
  * Determine the drawer state to pass to the modal drawer.

--- a/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
@@ -16,7 +16,21 @@
 
 package com.example.jetnews.utils
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.window.layout.WindowInfoRepository
+import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowMetrics
+import androidx.window.layout.WindowMetricsCalculator
 
 /**
  * Opinionated set of viewport breakpoints
@@ -34,3 +48,45 @@ fun getWindowSize(width: Dp): WindowSize = when {
     width.value <= 800f -> WindowSize.Medium
     else -> WindowSize.Expanded
 }
+
+/**
+ * Remembers the [WindowSize] corresponding to the current window metrics.
+ */
+@Composable
+fun rememberWindowSizeState(): WindowSize {
+    val windowMetrics by rememberCurrentWindowMetrics()
+    val density = LocalDensity.current
+
+    return remember(windowMetrics, density) {
+        with(density) {
+            getWindowSize(windowMetrics.bounds.width().toDp())
+        }
+    }
+}
+
+/**
+ * Returns the [WindowMetrics] corresponding to the current activities
+ * [WindowInfoRepository.currentWindowMetrics] as [State].
+ */
+@Composable
+private fun rememberCurrentWindowMetrics(): State<WindowMetrics> {
+    val activity = LocalContext.current.findActivity()
+    val currentWindowMetricsFlow = remember(activity) {
+        activity.windowInfoRepository().currentWindowMetrics
+    }
+    return currentWindowMetricsFlow.collectAsState(
+        WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity)
+    )
+}
+
+/**
+ * Find the closest Activity in a given Context.
+ */
+private tailrec fun Context.findActivity(): Activity =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> throw IllegalStateException(
+            "findActivity should be called in the context of an Activity"
+        )
+    }


### PR DESCRIPTION
Converts the decision on whether to use the navrail or the drawer to use the current window metrics, as opposed to a top-level `BoxWithConstraints`.

There are three other places where we are currently calling `getWindowSize`:
- Deciding between which home screens to use
- Deciding what interests tab layout to use
- Deciding what interests to use

This PR doesn't change any of those places, but we may want to adjust some (or all) of them to use the current window metrics instead of nested `BoxWithConstraints`.

We also could pass down the window size class manually, or have each of those places individually call `rememberWindowSizeState()`.