### PR TITLE
[Crane] Improved Tab selector ripple and added animation transition between tabs

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/base/CraneTabs.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/base/CraneTabs.kt
@@ -20,20 +20,25 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Tab
+import androidx.compose.material.TabPosition
 import androidx.compose.material.TabRow
+import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.samples.crane.R
 import androidx.compose.samples.crane.home.CraneScreen
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
@@ -82,23 +87,30 @@ fun CraneTabs(
         selectedTabIndex = tabSelected.ordinal,
         modifier = modifier,
         contentColor = MaterialTheme.colors.onSurface,
-        indicator = { },
+        indicator = { tabPositions: List<TabPosition> ->
+            Box(
+                Modifier.tabIndicatorOffset(tabPositions[tabSelected.ordinal])
+                    .fillMaxSize()
+                    .padding(2.dp)
+                    .border(BorderStroke(2.dp, Color.White), RoundedCornerShape(16.dp))
+            )
+        },
         divider = { }
     ) {
         titles.forEachIndexed { index, title ->
             val selected = index == tabSelected.ordinal
 
-            var textModifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)
-            if (selected) {
-                textModifier =
-                    Modifier
-                        .border(BorderStroke(2.dp, Color.White), RoundedCornerShape(16.dp))
-                        .then(textModifier)
-            }
+            val textModifier = Modifier
+                .padding(vertical = 8.dp, horizontal = 16.dp)
 
             Tab(
+                modifier = Modifier
+                    .padding(2.dp)
+                    .clip(RoundedCornerShape(16.dp)),
                 selected = selected,
-                onClick = { onTabSelected(CraneScreen.values()[index]) }
+                onClick = {
+                    onTabSelected(CraneScreen.values()[index])
+                }
             ) {
                 Text(
                     modifier = textModifier,

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/base/CraneTabs.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/base/CraneTabs.kt
@@ -91,7 +91,7 @@ fun CraneTabs(
             Box(
                 Modifier.tabIndicatorOffset(tabPositions[tabSelected.ordinal])
                     .fillMaxSize()
-                    .padding(2.dp)
+                    .padding(horizontal = 4.dp)
                     .border(BorderStroke(2.dp, Color.White), RoundedCornerShape(16.dp))
             )
         },
@@ -105,7 +105,7 @@ fun CraneTabs(
 
             Tab(
                 modifier = Modifier
-                    .padding(2.dp)
+                    .padding(horizontal = 4.dp)
                     .clip(RoundedCornerShape(16.dp)),
                 selected = selected,
                 onClick = {


### PR DESCRIPTION
## Description ✏️

The Tab's on Crane were current don't animate the selection changes, and the ripple shape is currently square - extending past the size of the rounded border. 

This PR changes the ripple to be clipped to the `RoundedCornerShape` and animates the tab selection based on the docs [here](https://developer.android.com/reference/kotlin/androidx/compose/material/package-summary#TabRow(kotlin.Int,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,kotlin.Function1,kotlin.Function0,kotlin.Function0)).

## Screenshots 📸

| Before | After |
|-------|-------|
|![Crane_TabRow_Before](https://user-images.githubusercontent.com/9973046/159972088-48541490-0bda-46af-b1bf-19d7d2fdb08a.gif)| ![Crane_TabRow_Improvements](https://user-images.githubusercontent.com/9973046/159972154-b74eab31-ac68-475f-b355-e53518b87afb.gif)|