### PR TITLE
[JetNews] Adjust medium behavior

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -107,8 +107,8 @@ fun JetnewsApp(
                     }
                     JetnewsNavGraph(
                         appContainer = appContainer,
-                        // Either allow showing the drawer, or show the nav rail
-                        showTopAppBar = !showNavRail,
+                        windowSize = windowSize,
+                        isDrawerActive = isDrawerActive,
                         navController = navController,
                         openDrawer = { coroutineScope.launch { sizeAwareDrawerState.open() } },
                     )

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavGraph.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavGraph.kt
@@ -28,11 +28,13 @@ import com.example.jetnews.ui.home.HomeRoute
 import com.example.jetnews.ui.home.HomeViewModel
 import com.example.jetnews.ui.interests.InterestsRoute
 import com.example.jetnews.ui.interests.InterestsViewModel
+import com.example.jetnews.utils.WindowSize
 
 @Composable
 fun JetnewsNavGraph(
     appContainer: AppContainer,
-    showTopAppBar: Boolean,
+    windowSize: WindowSize,
+    isDrawerActive: Boolean,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
     openDrawer: () -> Unit = {},
@@ -49,7 +51,8 @@ fun JetnewsNavGraph(
             )
             HomeRoute(
                 homeViewModel = homeViewModel,
-                showTopAppBar = showTopAppBar,
+                windowSize = windowSize,
+                isDrawerActive = isDrawerActive,
                 openDrawer = openDrawer
             )
         }
@@ -59,7 +62,7 @@ fun JetnewsNavGraph(
             )
             InterestsRoute(
                 interestsViewModel = interestsViewModel,
-                showNavigationIcon = showTopAppBar,
+                windowSize = windowSize,
                 openDrawer = openDrawer
             )
         }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavGraph.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavGraph.kt
@@ -63,6 +63,7 @@ fun JetnewsNavGraph(
             InterestsRoute(
                 interestsViewModel = interestsViewModel,
                 windowSize = windowSize,
+                isDrawerActive = isDrawerActive,
                 openDrawer = openDrawer
             )
         }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
@@ -76,7 +76,7 @@ import kotlinx.coroutines.runBlocking
  * Stateless Article Screen that displays a single post adapting the UI to different screen sizes.
  *
  * @param post (state) item to display
- * @param showNavRail (state) whether the Drawer or NavigationRail needs to be shown
+ * @param isDrawerActive (state) if the drawer is active
  * @param onBack (event) request navigate back
  * @param isFavorite (state) is this item currently a favorite
  * @param onToggleFavorite (event) request that this post toggle it's favorite state
