### PR TITLE
[JetSnack] Move scroll state reads into layout phase via lambdas

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetail.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetail.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -50,7 +51,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
@@ -102,8 +103,8 @@ fun SnackDetail(
         val scroll = rememberScrollState(0)
         Header()
         Body(related, scroll)
-        Title(snack, scroll.value)
-        Image(snack.imageUrl, scroll.value)
+        Title(snack) { scroll.value }
+        Image(snack.imageUrl) { scroll.value }
         Up(upPress)
         CartBottomBar(modifier = Modifier.align(Alignment.BottomCenter))
     }
@@ -237,16 +238,20 @@ private fun Body(
 }
 
 @Composable
-private fun Title(snack: Snack, scroll: Int) {
+private fun Title(snack: Snack, scrollProvider: () -> Int) {
     val maxOffset = with(LocalDensity.current) { MaxTitleOffset.toPx() }
     val minOffset = with(LocalDensity.current) { MinTitleOffset.toPx() }
-    val offset = (maxOffset - scroll).coerceAtLeast(minOffset)
+
     Column(
         verticalArrangement = Arrangement.Bottom,
         modifier = Modifier
             .heightIn(min = TitleHeight)
             .statusBarsPadding()
-            .graphicsLayer { translationY = offset }
+            .offset {
+                val scroll = scrollProvider()
+                val offset = (maxOffset - scroll).coerceAtLeast(minOffset)
+                IntOffset(x = 0, y = offset.toInt())
+            }
             .background(color = JetsnackTheme.colors.uiBackground)
     ) {
         Spacer(Modifier.height(16.dp))
@@ -279,13 +284,15 @@ private fun Title(snack: Snack, scroll: Int) {
 @Composable
 private fun Image(
     imageUrl: String,
-    scroll: Int
+    scrollProvider: () -> Int
 ) {
     val collapseRange = with(LocalDensity.current) { (MaxTitleOffset - MinTitleOffset).toPx() }
-    val collapseFraction = (scroll / collapseRange).coerceIn(0f, 1f)
+    val collapseFractionProvider = {
+        (scrollProvider() / collapseRange).coerceIn(0f, 1f)
+    }
 
     CollapsingImageLayout(
-        collapseFraction = collapseFraction,
+        collapseFractionProvider = collapseFractionProvider,
         modifier = HzPadding.then(Modifier.statusBarsPadding())
     ) {
         SnackImage(
@@ -298,7 +305,7 @@ private fun Image(
 
 @Composable
 private fun CollapsingImageLayout(
-    collapseFraction: Float,
+    collapseFractionProvider: () -> Float,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
@@ -307,6 +314,8 @@ private fun CollapsingImageLayout(
         content = content
     ) { measurables, constraints ->
         check(measurables.size == 1)
+
+        val collapseFraction = collapseFractionProvider()
 
         val imageMaxSize = min(ExpandedImageSize.roundToPx(), constraints.maxWidth)
         val imageMinSize = max(CollapsedImageSize.roundToPx(), constraints.minWidth)


### PR DESCRIPTION
Fixes janky scrolling on the JetSnack details page.
Fixes #231 

It should not be necessary to recompose just to relayout a page. JetSnack has a collapsing toolbar like layout on the details page, it shrinks the image and moves the title text up on scroll. This was previously done using in composition but by moving the read of the scroll value into a lambda, we can read the value only during layout and skip the composition phase entirely.