### PR TITLE
Create blunderbuss.yml config to assign issues to compose devrel

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,0 +1,3 @@
+assign_issues:
+  - android/compose-devrel
+  


### PR DESCRIPTION
Create blunderbuss.yml, for auto assignment of new open issues to @android/compose-devrel team members. 