### PR TITLE
[Crane] Fix issue with "Choose Destination" text being editable

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/base/BaseUserInput.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/base/BaseUserInput.kt
@@ -89,27 +89,32 @@ fun CraneEditableUserInput(
     @DrawableRes vectorImageId: Int? = null,
     onInputChanged: (String) -> Unit
 ) {
-    var textFieldState by remember { mutableStateOf(TextFieldValue(text = hint)) }
-    val isHint = { textFieldState.text == hint }
-
+    var textFieldState by remember { mutableStateOf(TextFieldValue()) }
     CraneBaseUserInput(
         caption = caption,
-        tintIcon = { !isHint() },
-        showCaption = { !isHint() },
+        tintIcon = {
+            textFieldState.text.isNotEmpty()
+        },
+        showCaption = { textFieldState.text.isEmpty() },
         vectorImageId = vectorImageId
     ) {
         BasicTextField(
             value = textFieldState,
             onValueChange = {
                 textFieldState = it
-                if (!isHint()) onInputChanged(textFieldState.text)
+                onInputChanged(textFieldState.text)
             },
-            textStyle = if (isHint()) {
-                captionTextStyle.copy(color = LocalContentColor.current)
-            } else {
-                MaterialTheme.typography.body1.copy(color = LocalContentColor.current)
-            },
-            cursorBrush = SolidColor(LocalContentColor.current)
+            textStyle = MaterialTheme.typography.body1.copy(color = LocalContentColor.current),
+            cursorBrush = SolidColor(LocalContentColor.current),
+            decorationBox = { innerTextField ->
+                if (hint.isNotEmpty() && textFieldState.text.isEmpty()) {
+                    Text(
+                        text = hint,
+                        style = captionTextStyle.copy(color = LocalContentColor.current)
+                    )
+                }
+                innerTextField()
+            }
         )
     }
 }

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/base/BaseUserInput.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/base/BaseUserInput.kt
@@ -95,7 +95,9 @@ fun CraneEditableUserInput(
         tintIcon = {
             textFieldState.text.isNotEmpty()
         },
-        showCaption = { textFieldState.text.isEmpty() },
+        showCaption = {
+            textFieldState.text.isNotEmpty()
+        },
         vectorImageId = vectorImageId
     ) {
         BasicTextField(


### PR DESCRIPTION
## Description

Previously when clicking on the "Choose Destination" text in the C


rane app, it would let you start editing the hint.  This PR introduces a change that uses `decorationBox` to draw the hint as a separate `Text` field, similar to the way in which Material `TextField` works. 

## Screenshots






| Before | After |
|-------|-------|
| https://user-images.githubusercontent.com/9973046/160439435-405447cf-4b1d-4d91-aa4d-13c18b0efcc7.mp4 | https://user-images.githubusercontent.com/9973046/160439498-4b312a1b-c8cc-4991-8fac-681f839a1f54.mp4  |