@@ -101,7 +101,7 @@ fun ArticleScreen(
         val context = LocalContext.current
         ArticleScreenContent(
             post = post,
-            // Allow opening the Drawer if the NavRail is not on the screen
+            // Allow opening the Drawer if the drawer is active
             navigationIconContent = if (isDrawerActive) {
                 {
                     IconButton(onClick = onBack) {
@@ -115,7 +115,7 @@ fun ArticleScreen(
             } else {
                 null
             },
-            // Show the bottom bar if the NavRail is not on the screen
+            // Show the bottom bar if the drawer is active
             bottomBarContent = if (isDrawerActive) {
                 {
                     BottomBar(
@@ -188,40 +188,6 @@ private fun ArticleScreenContent(
                 .padding(innerPadding),
             state = lazyListState,
         )
-    }
-}
-
-/**
- * Bottom bar for Article screen
- *
- * @param onUnimplementedAction (event) called when the user performs an unimplemented action
- * @param isFavorite (state) if this post is currently a favorite
- * @param onToggleFavorite (event) request this post toggle it's favorite status
- * @param onSharePost (event) request this post to be shared
- */
-@Composable
-private fun ArticleNavRail(
-    onBack: () -> Unit,
-    onUnimplementedAction: () -> Unit,
-    isFavorite: Boolean,
-    onToggleFavorite: () -> Unit,
-    onSharePost: () -> Unit
-) {
-    JetnewsNavRail(
-        header = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    imageVector = Icons.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.cd_navigate_up),
-                    tint = MaterialTheme.colors.primary
-                )
-            }
-        }
-    ) {
-        FavoriteButton(onClick = onUnimplementedAction)
-        BookmarkButton(isBookmarked = isFavorite, onClick = onToggleFavorite)
-        ShareButton(onClick = onSharePost)
-        TextSettingsButton(onClick = onUnimplementedAction)
     }
 }
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
@@ -85,7 +85,7 @@ import kotlinx.coroutines.runBlocking
 @Composable
 fun ArticleScreen(
     post: Post,
-    showNavRail: Boolean,
+    isDrawerActive: Boolean,
     onBack: () -> Unit,
     isFavorite: Boolean,
     onToggleFavorite: () -> Unit,
@@ -99,19 +99,10 @@ fun ArticleScreen(
 
     Row(modifier.fillMaxSize()) {
         val context = LocalContext.current
-        if (showNavRail) {
-            ArticleNavRail(
-                onBack = onBack,
-                onUnimplementedAction = { showUnimplementedActionDialog = true },
-                isFavorite = isFavorite,
-                onToggleFavorite = onToggleFavorite,
-                onSharePost = { sharePost(post, context) }
-            )
-        }
         ArticleScreenContent(
             post = post,
             // Allow opening the Drawer if the NavRail is not on the screen
-            navigationIconContent = if (!showNavRail) {
+            navigationIconContent = if (isDrawerActive) {
                 {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -125,7 +116,7 @@ fun ArticleScreen(
                 null
             },
             // Show the bottom bar if the NavRail is not on the screen
-            bottomBarContent = if (!showNavRail) {
+            bottomBarContent = if (isDrawerActive) {
                 {
                     BottomBar(
                         onUnimplementedAction = { showUnimplementedActionDialog = true },

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
@@ -62,7 +62,6 @@ import com.example.jetnews.data.Result
 import com.example.jetnews.data.posts.impl.BlockingFakePostsRepository
 import com.example.jetnews.data.posts.impl.post3
 import com.example.jetnews.model.Post
-import com.example.jetnews.ui.components.JetnewsNavRail
 import com.example.jetnews.ui.theme.JetnewsTheme
 import com.example.jetnews.ui.utils.BookmarkButton
 import com.example.jetnews.ui.utils.FavoriteButton

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsRoute.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsRoute.kt
@@ -21,31 +21,32 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import com.example.jetnews.utils.WindowSize
 
 /**
  * Stateful composable that displays the Navigation route for the Interests screen.
  *
  * @param interestsViewModel ViewModel that handles the business logic of this screen
- * @param showNavigationIcon (state) whether the navigation icon needs to be shown
+ * @param windowSize (state) The current window size class
  * @param openDrawer (event) request opening the app drawer
  * @param scaffoldState (state) state for screen Scaffold
  */
 @Composable
 fun InterestsRoute(
     interestsViewModel: InterestsViewModel,
-    showNavigationIcon: Boolean,
+    windowSize: WindowSize,
     openDrawer: () -> Unit,
     scaffoldState: ScaffoldState = rememberScaffoldState()
 ) {
-    val tabContent = rememberTabContent(interestsViewModel)
+    val tabContent = rememberTabContent(windowSize, interestsViewModel)
     val (currentSection, updateSection) = rememberSaveable {
         mutableStateOf(tabContent.first().section)
     }
 
     InterestsScreen(
+        windowSize = windowSize,
         tabContent = tabContent,
         currentSection = currentSection,
-        showNavigationIcon = showNavigationIcon,
         onTabChange = updateSection,
         openDrawer = openDrawer,
         scaffoldState = scaffoldState

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsRoute.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsRoute.kt
@@ -27,7 +27,8 @@ import com.example.jetnews.utils.WindowSize
  * Stateful composable that displays the Navigation route for the Interests screen.
  *
  * @param interestsViewModel ViewModel that handles the business logic of this screen
- * @param windowSize (state) The current window size class
+ * @param windowSize (state) the current window size class
+ * @param isDrawerActive (state) true if the drawer is active
  * @param openDrawer (event) request opening the app drawer
  * @param scaffoldState (state) state for screen Scaffold
  */
@@ -35,6 +36,7 @@ import com.example.jetnews.utils.WindowSize
 fun InterestsRoute(
     interestsViewModel: InterestsViewModel,
     windowSize: WindowSize,
+    isDrawerActive: Boolean,
     openDrawer: () -> Unit,
     scaffoldState: ScaffoldState = rememberScaffoldState()
 ) {
@@ -44,9 +46,10 @@ fun InterestsRoute(
     }
 
     InterestsScreen(
-        windowSize = windowSize,
         tabContent = tabContent,
         currentSection = currentSection,
+        windowSize = windowSize,
+        isDrawerActive = isDrawerActive,
         onTabChange = updateSection,
         openDrawer = openDrawer,
         scaffoldState = scaffoldState

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -293,8 +293,9 @@ private fun TabWithSections(
     selectedTopics: Set<TopicSelection>,
     onTopicSelect: (TopicSelection) -> Unit
 ) {
+    val columns = remember(windowSize) { if (windowSize == WindowSize.Compact) 1 else 2 }
+
     BoxWithConstraints {
-        val columns = remember(windowSize) { if (windowSize == WindowSize.Compact) 1 else 2 }
         val itemMaxWidth = rememberItemMaxWidth(maxWidth, columns)
         val groupedSections = rememberSectionsGroupedInColumns(sections, columns)
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -169,6 +169,7 @@ fun InterestsScreen(
 /**
  * Displays a tab row with [currentSection] selected and the body of the corresponding [tabContent].
  *
+ * @param windowSize (state) the current window size class
  * @param currentSection (state) the tab that is currently selected
  * @param updateSection (event) request a change in tab selection
  * @param tabContent (slot) tabs and their content to display, must be a non-empty list, tabs are
@@ -198,6 +199,7 @@ private fun TabContent(
 /**
  * Display the list for the topic tab
  *
+ * @param windowSize (state) the current window size class
  * @param topics (state) topics to display, mapped by section
  * @param selectedTopics (state) currently selected topics
  * @param onTopicSelect (event) request a topic selection be changed
@@ -284,6 +286,7 @@ private fun TabWithTopics(
 /**
  * Display a sectioned list of topics
  *
+ * @param windowSize (state) the current window size class
  * @param sections (state) topics to display, grouped by sections
  * @param selectedTopics (state) currently selected topics
  * @param onTopicSelect (event) request a topic+section selection be changed

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -259,6 +259,7 @@ private fun TabWithTopics(
     selectedTopics: Set<String>,
     onTopicSelect: (String) -> Unit
 ) {
+    // TODO: Optimize by manually positioning items, rather than using BoxWithConstraints
     BoxWithConstraints {
         val itemMaxWidth = rememberItemMaxWidth(windowMaxWidth = maxWidth, columns = 1)
         val topicModifier = Modifier
@@ -300,6 +301,7 @@ private fun TabWithSections(
 ) {
     val columns = remember(windowSize) { if (windowSize == WindowSize.Compact) 1 else 2 }
 
+    // TODO: Optimize by manually positioning items, rather than using BoxWithConstraints
     BoxWithConstraints {
         val itemMaxWidth = rememberItemMaxWidth(maxWidth, columns)
         val groupedSections = rememberSectionsGroupedInColumns(sections, columns)

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -106,16 +106,18 @@ class TabContent(val section: Sections, val content: @Composable () -> Unit)
  * @param tabContent (slot) the tabs and their content to display on this screen, must be a
  * non-empty list, tabs are displayed in the order specified by this list
  * @param currentSection (state) the current tab to display, must be in [tabContent]
- * @param showNavigationIcon (state) whether to show the navigation icon
+ * @param windowSize (state) the current window size class
+ * @param isDrawerActive (state) true if the drawer is active
  * @param onTabChange (event) request a change in [currentSection] to another tab from [tabContent]
  * @param openDrawer (event) request opening the app drawer
  * @param scaffoldState (state) the state for the screen's [Scaffold]
  */
 @Composable
 fun InterestsScreen(
-    windowSize: WindowSize,
     tabContent: List<TabContent>,
     currentSection: Sections,
+    windowSize: WindowSize,
+    isDrawerActive: Boolean,
     onTabChange: (Sections) -> Unit,
     openDrawer: () -> Unit,
     scaffoldState: ScaffoldState
@@ -131,7 +133,7 @@ fun InterestsScreen(
                         textAlign = TextAlign.Center
                     )
                 },
-                navigationIcon = if (windowSize == WindowSize.Compact) {
+                navigationIcon = if (isDrawerActive) {
                     {
                         IconButton(onClick = openDrawer) {
                             Icon(
@@ -550,9 +552,10 @@ fun PreviewInterestsScreenDrawer() {
         }
 
         InterestsScreen(
-            windowSize = WindowSize.Compact,
             tabContent = tabContent,
             currentSection = currentSection,
+            windowSize = WindowSize.Compact,
+            isDrawerActive = true,
             onTabChange = updateSection,
             openDrawer = { },
             scaffoldState = rememberScaffoldState()
@@ -578,9 +581,10 @@ fun PreviewInterestsScreenNavRail() {
         }
 
         InterestsScreen(
-            windowSize = WindowSize.Expanded,
             tabContent = tabContent,
             currentSection = currentSection,
+            windowSize = WindowSize.Expanded,
+            isDrawerActive = false,
             onTabChange = updateSection,
             openDrawer = { },
             scaffoldState = rememberScaffoldState()

--- a/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
@@ -43,7 +43,7 @@ import androidx.window.layout.WindowMetricsCalculator
  */
 enum class WindowSize { Compact, Medium, Expanded }
 
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+@VisibleForTesting
 fun getWindowSize(width: Dp): WindowSize = when {
     width.value < 0f -> throw IllegalArgumentException("Dp value cannot be negative")
     width.value < 600f -> WindowSize.Compact

--- a/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
@@ -19,6 +19,7 @@ package com.example.jetnews.utils
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
@@ -42,6 +43,7 @@ import androidx.window.layout.WindowMetricsCalculator
  */
 enum class WindowSize { Compact, Medium, Expanded }
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 fun getWindowSize(width: Dp): WindowSize = when {
     width.value < 0f -> throw IllegalArgumentException("Dp value cannot be negative")
     width.value < 600f -> WindowSize.Compact


### PR DESCRIPTION
This PR refines the window size class handling, primarily by resolving that size class in one place, in the top-level `JetnewsApp`.

I also fixed the issue where the list and detail layout was being used for the `Medium` size class, whereas we want to show either the list or detail at the `Medium` breakpoint.

A couple notes:
- I am passing down both a `WindowSize` and a resolved `Boolean` flag in some places. My rationale there is making a certain decision in exactly once place, and passing down that resolved value. So, therefore we create `isDrawerActive` in exactly one place, and then pass it down, while also passing down the raw `WindowSize`, because some screen may make an unrelated decisions using the size class (1 or 2 columns somewhere).

- The `Medium` size class design is not complete yet, mostly due to the complications created by the nav bar with the article screen. We need to change the contents of the nav bar to match the designs, but we only can do that based on the state contained within the home route. It might, therefore, make sense to revert back to having a different nav bar in each destination.  I'm not planning to address that in this PR, but a later one.