### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,1 @@
 * @android/compose-devrel
-
-/Crane/ @riggaroo
-/JetNews/ @JolandaVerhoef
-/Jetcaster/ @ricknout
-/Jetchat/ @astamato
-/Jetsnack/ @bentrengrove
-/Jetsurvey/ @IanGClifton
-/Owl/ @simona-anomis


### PR DESCRIPTION
Current config doesn't allow any code owner to approve PRs that aren't in their directory. This is limiting us and creating individual bottlenecks - even when PRs are approved. Updating to allow any codeowner to approve any sample changes. 