### PR TITLE
Remove CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @android/compose-devrel


### PR DESCRIPTION
Removing CODEOWNERS file as the config under `.github/blunderbuss.yml` will auto-assign issues and PRs. Blunderbuss guarantees only one person will be assigned to an issue/PR rather than the whole team.
