### PR TITLE
[Jetcaster] Fix Readme out-of-date

### DIFF
--- a/Jetcaster/README.md
+++ b/Jetcaster/README.md
@@ -55,7 +55,7 @@ Underneath, [`DominantColorState`](app/src/main/java/com/example/jetcaster/util/
 ### Others
 Some other notable things which are implemented:
 
-* Images are all provided from each podcast's RSS feed, and loaded using [Accompanist Coil](https://google.github.io/accompanist/coil/) library.
+* Images are all provided from each podcast's RSS feed, and loaded using [Coil][coil] library.
 
 ## Architecture
 The app is built in a Redux-style, where each UI 'screen' has its own [ViewModel][viewmodel], which exposes a single [StateFlow][stateflow] containing the entire view state. Each [ViewModel][viewmodel] is responsible for subscribing to any data streams required for the view, as well as exposing functions which allow the UI to send events.

--- a/Jetcaster/README.md
+++ b/Jetcaster/README.md
@@ -55,7 +55,6 @@ Underneath, [`DominantColorState`](app/src/main/java/com/example/jetcaster/util/
 ### Others
 Some other notable things which are implemented:
 
-* [`WindowInsets`](https://developer.android.com/reference/kotlin/android/view/WindowInsets) support is provided by the [Accompanist Insets](https://google.github.io/accompanist/insets/) library.
 * Images are all provided from each podcast's RSS feed, and loaded using [Accompanist Coil](https://google.github.io/accompanist/coil/) library.
 
 ## Architecture


### PR DESCRIPTION
Since WindowInsets and Coil are no longer supported by Accompanist, they have been removed from app dependencies, but still remain in Readme.

```kt
object Accompanist {
    const val version = "0.24.9-beta"
    const val pager = "com.google.accompanist:accompanist-pager:$version"
}
```

There is only Pager as Accompanist in the app dependencies.