### PR TITLE
[Crane] Change back arrow to be onSurface color 🔙

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/CalendarActivity.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/CalendarActivity.kt
@@ -21,7 +21,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -29,11 +28,14 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsTopHeight
+import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.samples.crane.R
 import androidx.compose.samples.crane.calendar.model.CalendarDay
@@ -42,7 +44,6 @@ import androidx.compose.samples.crane.calendar.model.DaySelected
 import androidx.compose.samples.crane.data.CalendarYear
 import androidx.compose.samples.crane.ui.CraneTheme
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
@@ -124,9 +125,10 @@ private fun CalendarTopAppBar(selectedDates: String, onBackPressed: () -> Unit) 
             },
             navigationIcon = {
                 IconButton(onClick = { onBackPressed() }) {
-                    Image(
-                        painter = painterResource(R.drawable.ic_back),
-                        contentDescription = stringResource(R.string.cd_back)
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = stringResource(id = R.string.cd_back),
+                        tint = MaterialTheme.colors.onSurface
                     )
                 }
             },


### PR DESCRIPTION
## Description ✨

The back arrow was black on purple, this PR changes it to use `onSurface` color. 


## Screenshots 📸 
 
| Before | After |
|----|----|
| ![image](https://user-images.githubusercontent.com/9973046/160102286-2d2ceecb-3d7f-4972-8fee-32d4f59ff829.png) | ![Screenshot_1648203482](https://user-images.githubusercontent.com/9973046/160102221-54a01fa7-9f5e-4740-8785-3a1538f2a880.png) |