### PR TITLE
[JetNews] Replace currentWindowMetrics flow with synchronous calculation

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/utils/WindowSize.kt
@@ -21,15 +21,11 @@ import android.content.Context
 import android.content.ContextWrapper
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
 import androidx.window.layout.WindowMetrics
 import androidx.window.layout.WindowMetricsCalculator
 
@@ -56,7 +52,7 @@ fun getWindowSize(width: Dp): WindowSize = when {
  */
 @Composable
 fun rememberWindowSizeState(): WindowSize {
-    val windowMetrics by rememberCurrentWindowMetrics()
+    val windowMetrics = rememberCurrentWindowMetrics()
     val density = LocalDensity.current
 
     return remember(windowMetrics, density) {
@@ -68,17 +64,15 @@ fun rememberWindowSizeState(): WindowSize {
 
 /**
  * Returns the [WindowMetrics] corresponding to the current activities
- * [WindowInfoRepository.currentWindowMetrics] as [State].
+ * [WindowMetricsCalculator.computeCurrentWindowMetrics].
  */
 @Composable
-private fun rememberCurrentWindowMetrics(): State<WindowMetrics> {
+private fun rememberCurrentWindowMetrics(): WindowMetrics {
     val activity = LocalContext.current.findActivity()
-    val currentWindowMetricsFlow = remember(activity) {
-        activity.windowInfoRepository().currentWindowMetrics
-    }
-    return currentWindowMetricsFlow.collectAsState(
+    val configuration = LocalConfiguration.current
+    return remember(activity, configuration) {
         WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity)
-    )
+    }
 }
 
 /**


### PR DESCRIPTION
Removes the subscription to `currentWindowMetrics` flow, in favor of always performing the synchronous calculation.

The currently released version of `WindowManager` (`1.0.0-beta02`) has an [issue](https://issuetracker.google.com/issues/198562467) with `currentWindowMetrics` flow, where the new window metrics won't be properly propagated after a configuration change, if the activity is handling the configuration change.

This is reproducible with JetNews on Chrome OS, if the activity is adjusted to handle all configuration changes:
Resizing the window never propagates a new window metrics value, so the app doesn't change layouts.

This bug was fixed with a [workaround](https://cs.android.com/androidx/platform/frameworks/support/+/adbfb31c7699e5bebde57e625916979bd32de242), but this workaround uses an `onLayoutChange` listener, which means that the window metrics changes are delayed by a frame: they first need to be laid out at the new size, before the change is received. This can be reproduced by using the snapshot version of `WindowManager`, which results in the wrong window class being displayed for a frame.

Per a recommendation from @ianhanniballake, since there is a synchronous way to get the window metrics, we can bypass the WindowManager provided asynchronous flow and just call the synchronous getter directly guarded against a configuration change (which we were doing already for the initial value sine `currentWindowMetrics` is asynchronous).

This avoids both issues (with and without the workaround), and ends up being simpler as well, since we don't touch any `Flow`s.