### PR TITLE
When I scroll down the explore section the h6 black color disappear

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/base/ExploreSection.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/base/ExploreSection.kt
@@ -129,7 +129,7 @@ private fun ExploreItem(
         Column {
             Text(
                 text = item.city.nameToDisplay,
-                style = MaterialTheme.typography.h6
+                style = MaterialTheme.typography.h6.copy(color = Color.DarkGray)
             )
             Spacer(Modifier.height(8.dp))
             Text(


### PR DESCRIPTION
Hi guys,

I'm new in android development, when I debugged Crane sample , I saw the color of h6 is disappear sometimes.
I did some changes to keep the colors of h6, but I don't fix it the right way in my opinion.
I wish this pr can help you to fix this bug in the right ways.

Best wishes.