### PR TITLE
[Crane] Make Maps test pass without using an API key

### DIFF
--- a/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
+++ b/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
@@ -33,6 +33,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
@@ -40,6 +41,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.math.pow
 
+@Ignore("To be fixed in https://github.com/android/compose-samples/issues/746")
 @HiltAndroidTest
 class CityMapViewTests {
     @Inject

--- a/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
+++ b/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
@@ -33,7 +33,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
@@ -41,7 +40,6 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.math.pow
 
-@Ignore("To be fixed in https://github.com/android/compose-samples/issues/746")
 @HiltAndroidTest
 class CityMapViewTests {
     @Inject

--- a/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
+++ b/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.filters.SdkSuppress
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -40,6 +41,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.math.pow
 
+@SdkSuppress(minSdkVersion = 28)
 @HiltAndroidTest
 class CityMapViewTests {
     @Inject

--- a/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
+++ b/Crane/app/src/androidTest/java/androidx/compose/samples/crane/details/CityMapViewTests.kt
@@ -86,7 +86,10 @@ class CityMapViewTests {
             }
         }
 
-        assertTrue("Map failed to load in time.", countDownLatch.await(30, TimeUnit.SECONDS))
+        assertTrue(
+            "Map failed to load in time.",
+            countDownLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        )
     }
 
     @Test
@@ -107,7 +110,10 @@ class CityMapViewTests {
             .performClick()
 
         // Wait for the animation to happen
-        assertTrue("Zoom timed out", zoomLatch.await(30, TimeUnit.SECONDS))
+        assertTrue(
+            "Zoom timed out",
+            zoomLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        )
 
         assertTrue(InitialZoom < currentCameraPosition.zoom)
     }
@@ -119,11 +125,15 @@ class CityMapViewTests {
             .performClick()
 
         // Wait for the animation to happen
-        assertTrue("Zoom timed out", zoomLatch.await(30, TimeUnit.SECONDS))
+        assertTrue(
+            "Zoom timed out",
+            zoomLatch.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        )
 
         assertTrue(InitialZoom > currentCameraPosition.zoom)
     }
 }
 
+private const val LATCH_TIMEOUT_SECONDS = 60L
 private fun Double.round(decimals: Int = 2): Double =
     kotlin.math.round(this * 10f.pow(decimals)) / 10f.pow(decimals)

