### PR TITLE
[Jetcaster] Project does not build on Mac with Apple Silicon m1 - fix

### DIFF
--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -113,7 +113,7 @@ object Libs {
         }
 
         object Room {
-            private const val version = "2.3.0"
+            private const val version = "2.4.0-beta01"
             const val runtime = "androidx.room:room-runtime:${version}"
             const val ktx = "androidx.room:room-ktx:${version}"
             const val compiler = "androidx.room:room-compiler:${version}"


### PR DESCRIPTION
upgraded room to `2.4.0-beta01`.

Able to build successfully after this change in mac with M1 chip.

[Issue link](https://github.com/android/compose-samples/issues/666)