### PR TITLE
[Jetcaster] Using isSeparating to check tableTop mode instead of HALF_OPENED

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/util/WindowInfoUtil.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/util/WindowInfoUtil.kt
@@ -37,10 +37,10 @@ sealed interface DevicePosture {
 @OptIn(ExperimentalContracts::class)
 fun isTableTopPosture(foldFeature: FoldingFeature?): Boolean {
     contract { returns(true) implies (foldFeature != null) }
-    return foldFeature?.state == FoldingFeature.State.HALF_OPENED &&
+    return foldFeature?.isSeparating == true &&
         foldFeature.orientation == FoldingFeature.Orientation.HORIZONTAL
 }
 
 fun isBookPosture(foldFeature: FoldingFeature?) =
-    foldFeature?.state == FoldingFeature.State.HALF_OPENED &&
+    foldFeature?.isSeparating == true &&
         foldFeature.orientation == FoldingFeature.Orientation.VERTICAL


### PR DESCRIPTION
The idea of the change is to use [isSeparating](window/window/src/main/java/androidx/window/layout/HardwareFoldingFeature.kt) to check which UI should be shown instead of HALF_OPENED.

Currently, in Jetcaster, the player screen will be cut off on the Microsoft Surface Duo device when the device is open (more than 180-degree hinge) until the device is folded to HALF_OPENED (less than 180). 
![Screenshot_1643317559](https://user-images.githubusercontent.com/7552466/152078930-e0590b8c-d50e-4911-8d76-538a295d3432.png)

With the change, the player screen will behave well on the Surface Duo device, no matter it is half-open, or fully open. 
![Screenshot_1643317445](https://user-images.githubusercontent.com/7552466/152078937-966424b9-faae-4636-8b43-cadc70d184d0.png)

The behavior of Samsung Fold device would stay the same, showing the regular UI when the device is fully open and the tableTop UI at half-open.
![1](https://user-images.githubusercontent.com/7552466/152081450-605e4bae-f3df-411a-b79f-9fbbc449df80.jpeg)
![2](https://user-images.githubusercontent.com/7552466/152081453-4932b278-278c-4474-a062-f35afa64eee8.jpeg)

