### PR TITLE
[JetNews] Move window size calculation to activity level

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -38,7 +38,6 @@ import com.example.jetnews.data.AppContainer
 import com.example.jetnews.ui.components.AppNavRail
 import com.example.jetnews.ui.theme.JetnewsTheme
 import com.example.jetnews.utils.WindowSize
-import com.example.jetnews.utils.rememberWindowSizeState
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.insets.navigationBarsPadding
@@ -49,7 +48,8 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun JetnewsApp(
-    appContainer: AppContainer
+    appContainer: AppContainer,
+    windowSize: WindowSize
 ) {
     JetnewsTheme {
         ProvideWindowInsets {
@@ -70,7 +70,6 @@ fun JetnewsApp(
             val currentRoute =
                 navBackStackEntry?.destination?.route ?: JetnewsDestinations.HOME_ROUTE
 
-            val windowSize = rememberWindowSizeState()
             val isExpandedScreen = windowSize == WindowSize.Expanded
             val sizeAwareDrawerState = rememberSizeAwareDrawerState(isExpandedScreen)
 

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/MainActivity.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import com.example.jetnews.JetnewsApplication
+import com.example.jetnews.utils.rememberWindowSizeClass
 
 class MainActivity : AppCompatActivity() {
 
@@ -30,7 +31,8 @@ class MainActivity : AppCompatActivity() {
 
         val appContainer = (application as JetnewsApplication).container
         setContent {
-            JetnewsApp(appContainer)
+            val windowSizeClass = rememberWindowSizeClass()
+            JetnewsApp(appContainer, windowSizeClass)
         }
     }
 }

--- a/JetNews/app/src/sharedTest/java/com/example/jetnews/TestHelper.kt
+++ b/JetNews/app/src/sharedTest/java/com/example/jetnews/TestHelper.kt
@@ -19,6 +19,7 @@ package com.example.jetnews
 import android.content.Context
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import com.example.jetnews.ui.JetnewsApp
+import com.example.jetnews.utils.WindowSize
 
 /**
  * Launches the app from a test context
@@ -26,7 +27,8 @@ import com.example.jetnews.ui.JetnewsApp
 fun ComposeContentTestRule.launchJetNewsApp(context: Context) {
     setContent {
         JetnewsApp(
-            TestAppContainer(context)
+            appContainer = TestAppContainer(context),
+            windowSize = WindowSize.Compact
         )
     }
 }

--- a/JetNews/app/src/test/java/com/example/jetnews/utils/WindowSizeTest.kt
+++ b/JetNews/app/src/test/java/com/example/jetnews/utils/WindowSizeTest.kt
@@ -16,6 +16,7 @@
 
 package com.example.jetnews.utils
 
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -24,26 +25,26 @@ class WindowSizeTest {
 
     @Test
     fun getWindowSize_Compact() {
-        assertEquals(WindowSize.Compact, getWindowSize(599.5.dp))
+        assertEquals(WindowSize.Compact, getWindowSizeClass(DpSize(599.5.dp, 300.dp)))
     }
 
     @Test
     fun getWindowSize_Medium_lowEnd() {
-        assertEquals(WindowSize.Medium, getWindowSize(800.dp))
+        assertEquals(WindowSize.Medium, getWindowSizeClass(DpSize(800.dp, 300.dp)))
     }
 
     @Test
     fun getWindowSize_Medium_highEnd() {
-        assertEquals(WindowSize.Medium, getWindowSize(839.5.dp))
+        assertEquals(WindowSize.Medium, getWindowSizeClass(DpSize(839.5.dp, 300.dp)))
     }
 
     @Test
     fun getWindowSize_Expanded() {
-        assertEquals(WindowSize.Expanded, getWindowSize(840.dp))
+        assertEquals(WindowSize.Expanded, getWindowSizeClass(DpSize(840.dp, 300.dp)))
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun getWindowSize_Negative() {
-        getWindowSize((-1).dp)
+        getWindowSizeClass(DpSize((-1).dp, 300.dp))
     }
 }


### PR DESCRIPTION
This is a slight reworking of the window size class logic, with no functional changes.

The main change is that `rememberWindowSizeClass()` becomes an extension of the `Activity` which encourages its use at the top-level `@Composable` (that is, directly inside `setContent`). This deliberately makes it more difficult to fetch the window size class arbitrarily from nested composables (by looking up the activity), in favor of passing it down explicitly. 