### PR TITLE
[Crane] Set the onClick label for DayContainer fix #766

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/Calendar.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/Calendar.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.text
@@ -185,9 +186,7 @@ private fun DayContainer(
     onClick: () -> Unit = { },
     onClickEnabled: Boolean = true,
     backgroundColor: Color = Color.Transparent,
-    // TODO: Determine the best way to pass the onClickLabel via the updated Surface API
-    // https://github.com/android/compose-samples/issues/766
-    @Suppress("UNUSED_PARAMETER") onClickLabel: String? = null,
+    onClickLabel: String? = null,
     content: @Composable () -> Unit
 ) {
     // What if this doesn't fit the screen? - LayoutFlexible(1f) + LayoutAspectRatio(1f)
@@ -201,6 +200,7 @@ private fun DayContainer(
                 if (onClickEnabled) {
                     modifier.semantics {
                         stateDescription = stateDescriptionLabel
+                        onClick(label = onClickLabel, action = null)
                     }
                 } else {
                     modifier.clearAndSetSemantics { }
@@ -208,7 +208,6 @@ private fun DayContainer(
             ),
         onClick = onClick,
         enabled = onClickEnabled,
-        selected = selected,
         color = backgroundColor,
     ) {
         content()


### PR DESCRIPTION
This specifies the onClick label to use for the individual calendar
days. I also stopped passing the selected boolean to Surface. When it is
passed, that uses the selectable version of Surface which announces the
composable as a Tab and automatically states "selected" at the start of
the announcement when selected==true but does not announce anything at
the start when not selected.

Instead, it's now using the clickable version of Surface, so our
announcements are like:

"{Selected/not selected}, January 1st 2020, Button, Double-tap to
select"

This seems reasonable, since the other Roles are Checkbox, Switch,
RadioButton, and Image, all of which seem less correct than Button.