--- a/Crane/build.gradle
+++ b/Crane/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.2.0'
+    id 'com.diffplug.spotless' version '6.3.0'
 }
 
 subprojects {

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -17,11 +17,11 @@
 package com.example.crane.buildsrc
 
 object Versions {
-    const val ktLint = "0.43.2"
+    const val ktLint = "0.44.0"
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.1"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
     const val ktLint = "com.pinterest:ktlint:${Versions.ktLint}"
 
     object GoogleMaps {
@@ -60,7 +60,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.1.0"
+            const val version = "1.1.1"
 
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val runtimeLivedata = "androidx.compose.runtime:runtime-livedata:$version"
@@ -75,7 +75,7 @@ object Libs {
         }
 
         object Lifecycle {
-            private const val version = "2.4.0"
+            private const val version = "2.4.1"
             const val viewModelCompose = "androidx.lifecycle:lifecycle-viewmodel-compose:$version"
             const val viewModelKtx = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
         }

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -34,7 +34,7 @@ object Libs {
     }
 
     object Accompanist {
-        const val version = "0.23.0"
+        const val version = "0.23.1"
         const val insets = "com.google.accompanist:accompanist-insets:$version"
     }
 

--- a/JetNews/app/build.gradle
+++ b/JetNews/app/build.gradle
@@ -112,12 +112,12 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation "androidx.activity:activity-compose:1.4.0"
 
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.4.0"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.4.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1"
 
-    implementation 'androidx.navigation:navigation-compose:2.4.0'
+    implementation 'androidx.navigation:navigation-compose:2.4.1'
 
     implementation "androidx.window:window:1.0.0"
 

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext.kotlin_version = '1.6.10'
-    ext.compose_version = '1.1.0'
+    ext.compose_version = '1.1.1'
     ext.coroutines_version = '1.6.0'
     ext.accompanist_version = '0.23.0'
 
@@ -26,13 +26,13 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.2.0'
+    id 'com.diffplug.spotless' version '6.3.0'
 }
 
 subprojects {
@@ -48,7 +48,7 @@ subprojects {
             targetExclude("$buildDir/**/*.kt")
             targetExclude('bin/**/*.kt')
 
-            ktlint("0.43.2")
+            ktlint("0.44.0")
             licenseHeaderFile rootProject.file('spotless/copyright.kt')
         }
     }

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     ext.compose_version = '1.1.1'
     ext.coroutines_version = '1.6.0'
-    ext.accompanist_version = '0.23.0'
+    ext.accompanist_version = '0.23.1'
 
     repositories {
         google()

--- a/Jetcaster/build.gradle
+++ b/Jetcaster/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.2.0'
+    id 'com.diffplug.spotless' version '6.3.0'
 }
 
 subprojects {

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -17,11 +17,11 @@
 package com.example.jetcaster.buildsrc
 
 object Versions {
-    const val ktlint = "0.43.2"
+    const val ktlint = "0.44.0"
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
     const val jdkDesugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object Accompanist {
@@ -71,7 +71,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.1.0"
+            const val version = "1.1.1"
 
             @get:JvmStatic
             val snapshotUrl: String
@@ -90,14 +90,14 @@ object Libs {
         }
 
         object Lifecycle {
-            private const val version = "2.4.0"
+            private const val version = "2.4.1"
             const val runtime = "androidx.lifecycle:lifecycle-runtime-ktx:$version"
             const val viewModelCompose = "androidx.lifecycle:lifecycle-viewmodel-compose:$version"
             const val viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
         }
 
         object Navigation {
-            const val navigation = "androidx.navigation:navigation-compose:2.4.0"
+            const val navigation = "androidx.navigation:navigation-compose:2.4.1"
         }
 
         object Test {
@@ -114,7 +114,7 @@ object Libs {
         }
 
         object Room {
-            private const val version = "2.4.0"
+            private const val version = "2.4.2"
             const val runtime = "androidx.room:room-runtime:${version}"
             const val ktx = "androidx.room:room-ktx:${version}"
             const val compiler = "androidx.room:room-compiler:${version}"

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -25,7 +25,7 @@ object Libs {
     const val jdkDesugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object Accompanist {
-        const val version = "0.23.0"
+        const val version = "0.23.1"
         const val insets = "com.google.accompanist:accompanist-insets:$version"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
@@ -19,7 +19,7 @@ package com.example.compose.jetchat.components
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue.Closed
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.NavigationDrawer
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import com.example.compose.jetchat.theme.JetchatTheme
@@ -33,7 +33,7 @@ fun JetchatScaffold(
     content: @Composable () -> Unit
 ) {
     JetchatTheme {
-        NavigationDrawer(
+        ModalNavigationDrawer(
             drawerState = drawerState,
             drawerContent = {
                 JetchatDrawer(

--- a/Jetchat/build.gradle
+++ b/Jetchat/build.gradle
@@ -32,7 +32,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.2.0'
+    id 'com.diffplug.spotless' version '6.3.0'
 }
 
 subprojects {

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -17,16 +17,16 @@
 package com.example.compose.jetchat.buildsrc
 
 object Versions {
-    const val ktlint = "0.43.2"
+    const val ktlint = "0.44.0"
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
     const val jdkDesugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     const val junit = "junit:junit:4.13"
 
-    const val material3 = "com.google.android.material:material:1.5.0-rc01"
+    const val material3 = "com.google.android.material:material:1.5.0"
 
     object Accompanist {
         const val version = "0.23.0"
@@ -57,7 +57,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.1.0"
+            const val version = "1.1.1"
 
             const val foundation = "androidx.compose.foundation:foundation:$version"
             const val layout = "androidx.compose.foundation:foundation-layout:$version"
@@ -82,7 +82,7 @@ object Libs {
         }
 
         object Navigation {
-            private const val version = "2.4.0"
+            private const val version = "2.4.1"
             const val fragment = "androidx.navigation:navigation-fragment-ktx:$version"
             const val uiKtx = "androidx.navigation:navigation-ui-ktx:$version"
         }
@@ -101,7 +101,7 @@ object Libs {
         }
 
         object Lifecycle {
-            private const val version = "2.4.0"
+            private const val version = "2.4.1"
             const val extensions = "androidx.lifecycle:lifecycle-extensions:$version"
             const val livedata = "androidx.lifecycle:lifecycle-livedata-ktx:$version"
             const val viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -26,10 +26,10 @@ object Libs {
 
     const val junit = "junit:junit:4.13"
 
-    const val material3 = "com.google.android.material:material:1.5.0"
+    const val material3 = "com.google.android.material:material:1.6.0-alpha02"
 
     object Accompanist {
-        const val version = "0.23.0"
+        const val version = "0.23.1"
         const val insets = "com.google.accompanist:accompanist-insets:$version"
     }
 

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -75,7 +75,7 @@ object Libs {
 
             object Material3 {
                 const val snapshot = ""
-                const val version = "1.0.0-alpha04"
+                const val version = "1.0.0-alpha06"
 
                 const val material3 = "androidx.compose.material3:material3:$version"
             }

--- a/Jetsnack/build.gradle
+++ b/Jetsnack/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.2.0'
+    id 'com.diffplug.spotless' version '6.3.0'
 }
 
 subprojects {

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -24,7 +24,7 @@ object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
 
     object Accompanist {
-        const val version = "0.23.0"
+        const val version = "0.23.1"
         const val insets = "com.google.accompanist:accompanist-insets:$version"
         const val systemuicontroller = "com.google.accompanist:accompanist-systemuicontroller:$version"
         const val flowlayouts = "com.google.accompanist:accompanist-flowlayout:$version"

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -17,11 +17,11 @@
 package com.example.jetsnack.buildsrc
 
 object Versions {
-    const val ktlint = "0.43.2"
+    const val ktlint = "0.44.0"
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
 
     object Accompanist {
         const val version = "0.23.0"
@@ -49,7 +49,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.1.0"
+            const val version = "1.1.1"
 
             const val foundation = "androidx.compose.foundation:foundation:${version}"
             const val layout = "androidx.compose.foundation:foundation-layout:${version}"
@@ -69,11 +69,11 @@ object Libs {
         }
 
         object Lifecycle {
-            const val viewModelCompose = "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0"
+            const val viewModelCompose = "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1"
         }
 
         object Navigation {
-            const val navigationCompose = "androidx.navigation:navigation-compose:2.4.0"
+            const val navigationCompose = "androidx.navigation:navigation-compose:2.4.1"
         }
 
         object ConstraintLayout {

--- a/Jetsurvey/app/build.gradle
+++ b/Jetsurvey/app/build.gradle
@@ -97,7 +97,6 @@ dependencies {
     implementation Libs.AndroidX.Navigation.fragment
     implementation Libs.AndroidX.Navigation.uiKtx
     implementation Libs.AndroidX.Material.material
-    implementation Libs.material
 
     implementation Libs.AndroidX.Lifecycle.viewmodel
     implementation Libs.AndroidX.Lifecycle.viewModelCompose

--- a/Jetsurvey/build.gradle
+++ b/Jetsurvey/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.2.0'
+    id 'com.diffplug.spotless' version '6.3.0'
 }
 
 subprojects {

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -17,16 +17,14 @@
 package com.example.compose.jetsurvey.buildsrc
 
 object Versions {
-    const val ktlint = "0.43.2"
+    const val ktlint = "0.44.0"
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
     const val jdkDesugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     const val junit = "junit:junit:4.13"
-
-    const val material = "com.google.android.material:material:1.3.0"
 
     object Accompanist {
         const val version = "0.23.0"
@@ -52,7 +50,7 @@ object Libs {
         const val coreKtx = "androidx.core:core-ktx:1.7.0"
 
         object Lifecycle {
-            private const val version = "2.4.0"
+            private const val version = "2.4.1"
             const val viewModelCompose = "androidx.lifecycle:lifecycle-viewmodel-compose:$version"
             const val viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version"
         }
@@ -63,7 +61,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.1.0"
+            const val version = "1.1.1"
 
             @get:JvmStatic
             val snapshotUrl: String
@@ -82,13 +80,13 @@ object Libs {
         }
 
         object Navigation {
-            private const val version = "2.4.0"
+            private const val version = "2.4.1"
             const val fragment = "androidx.navigation:navigation-fragment-ktx:$version"
             const val uiKtx = "androidx.navigation:navigation-ui-ktx:$version"
         }
 
         object Material {
-            private const val version = "1.3.0"
+            private const val version = "1.5.0"
             const val material = "com.google.android.material:material:$version"
         }
 

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -27,7 +27,7 @@ object Libs {
     const val junit = "junit:junit:4.13"
 
     object Accompanist {
-        const val version = "0.23.0"
+        const val version = "0.23.1"
         const val permissions = "com.google.accompanist:accompanist-permissions:$version"
     }
 
@@ -86,7 +86,7 @@ object Libs {
         }
 
         object Material {
-            private const val version = "1.5.0"
+            private const val version = "1.6.0-alpha02"
             const val material = "com.google.android.material:material:$version"
         }
 

--- a/Owl/build.gradle
+++ b/Owl/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.diffplug.spotless' version '6.2.0'
+    id 'com.diffplug.spotless' version '6.3.0'
 }
 
 subprojects {

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -17,11 +17,11 @@
 package com.example.owl.buildsrc
 
 object Versions {
-    const val ktlint = "0.43.2"
+    const val ktlint = "0.44.0"
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
 
     object Accompanist {
         const val version = "0.23.0"
@@ -49,7 +49,7 @@ object Libs {
 
     object AndroidX {
         const val coreKtx = "androidx.core:core-ktx:1.7.0"
-        const val navigation = "androidx.navigation:navigation-compose:2.4.0"
+        const val navigation = "androidx.navigation:navigation-compose:2.4.1"
 
         object Activity {
             const val activityCompose = "androidx.activity:activity-compose:1.4.0"
@@ -57,7 +57,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.1.0"
+            const val version = "1.1.1"
 
             const val animation = "androidx.compose.animation:animation:$version"
             const val foundation = "androidx.compose.foundation:foundation:$version"

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -24,7 +24,7 @@ object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.2"
 
     object Accompanist {
-        const val version = "0.23.0"
+        const val version = "0.23.1"
         const val insets = "com.google.accompanist:accompanist-insets:$version"
     }
 


### PR DESCRIPTION
Added a hack method to make the tests work without having to provide an API key.

I have come to the realisation that making a maps API key a requirement for tests to pass is probably too large a burden to place on people. I have come up with this workaround for it and also filed a feature request on [Maps Compose](https://github.com/googlemaps/android-maps-compose/issues/50) which would improve the situation.

I tested to make sure the tests are indeed still testing and failing when they should.

Fixes #746 