### PR TITLE
Add assembleRelease to CI steps

### DIFF
--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build project
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug lintDebug --stacktrace
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/Crane.yaml'
       - 'Crane/**'
   pull_request:
     paths:
+      - '.github/workflows/Crane.yaml'
       - 'Crane/**'
 
 env:

--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -41,9 +41,25 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build project
+      - name: Check spotless
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Check lint
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Build debug
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Build release
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Run local tests
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew testDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/JetNews.yaml'
       - 'JetNews/**'
   pull_request:
     paths:
+      - '.github/workflows/JetNews.yaml'
       - 'JetNews/**'
 
 env:

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -41,9 +41,25 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build project and run local tests
+      - name: Check spotless
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug testDebug --stacktrace --no-build-cache --rerun-tasks
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Check lint
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Build debug
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Build release
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Run local tests
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew testDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build project and run local tests
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug lintDebug testDebug --stacktrace --no-build-cache --rerun-tasks
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug testDebug --stacktrace --no-build-cache --rerun-tasks
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build project
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug lintDebug --stacktrace
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/Jetcaster.yaml'
       - 'Jetcaster/**'
   pull_request:
     paths:
+      - '.github/workflows/Jetcaster.yaml'
       - 'Jetcaster/**'
 
 env:

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -41,9 +41,25 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build project
+      - name: Check spotless
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Check lint
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Build debug
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Build release
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Run local tests
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew testDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/Jetchat.yaml'
       - 'Jetchat/**'
   pull_request:
     paths:
+      - '.github/workflows/Jetchat.yaml'
       - 'Jetchat/**'
 
 env:

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build project
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug lintDebug --stacktrace
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -41,9 +41,25 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build project
+      - name: Check spotless
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Check lint
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Build debug
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Build release
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Run local tests
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew testDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/Jetsnack.yaml'
       - 'Jetsnack/**'
   pull_request:
     paths:
+      - '.github/workflows/Jetsnack.yaml'
       - 'Jetsnack/**'
 
 env:

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build project
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug lintDebug --stacktrace
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -41,9 +41,25 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build project
+      - name: Check spotless
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Check lint
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Build debug
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Build release
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Run local tests
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew testDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/Jetsurvey.yaml'
       - 'Jetsurvey/**'
   pull_request:
     paths:
+      - '.github/workflows/Jetsurvey.yaml'
       - 'Jetsurvey/**'
 
 env:

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build project
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug lintDebug --stacktrace
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -41,9 +41,25 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build project
+      - name: Check spotless
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Check lint
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Build debug
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Build release
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Run local tests
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew testDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/Owl.yaml'
       - 'Owl/**'
   pull_request:
     paths:
+      - '.github/workflows/Owl.yaml'
       - 'Owl/**'
 
 env:

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build project
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug lintDebug --stacktrace
+        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -41,9 +41,25 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build project
+      - name: Check spotless
         working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck assembleDebug assembleRelease lintDebug --stacktrace
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Check lint
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Build debug
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Build release
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Run local tests
+        working-directory: ${{ env.SAMPLE_PATH }}
+        run: ./gradlew testDebug --stacktrace
 
       - name: Upload build outputs (APKs)
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Adds `assembleRelease` to the build steps for all projects.

This will ensure that changes can't be made that prevent `release` variants of apps from failing to compile, although it doesn't verify any runtime behavior (i.e. `release` variants could crash on startup).