### PR TITLE
Maintenance: Cancel in progress builds when new changes are triggered

### DIFF
--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -11,7 +11,9 @@ on:
     paths:
       - '.github/workflows/Crane.yaml'
       - 'Crane/**'
-
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 env:
   SAMPLE_PATH: Crane
 

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -11,7 +11,9 @@ on:
     paths:
       - '.github/workflows/JetNews.yaml'
       - 'JetNews/**'
-
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 env:
   SAMPLE_PATH: JetNews
 

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -11,7 +11,9 @@ on:
     paths:
       - '.github/workflows/Jetcaster.yaml'
       - 'Jetcaster/**'
-
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 env:
   SAMPLE_PATH: Jetcaster
 

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -11,7 +11,9 @@ on:
     paths:
       - '.github/workflows/Jetchat.yaml'
       - 'Jetchat/**'
-
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 env:
   SAMPLE_PATH: Jetchat
 

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -11,7 +11,9 @@ on:
     paths:
       - '.github/workflows/Jetsnack.yaml'
       - 'Jetsnack/**'
-
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 env:
   SAMPLE_PATH: Jetsnack
 

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -11,7 +11,9 @@ on:
     paths:
       - '.github/workflows/Jetsurvey.yaml'
       - 'Jetsurvey/**'
-
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 env:
   SAMPLE_PATH: Jetsurvey
 

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -11,7 +11,9 @@ on:
     paths:
       - '.github/workflows/Owl.yaml'
       - 'Owl/**'
-
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 env:
   SAMPLE_PATH: Owl
 


### PR DESCRIPTION
As per this SO - adding Concurrency section into action pipeline - this will terminate in progress actions when a new push on that branch occurs. 