### PR TITLE
[All] Add a script to update all sample Compose versions

### DIFF
--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -17,6 +17,7 @@
 buildscript {
     ext.kotlin_version = '1.6.10'
     ext.compose_version = '1.2.0-alpha06'
+    ext.compose_snapshot_version = ''
     ext.coroutines_version = '1.6.0'
     ext.accompanist_version = '0.24.4-alpha'
 
@@ -39,6 +40,11 @@ subprojects {
     repositories {
         google()
         mavenCentral()
+
+        if (!compose_snapshot_version.isEmpty()) {
+            maven { url "https://androidx.dev/snapshots/builds/" +
+                    "${compose_snapshot_version}/artifacts/repository/" }
+        }
     }
 
     apply plugin: 'com.diffplug.spotless'

--- a/scripts/upgrade_samples.sh
+++ b/scripts/upgrade_samples.sh
@@ -33,36 +33,36 @@ read snapshot_version;
 
 echo "Upgrading to $compose_version snapshot $snapshot_version"
 
-# Upgrade Dependencies.kt
-# for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
-#     echo $DEPENDENCIES_FILE;
-#     COMPOSE_BLOCK=false;
-#     while IFS= read -r line; do
-#         if [[ $line == *"val version ="* ]] && $COMPOSE_BLOCK = true; then
-#             echo "$line" | sed -En 's/".*"/"'$compose_version'"/p'
-#         elif [[ $line == *"val snapshot ="* ]] && $COMPOSE_BLOCK = true; then
-#             echo "$line" | sed -En 's/".*"/"'$snapshot_version'"/p'
-#         else
-#             if [[ $line == *"object Compose {"* ]]; then
-#                 COMPOSE_BLOCK=true;
-#             elif [[ $line == *"}"* ]]; then
-#                 COMPOSE_BLOCK=false;
-#             fi
-#             echo "$line";
-#         fi
-#     done < $DEPENDENCIES_FILE > "${DEPENDENCIES_FILE}_new"
-#     mv "${DEPENDENCIES_FILE}_new" $DEPENDENCIES_FILE
-# done
+# Change Dependencies.kt versions
+for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
+    echo $DEPENDENCIES_FILE;
+    COMPOSE_BLOCK=false;
+    while IFS= read -r line; do
+        if [[ $line == *"val version ="* ]] && $COMPOSE_BLOCK = true; then
+            echo "$line" | sed -En 's/".*"/"'$compose_version'"/p'
+        elif [[ $line == *"val snapshot ="* ]] && $COMPOSE_BLOCK = true; then
+            echo "$line" | sed -En 's/".*"/"'$snapshot_version'"/p'
+        else
+            if [[ $line == *"object Compose {"* ]]; then
+                COMPOSE_BLOCK=true;
+            elif [[ $line == *"}"* ]]; then
+                COMPOSE_BLOCK=false;
+            fi
+            echo "$line";
+        fi
+    done < $DEPENDENCIES_FILE > "${DEPENDENCIES_FILE}_new"
+    mv "${DEPENDENCIES_FILE}_new" $DEPENDENCIES_FILE
+done
 
-# Upgrade build.gradle
+# Change build.gradle versions
 for DEPENDENCIES_FILE in `find . -type f -iname "build.gradle"` ; do
     echo $DEPENDENCIES_FILE;
     
     while IFS= read -r line; do
         if [[ $line == *"ext.compose_version ="* ]]; then
             echo "$line" | sed -En "s/\'.*'/\'$compose_version\'/p"
-        elif [[ $line == *"val snapshot ="* ]] && $COMPOSE_BLOCK = true; then
-            echo "$line" | sed -En 's/".*"/"'$snapshot_version'"/p'
+        elif [[ $line == *"ext.compose_snapshot_version ="* ]]; then
+            echo "$line" | sed -En "s/\'.*'/\'$snapshot_version\'/p"
         else
             echo "$line";
         fi

--- a/scripts/upgrade_samples.sh
+++ b/scripts/upgrade_samples.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################################################################
+#
+# Changes all samples to a new Compose version
+#
+# Example: To run 
+#     ./scripts/upgrade_samples.sh
+#
+########################################################################
+
+set -e
+
+echo "Version to change Compose to (e.g 1.2.0-alpha06): ";
+read compose_version;
+
+echo "Snapshot ID: (Blank for none)";
+read snapshot_version;
+
+echo "Upgrading to $compose_version snapshot $snapshot_version"
+
+for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
+    echo $DEPENDENCIES_FILE;
+    COMPOSE_BLOCK=false;
+    while IFS= read -r line; do
+        if [[ $line == *"val version ="* ]] && $COMPOSE_BLOCK = true; then
+            echo "$line" | sed -En 's/".*"/"'$compose_version'"/p'
+        elif [[ $line == *"val snapshot ="* ]] && $COMPOSE_BLOCK = true; then
+            echo "$line" | sed -En 's/".*"/"'$snapshot_version'"/p'
+        else
+            if [[ $line == *"object Compose {"* ]]; then
+                COMPOSE_BLOCK=true;
+            elif [[ $line == *"}"* ]]; then
+                COMPOSE_BLOCK=false;
+            fi
+            echo "$line";
+        fi
+    done < $DEPENDENCIES_FILE > "${DEPENDENCIES_FILE}_new"
+    mv "${DEPENDENCIES_FILE}_new" $DEPENDENCIES_FILE
+done
+

--- a/scripts/upgrade_samples.sh
+++ b/scripts/upgrade_samples.sh
@@ -33,20 +33,37 @@ read snapshot_version;
 
 echo "Upgrading to $compose_version snapshot $snapshot_version"
 
-for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
+# Upgrade Dependencies.kt
+# for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
+#     echo $DEPENDENCIES_FILE;
+#     COMPOSE_BLOCK=false;
+#     while IFS= read -r line; do
+#         if [[ $line == *"val version ="* ]] && $COMPOSE_BLOCK = true; then
+#             echo "$line" | sed -En 's/".*"/"'$compose_version'"/p'
+#         elif [[ $line == *"val snapshot ="* ]] && $COMPOSE_BLOCK = true; then
+#             echo "$line" | sed -En 's/".*"/"'$snapshot_version'"/p'
+#         else
+#             if [[ $line == *"object Compose {"* ]]; then
+#                 COMPOSE_BLOCK=true;
+#             elif [[ $line == *"}"* ]]; then
+#                 COMPOSE_BLOCK=false;
+#             fi
+#             echo "$line";
+#         fi
+#     done < $DEPENDENCIES_FILE > "${DEPENDENCIES_FILE}_new"
+#     mv "${DEPENDENCIES_FILE}_new" $DEPENDENCIES_FILE
+# done
+
+# Upgrade build.gradle
+for DEPENDENCIES_FILE in `find . -type f -iname "build.gradle"` ; do
     echo $DEPENDENCIES_FILE;
-    COMPOSE_BLOCK=false;
+    
     while IFS= read -r line; do
-        if [[ $line == *"val version ="* ]] && $COMPOSE_BLOCK = true; then
-            echo "$line" | sed -En 's/".*"/"'$compose_version'"/p'
+        if [[ $line == *"ext.compose_version ="* ]]; then
+            echo "$line" | sed -En "s/\'.*'/\'$compose_version\'/p"
         elif [[ $line == *"val snapshot ="* ]] && $COMPOSE_BLOCK = true; then
             echo "$line" | sed -En 's/".*"/"'$snapshot_version'"/p'
         else
-            if [[ $line == *"object Compose {"* ]]; then
-                COMPOSE_BLOCK=true;
-            elif [[ $line == *"}"* ]]; then
-                COMPOSE_BLOCK=false;
-            fi
             echo "$line";
         fi
     done < $DEPENDENCIES_FILE > "${DEPENDENCIES_FILE}_new"


### PR DESCRIPTION
This PR adds a script that will search all the sample projects for Compose versions and update them all at the same time to either a release like 1.2.0-alpha06 or a snapshot. In order to achieve this I had to add the ability for JetNews to use a snapshot version.

Used with:
`scripts/upgrade_samples.sh`

<img width="990" alt="Screen Shot 2022-04-05 at 3 38 43 pm" src="https://user-images.githubusercontent.com/19445/161686704-f69c20aa-6f91-4f16-9619-1473d377c15e.png">
