### PR TITLE
[All] Update to Compose 1.2.0-alpha07

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/Calendar.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/Calendar.kt
@@ -17,16 +17,21 @@
 package androidx.compose.samples.crane.calendar
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumedWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -64,6 +69,7 @@ import androidx.compose.ui.unit.dp
 
 typealias CalendarWeek = List<CalendarDay>
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun Calendar(
     calendarYear: CalendarYear,
@@ -72,12 +78,13 @@ fun Calendar(
     contentPadding: PaddingValues = PaddingValues()
 ) {
     LazyColumn(
-        modifier = modifier,
+        modifier = modifier.consumedWindowInsets(contentPadding),
         contentPadding = contentPadding
     ) {
         for (month in calendarYear) {
             itemsCalendarMonth(month = month, onDayClicked = onDayClicked)
         }
+        item { Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars)) }
     }
 }
 

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/Calendar.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/Calendar.kt
@@ -17,18 +17,16 @@
 package androidx.compose.samples.crane.calendar
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -70,13 +68,16 @@ typealias CalendarWeek = List<CalendarDay>
 fun Calendar(
     calendarYear: CalendarYear,
     onDayClicked: (CalendarDay, CalendarMonth) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues()
 ) {
-    LazyColumn(modifier) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = contentPadding
+    ) {
         for (month in calendarYear) {
             itemsCalendarMonth(month = month, onDayClicked = onDayClicked)
         }
-        item { Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars)) }
     }
 }
 

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/CalendarActivity.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/CalendarActivity.kt
@@ -102,8 +102,12 @@ private fun CalendarContent(
         topBar = {
             CalendarTopAppBar(selectedDates, onBackPressed)
         }
-    ) {
-        Calendar(calendarYear, onDayClicked)
+    ) { contentPadding ->
+        Calendar(
+            calendarYear = calendarYear,
+            onDayClicked = onDayClicked,
+            contentPadding = contentPadding
+        )
     }
 }
 

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/home/CraneHome.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/home/CraneHome.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.samples.crane.home
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.BackdropScaffold
 import androidx.compose.material.BackdropValue
