### PR TITLE
Update R8 to avoid minified crash with navigation-compose

### DIFF
--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -23,9 +23,13 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url 'https://storage.googleapis.com/r8-releases/raw'
+        }
     }
 
     dependencies {
+        classpath 'com.android.tools:r8:3.1.34' // Needed for release builds with navigation-compose 2.4.0-alpha10 (https://issuetracker.google.com/issues/204910734)
         classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/Jetsnack/build.gradle
+++ b/Jetsnack/build.gradle
@@ -21,8 +21,12 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url 'https://storage.googleapis.com/r8-releases/raw'
+        }
     }
     dependencies {
+        classpath Libs.r8 // Needed for release builds with navigation-compose 2.4.0-alpha10 (https://issuetracker.google.com/issues/204910734)
         classpath Libs.androidGradlePlugin
         classpath Libs.Kotlin.gradlePlugin
     }

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -21,6 +21,7 @@ object Versions {
 }
 
 object Libs {
+    const val r8 = "com.android.tools:r8:3.1.34"
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.0.3"
 
     object Accompanist {

--- a/Owl/build.gradle
+++ b/Owl/build.gradle
@@ -21,8 +21,12 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url 'https://storage.googleapis.com/r8-releases/raw'
+        }
     }
     dependencies {
+        classpath Libs.r8 // Needed for release builds with navigation-compose 2.4.0-alpha10 (https://issuetracker.google.com/issues/204910734)
         classpath Libs.androidGradlePlugin
         classpath Libs.Kotlin.gradlePlugin
     }
@@ -36,6 +40,7 @@ subprojects {
     repositories {
         google()
         mavenCentral()
+
 
         if (!Libs.AndroidX.Compose.snapshot.isEmpty()) {
             maven { url "https://androidx.dev/snapshots/builds/${Libs.AndroidX.Compose.snapshot}/artifacts/repository/" }

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -21,6 +21,7 @@ object Versions {
 }
 
 object Libs {
+    const val r8 = "com.android.tools:r8:3.1.34"
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.0.3"
 
     object Accompanist {


### PR DESCRIPTION
As reported in #692 , using version `2.4.0-alpha09` or `2.4.0-alpha10` of `navigation-compose` with a minified build will result in a crash upon startup.

I created an upstream issue [here](https://issuetracker.google.com/issues/204910734) on the navigation side, but it looks like an R8 issue since updating to a newer version than default resolves the issue.

This PR adds that workaround, updating R8 for the 3 affected projects: `JetNews`, `Jetsnack`, and `Owl` (`Jetcaster` uses `navigation-compose`, but doesn't minify the release build). If `navigation-compose` changes its implementation to avoid this bug, or the default version of R8 fixes the issue, we can revert this commit.

This fixes #692 