### PR TITLE
[Crane]: Update Maps Compose to 2.1.0

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/details/DetailsActivity.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/details/DetailsActivity.kt
@@ -62,6 +62,7 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -200,7 +201,7 @@ fun CityMapView(
         },
         onZoomChanged = onZoomChanged
     ) {
-        Marker(position = cityLocation)
+        Marker(state = MarkerState(position = cityLocation))
     }
 }
 

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -25,7 +25,7 @@ object Libs {
     const val ktLint = "com.pinterest:ktlint:${Versions.ktLint}"
 
     object GoogleMaps {
-        const val composeMaps = "com.google.maps.android:maps-compose:1.2.0"
+        const val composeMaps = "com.google.maps.android:maps-compose:2.1.0"
         const val maps = "com.google.android.gms:play-services-maps:18.0.2"
     }
 


### PR DESCRIPTION
Update Maps Compose to the latest version [v2.1.0](https://github.com/googlemaps/android-maps-compose/releases/tag/v2.1.0).