@@ -61,10 +62,10 @@ fun CraneHome(
         drawerContent = {
             CraneDrawer()
         }
-    ) {
+    ) { contentPadding ->
         val scope = rememberCoroutineScope()
         CraneHomeContent(
-            modifier = modifier,
+            modifier = modifier.padding(contentPadding),
             onExploreItemClicked = onExploreItemClicked,
             onDateSelectionClicked = onDateSelectionClicked,
             openDrawer = {

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -55,7 +55,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.2.0-alpha06"
+            const val version = "1.2.0-alpha07"
 
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val runtimeLivedata = "androidx.compose.runtime:runtime-livedata:$version"

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     ext.compose_version = '1.2.0-alpha07'
     ext.compose_snapshot_version = ''
     ext.coroutines_version = '1.6.0'
-    ext.accompanist_version = '0.24.4-alpha'
+    ext.accompanist_version = '0.24.6-alpha'
 
     repositories {
         google()

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext.kotlin_version = '1.6.10'
-    ext.compose_version = '1.2.0-alpha06'
+    ext.compose_version = '1.2.0-alpha07'
     ext.compose_snapshot_version = ''
     ext.coroutines_version = '1.6.0'
     ext.accompanist_version = '0.24.4-alpha'

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -70,7 +70,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.2.0-alpha06"
+            const val version = "1.2.0-alpha07"
 
             @get:JvmStatic
             val snapshotUrl: String

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -25,7 +25,7 @@ object Libs {
     const val jdkDesugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object Accompanist {
-        const val version = "0.24.5-alpha"
+        const val version = "0.24.6-alpha"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }
 

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -52,7 +52,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.2.0-alpha06"
+            const val version = "1.2.0-alpha07"
 
             const val foundation = "androidx.compose.foundation:foundation:$version"
             const val layout = "androidx.compose.foundation:foundation-layout:$version"

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
@@ -73,6 +73,7 @@ import com.example.jetsnack.ui.components.JetsnackSurface
 import com.example.jetsnack.ui.home.cart.Cart
 import com.example.jetsnack.ui.home.search.Search
 import com.example.jetsnack.ui.theme.JetsnackTheme
+import java.util.*
 
 fun NavGraphBuilder.addHomeGraph(
     onSnackSelected: (Long, NavBackStackEntry) -> Unit,
@@ -130,6 +131,10 @@ fun JetsnackBottomBar(
             animSpec = springSpec,
             modifier = Modifier.navigationBarsPadding()
         ) {
+            val configuration = LocalConfiguration.current
+            val currentLocale: Locale =
+                ConfigurationCompat.getLocales(configuration).get(0) ?: Locale.getDefault()
+
             tabs.forEach { section ->
                 val selected = section == currentSection
                 val tint by animateColorAsState(
@@ -140,11 +145,7 @@ fun JetsnackBottomBar(
                     }
                 )
 
-                val text = stringResource(section.title).uppercase(
-                    ConfigurationCompat.getLocales(
-                        LocalConfiguration.current
-                    ).get(0)
-                )
+                val text = stringResource(section.title).uppercase(currentLocale)
 
                 JetsnackBottomNavigationItem(
                     icon = {

--- a/Jetsnack/build.gradle
+++ b/Jetsnack/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 
 plugins {
     id 'com.diffplug.spotless' version '6.3.0'
-    id 'com.android.test' version '7.3.0-alpha05' apply false
+    id 'com.android.test' version '7.3.0-alpha07' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
 }
 

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -21,7 +21,7 @@ object Versions {
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.3.0-alpha05"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.3.0-alpha07"
 
     object Accompanist {
         const val version = "0.24.5-alpha"
@@ -49,7 +49,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.2.0-alpha06"
+            const val version = "1.2.0-alpha07"
 
             const val foundation = "androidx.compose.foundation:foundation:${version}"
             const val layout = "androidx.compose.foundation:foundation-layout:${version}"

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -24,7 +24,7 @@ object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.3.0-alpha07"
 
     object Accompanist {
-        const val version = "0.24.5-alpha"
+        const val version = "0.24.6-alpha"
         const val systemuicontroller = "com.google.accompanist:accompanist-systemuicontroller:$version"
         const val flowlayouts = "com.google.accompanist:accompanist-flowlayout:$version"
     }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInScreen.kt
@@ -73,9 +73,10 @@ fun SignIn(onNavigationEvent: (SignInEvent) -> Unit) {
                 onBackPressed = { onNavigationEvent(SignInEvent.NavigateBack) }
             )
         },
-        content = {
+        content = { contentPadding ->
             SignInSignUpScreen(
                 modifier = Modifier.supportWideScreen(),
+                contentPadding = contentPadding,
                 onSignedInAsGuest = { onNavigationEvent(SignInEvent.SignInAsGuest) }
             ) {
                 Column(modifier = Modifier.fillMaxWidth()) {

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
@@ -18,6 +18,7 @@ package com.example.compose.jetsurvey.signinsignup
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -66,9 +67,13 @@ import com.example.compose.jetsurvey.R
 fun SignInSignUpScreen(
     onSignedInAsGuest: () -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
     content: @Composable() () -> Unit
 ) {
-    LazyColumn(modifier = modifier) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = contentPadding
+    ) {
         item {
             Spacer(modifier = Modifier.height(44.dp))
             Box(

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignUpScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignUpScreen.kt
@@ -56,9 +56,10 @@ fun SignUp(onNavigationEvent: (SignUpEvent) -> Unit) {
                 onBackPressed = { onNavigationEvent(SignUpEvent.NavigateBack) }
             )
         },
-        content = {
+        content = { contentPadding ->
             SignInSignUpScreen(
                 onSignedInAsGuest = { onNavigationEvent(SignUpEvent.SignInAsGuest) },
+                contentPadding = contentPadding,
                 modifier = Modifier.supportWideScreen()
             ) {
                 Column {

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -61,7 +61,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.2.0-alpha06"
+            const val version = "1.2.0-alpha07"
 
             @get:JvmStatic
             val snapshotUrl: String

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -27,7 +27,7 @@ object Libs {
     const val junit = "junit:junit:4.13"
 
     object Accompanist {
-        const val version = "0.24.5-alpha"
+        const val version = "0.24.6-alpha"
         const val permissions = "com.google.accompanist:accompanist-permissions:$version"
     }
 

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -52,7 +52,7 @@ object Libs {
 
         object Compose {
             const val snapshot = ""
-            const val version = "1.2.0-alpha06"
+            const val version = "1.2.0-alpha07"
 
             const val animation = "androidx.compose.animation:animation:$version"
             const val foundation = "androidx.compose.foundation:foundation:$version"


### PR DESCRIPTION
Fixes new lint error when you leave the `Scaffold` `contentPadding` parameter unused. 

I switched out some implementations of window insets to the recommended version for this.
- With LazyLists I used `contentPadding` so the content still scrolls under the edge of the screen
- With other layouts just `modifier.padding(contentPadding)` is enough