### PR TITLE
[Jetsurvey] Updated date handling to use UTC only

### DIFF
--- a/Jetsurvey/app/build.gradle
+++ b/Jetsurvey/app/build.gradle
@@ -114,4 +114,10 @@ dependencies {
     implementation Libs.Accompanist.permissions
 
     implementation Libs.Coil.coilCompose
+
+    testImplementation Libs.junit
+    testImplementation Libs.AndroidX.Test.core
+    testImplementation Libs.AndroidX.Test.Ext.junit
+    testImplementation Libs.AndroidX.Test.Ext.truth
+    testImplementation Libs.Robolectric.robolectric
 }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/Survey.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/Survey.kt
@@ -45,7 +45,7 @@ data class Question(
 enum class SurveyActionType { PICK_DATE, TAKE_PHOTO, SELECT_CONTACT }
 
 sealed class SurveyActionResult {
-    data class Date(val date: String) : SurveyActionResult()
+    data class Date(val dateMillis: Long) : SurveyActionResult()
     data class Photo(val uri: Uri) : SurveyActionResult()
     data class Contact(val contact: String) : SurveyActionResult()
 }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
@@ -94,10 +94,10 @@ class SurveyFragment : Fragment() {
         val picker = MaterialDatePicker.Builder.datePicker()
             .setSelection(date)
             .build()
-        activity?.let {
-            picker.show(it.supportFragmentManager, picker.toString())
-            picker.addOnPositiveButtonClickListener {
-                viewModel.onDatePicked(questionId, picker.selection)
+        picker.show(requireActivity().supportFragmentManager, picker.toString())
+        picker.addOnPositiveButtonClickListener {
+            picker.selection?.let { selectedDate ->
+                viewModel.onDatePicked(questionId, selectedDate)
             }
         }
     }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -646,9 +646,9 @@ private fun PhotoQuestion(
  */
 fun getDefaultDateInMillis(): Long {
     val cal = Calendar.getInstance()
-    val year  = cal.get(Calendar.YEAR)
+    val year = cal.get(Calendar.YEAR)
     val month = cal.get(Calendar.MONTH)
-    val date  = cal.get(Calendar.DATE)
+    val date = cal.get(Calendar.DATE)
     cal.clear()
     cal.set(year, month, date)
     return cal.timeInMillis

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyQuestions.kt
@@ -77,8 +77,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.util.*
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -642,6 +641,19 @@ private fun PhotoQuestion(
     }
 }
 
+/**
+ * Returns the start of today in milliseconds
+ */
+fun getDefaultDateInMillis(): Long {
+    val cal = Calendar.getInstance()
+    val year  = cal.get(Calendar.YEAR)
+    val month = cal.get(Calendar.MONTH)
+    val date  = cal.get(Calendar.DATE)
+    cal.clear()
+    cal.set(year, month, date)
+    return cal.timeInMillis
+}
+
 @Composable
 private fun DateQuestion(
     questionId: Int,
@@ -649,11 +661,17 @@ private fun DateQuestion(
     onAction: (Int, SurveyActionType) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val date = if (answer != null && answer.result is SurveyActionResult.Date) {
-        answer.result.date
+    val timestamp = if (answer != null && answer.result is SurveyActionResult.Date) {
+        answer.result.dateMillis
     } else {
-        SimpleDateFormat(simpleDateFormatPattern, Locale.getDefault()).format(Date())
+        getDefaultDateInMillis()
     }
+
+    // All times are stored in UTC, so generate the display from UTC also
+    val dateFormat = SimpleDateFormat(simpleDateFormatPattern, Locale.getDefault())
+    dateFormat.timeZone = TimeZone.getTimeZone("UTC")
+    val dateString = dateFormat.format(timestamp)
+
     Button(
         onClick = { onAction(questionId, SurveyActionType.PICK_DATE) },
         colors = ButtonDefaults.buttonColors(
@@ -669,7 +687,7 @@ private fun DateQuestion(
 
     ) {
         Text(
-            text = date,
+            text = dateString,
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1.8f)

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyRepository.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyRepository.kt
@@ -108,16 +108,22 @@ private val jetpackSurvey = Survey(
     questions = jetpackQuestions
 )
 
-object SurveyRepository {
+object JetpackSurveyRepository : SurveyRepository {
 
-    suspend fun getSurvey() = jetpackSurvey
+    override fun getSurvey() = jetpackSurvey
 
     @Suppress("UNUSED_PARAMETER")
-    fun getSurveyResult(answers: List<Answer<*>>): SurveyResult {
+    override fun getSurveyResult(answers: List<Answer<*>>): SurveyResult {
         return SurveyResult(
             library = "Compose",
             result = R.string.survey_result,
             description = R.string.survey_result_description
         )
     }
+}
+
+interface SurveyRepository {
+    fun getSurvey() : Survey
+
+    fun getSurveyResult(answers: List<Answer<*>>): SurveyResult
 }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyRepository.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyRepository.kt
@@ -123,7 +123,7 @@ object JetpackSurveyRepository : SurveyRepository {
 }
 
 interface SurveyRepository {
-    fun getSurvey() : Survey
+    fun getSurvey(): Survey
 
     fun getSurveyResult(answers: List<Answer<*>>): SurveyResult
 }

--- a/Jetsurvey/app/src/test/java/com/example/compose/jetsurvey/survey/SurveyViewModelTest.kt
+++ b/Jetsurvey/app/src/test/java/com/example/compose/jetsurvey/survey/SurveyViewModelTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.compose.jetsurvey.survey
 
 import androidx.test.core.app.ApplicationProvider
@@ -53,5 +69,4 @@ class TestSurveyRepository : SurveyRepository {
     override fun getSurveyResult(answers: List<Answer<*>>): SurveyResult {
         TODO("Not yet implemented")
     }
-
 }

--- a/Jetsurvey/app/src/test/java/com/example/compose/jetsurvey/survey/SurveyViewModelTest.kt
+++ b/Jetsurvey/app/src/test/java/com/example/compose/jetsurvey/survey/SurveyViewModelTest.kt
@@ -1,0 +1,57 @@
+package com.example.compose.jetsurvey.survey
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SurveyViewModelTest {
+
+    private lateinit var viewModel: SurveyViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = SurveyViewModel(
+            TestSurveyRepository(),
+            PhotoUriManager(ApplicationProvider.getApplicationContext())
+        )
+    }
+
+    @Test
+    fun onDatePicked_storesValueCorrectly() {
+        // Select a date
+        val initialDateMilliseconds = 0L
+        viewModel.onDatePicked(dateQuestionId, initialDateMilliseconds)
+
+        // Get the stored date
+        val newDateMilliseconds = viewModel.getCurrentDate(dateQuestionId)
+
+        // Verify they're identical
+        assertThat(newDateMilliseconds).isEqualTo(initialDateMilliseconds)
+    }
+}
+
+const val dateQuestionId = 1
+class TestSurveyRepository : SurveyRepository {
+
+    private val testSurvey = Survey(
+        title = -1,
+        questions = listOf(
+            Question(
+                id = dateQuestionId,
+                questionText = -1,
+                answer = PossibleAnswer.Action(label = -1, SurveyActionType.PICK_DATE)
+            )
+        )
+    )
+
+    override fun getSurvey() = testSurvey
+
+    override fun getSurveyResult(answers: List<Answer<*>>): SurveyResult {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -24,7 +24,7 @@ object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.2.0"
     const val jdkDesugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
-    const val junit = "junit:junit:4.13"
+    const val junit = "junit:junit:4.13.2"
 
     object Accompanist {
         const val version = "0.24.8-beta"
@@ -92,12 +92,12 @@ object Libs {
 
         object Test {
             private const val version = "1.4.0"
-            const val core = "androidx.test:core:$version"
+            const val core = "androidx.test:core-ktx:$version"
             const val rules = "androidx.test:rules:$version"
 
             object Ext {
-                private const val version = "1.1.2"
-                const val junit = "androidx.test.ext:junit-ktx:$version"
+                const val junit = "androidx.test.ext:junit:1.1.3"
+                const val truth = "androidx.test.ext:truth:1.4.0"
             }
 
             const val espressoCore = "androidx.test.espresso:espresso-core:3.2.0"
@@ -106,5 +106,9 @@ object Libs {
 
     object Coil {
         const val coilCompose = "io.coil-kt:coil-compose:2.0.0"
+    }
+
+    object Robolectric {
+        const val robolectric = "org.robolectric:robolectric:4.5.1"
     }
 }


### PR DESCRIPTION
This fixes #745. The answers to date questions now store the date in
milliseconds and all calculations are based on UTC.