### PR TITLE
Add layout for Book posture and supports dual-screen devices.

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/MainActivity.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.window.layout.WindowInfoTracker.Companion.getOrCreate
 import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.DevicePosture
 import com.example.jetcaster.util.isBookPosture
+import com.example.jetcaster.util.isSeparating
 import com.example.jetcaster.util.isTableTopPosture
 import com.google.accompanist.insets.ProvideWindowInsets
 import kotlinx.coroutines.flow.SharingStarted
@@ -51,7 +52,10 @@ class MainActivity : ComponentActivity() {
                 when {
                     isTableTopPosture(foldingFeature) ->
                         DevicePosture.TableTopPosture(foldingFeature.bounds)
-                    isBookPosture(foldingFeature) -> DevicePosture.BookPosture
+                    isBookPosture(foldingFeature) ->
+                        DevicePosture.BookPosture(foldingFeature.bounds)
+                    isSeparating(foldingFeature) ->
+                        DevicePosture.Separating(foldingFeature.bounds, foldingFeature.orientation)
                     else -> DevicePosture.NormalPosture
                 }
             }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
@@ -69,6 +70,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.window.layout.FoldingFeature
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import com.example.jetcaster.R
@@ -128,10 +130,27 @@ fun PlayerContent(
         // As the Player UI content changes considerably when the device is in tabletop posture,
         // we split the different UIs in different composables. For simpler UIs that don't change
         // much, prefer one composable that makes decisions based on the mode instead.
-        if (devicePosture is DevicePosture.TableTopPosture) {
-            PlayerContentTableTop(uiState, devicePosture, onBackPress)
-        } else {
-            PlayerContentRegular(uiState, onBackPress)
+        when (devicePosture) {
+            is DevicePosture.TableTopPosture ->
+                PlayerContentTableTop(uiState, devicePosture, onBackPress)
+            is DevicePosture.BookPosture ->
+                PlayerContentBook(uiState, devicePosture, onBackPress)
+            is DevicePosture.Separating ->
+                if (devicePosture.orientation == FoldingFeature.Orientation.HORIZONTAL) {
+                    PlayerContentTableTop(
+                        uiState,
+                        DevicePosture.TableTopPosture(devicePosture.hingePosition),
+                        onBackPress
+                    )
+                } else {
+                    PlayerContentBook(
+                        uiState,
+                        DevicePosture.BookPosture(devicePosture.hingePosition),
+                        onBackPress
+                    )
+                }
+            else ->
+                PlayerContentRegular(uiState, onBackPress)
         }
     }
 }
@@ -225,6 +244,58 @@ private fun PlayerContentTableTop(
             ) {
                 PlayerButtons(playerButtonSize = 92.dp, modifier = Modifier.padding(top = 8.dp))
                 PlayerSlider(uiState.duration)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerContentBook(
+    uiState: PlayerUiState,
+    bookPosture: DevicePosture.BookPosture,
+    onBackPress: () -> Unit
+) {
+    val hingePosition = with(LocalDensity.current) { bookPosture.hingePosition.left.toDp() }
+    val hingeWidth = with(LocalDensity.current) { bookPosture.hingePosition.width().toDp() }
+
+    Row(modifier = Modifier.fillMaxSize()) {
+        // Content for the left part of the screen - empty at the moment
+        Spacer(modifier = Modifier.width(hingePosition))
+        // Space for the hinge
+        Spacer(modifier = Modifier.width(hingeWidth))
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalGradientScrim(
+                    color = MaterialTheme.colors.primary.copy(alpha = 0.50f),
+                    startYPercentage = 1f,
+                    endYPercentage = 0f
+                )
+                .systemBarsPadding(bottom = false)
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            TopAppBar(onBackPress = onBackPress)
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+                PlayerImage(
+                    podcastImageUrl = uiState.podcastImageUrl,
+                    modifier = Modifier.weight(10f)
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+                PodcastDescription(uiState.title, uiState.podcastName)
+                Spacer(modifier = Modifier.height(32.dp))
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.weight(10f)
+                ) {
+                    PlayerSlider(uiState.duration)
+                    PlayerButtons(Modifier.padding(vertical = 8.dp))
+                }
+                Spacer(modifier = Modifier.weight(1f))
             }
         }
     }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/util/WindowInfoUtil.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/util/WindowInfoUtil.kt
@@ -31,7 +31,14 @@ sealed interface DevicePosture {
         val hingePosition: Rect
     ) : DevicePosture
 
-    object BookPosture : DevicePosture
+    data class BookPosture(
+        val hingePosition: Rect
+    ) : DevicePosture
+
+    data class Separating(
+        val hingePosition: Rect,
+        var orientation: FoldingFeature.Orientation
+    ) : DevicePosture
 }
 
 @OptIn(ExperimentalContracts::class)
@@ -41,6 +48,15 @@ fun isTableTopPosture(foldFeature: FoldingFeature?): Boolean {
         foldFeature.orientation == FoldingFeature.Orientation.HORIZONTAL
 }
 
-fun isBookPosture(foldFeature: FoldingFeature?) =
-    foldFeature?.state == FoldingFeature.State.HALF_OPENED &&
+@OptIn(ExperimentalContracts::class)
+fun isBookPosture(foldFeature: FoldingFeature?): Boolean {
+    contract { returns(true) implies (foldFeature != null) }
+    return foldFeature?.state == FoldingFeature.State.HALF_OPENED &&
         foldFeature.orientation == FoldingFeature.Orientation.VERTICAL
+}
+
+@OptIn(ExperimentalContracts::class)
+fun isSeparating(foldFeature: FoldingFeature?): Boolean {
+    contract { returns(true) implies (foldFeature != null) }
+    return foldFeature?.state == FoldingFeature.State.FLAT && foldFeature.isSeparating
+}


### PR DESCRIPTION
This adds a new layout for book postures, at the moment restricting the player on one half of the screen to avoid having controls too close to the hinge making them difficult to touch:

![Screenshot_20220310_120449](https://user-images.githubusercontent.com/188886/157649387-d81f018e-f489-4685-a92f-159fcd220bbb.png)

The left pane is currently left empty.

This PR also adds support for dual-screen devices (`isSeparating == true` and `State == FLAT` reusing TableTop and Book layouts to avoid drawing content over the hinge.