### PR TITLE
[Crane] Paddings in landscape mode

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/CalendarScreen.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/calendar/CalendarScreen.kt
@@ -20,8 +20,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -66,6 +70,9 @@ private fun CalendarContent(
     onBackPressed: () -> Unit
 ) {
     Scaffold(
+        modifier = Modifier.windowInsetsPadding(
+            WindowInsets.navigationBars.only(WindowInsetsSides.Start + WindowInsetsSides.End)
+        ),
         backgroundColor = MaterialTheme.colors.primary,
         topBar = {
             CalendarTopAppBar(calendarState, onBackPressed)

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/home/MainActivity.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/home/MainActivity.kt
@@ -30,7 +30,12 @@ import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -111,7 +116,12 @@ fun MainScreen(
     onDateSelectionClicked: () -> Unit,
     mainViewModel: MainViewModel
 ) {
-    Surface(color = MaterialTheme.colors.primary) {
+    Surface(
+        modifier = Modifier.windowInsetsPadding(
+            WindowInsets.navigationBars.only(WindowInsetsSides.Start + WindowInsetsSides.End)
+        ),
+        color = MaterialTheme.colors.primary
+    ) {
         val transitionState = remember { MutableTransitionState(mainViewModel.shownSplash.value) }
         val transition = updateTransition(transitionState, label = "splashTransition")
         val splashAlpha by transition.animateFloat(


### PR DESCRIPTION
Update paddings in landscape mode for main and calendar screens.
----
 - Before
![Screenshot_20220512-165759_Crane](https://user-images.githubusercontent.com/48360685/168246316-cd699e0d-e221-449a-9ef4-cf1968fcd07b.jpg)
![Screenshot_20220513-103110_Crane](https://user-images.githubusercontent.com/48360685/168246397-8a0fb5a4-5879-4cc1-b3ab-13954ab0f0d2.jpg)
![Screenshot_20220512-170354_Crane](https://user-images.githubusercontent.com/48360685/168246479-73b5ca36-7527-45d0-992e-751ac823f9b5.jpg)
 - After
![Screenshot_20220513-112639_Crane](https://user-images.githubusercontent.com/48360685/168246628-a3355681-5797-4166-a003-f3ea004226ce.jpg)
![Screenshot_20220513-110353_Crane](https://user-images.githubusercontent.com/48360685/168246736-32281207-138a-4b64-b019-ff0c5aa18868.jpg)
