### PR TITLE
Adding CODEOWNERS file for PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 /Crane/ @riggaroo
 /JetNews/ @JolandaVerhoef
 /Jetcaster/ @ricknout
-/Jetchat/ @astomato
+/Jetchat/ @astamato
 /Jetsnack/ @bentrengrove
 /Jetsurvey/ @IanGClifton
 /Owl/ @simona-anomis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+* @android/compose-devrel
+
+/Crane/ @riggaroo
+/JetNews/ @JolandaVerhoef
+/Jetcaster/ @ricknout
+/Jetchat/ @astomato
+/Jetsnack/ @bentrengrove
+/Jetsurvey/ @IanGClifton
+/Owl/ @simona-anomis


### PR DESCRIPTION
Adding CODEOWNERS per sample and overall codeowners. This will help with automatic assigning of code reviews to people.