### PR TITLE
Remove runs-on and timeout-minutes config from JetNews.yml

### DIFF
--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -11,72 +11,16 @@ on:
     paths:
       - '.github/workflows/Crane.yaml'
       - 'Crane/**'
-concurrency:
-  group: crane-build-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_dispatch:
 env:
   SAMPLE_PATH: Crane
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Generate cache key
-        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
-
-      - name: Check spotless
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck --stacktrace
-
-      - name: Check lint
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew lintDebug --stacktrace
-
-      - name: Build debug
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleDebug --stacktrace
-
-      - name: Build release
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleRelease --stacktrace
-
-      - name: Run local tests
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew testDebug --stacktrace
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-outputs
-          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
-
-      - name: Upload build reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-reports
-          path: ${{ env.SAMPLE_PATH }}/app/build/reports
+    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    with:
+      name: Crane
+      path: Crane
 
   test:
     needs: build

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -11,9 +11,6 @@ on:
     paths:
       - '.github/workflows/JetNews.yaml'
       - 'JetNews/**'
-concurrency:
-  group: jetnews-build-${{ github.ref }}
-  cancel-in-progress: true
 env:
   SAMPLE_PATH: JetNews
 
@@ -21,62 +18,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Generate cache key
-        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
-
-      - name: Check spotless
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck --stacktrace
-
-      - name: Check lint
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew lintDebug --stacktrace
-
-      - name: Build debug
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleDebug --stacktrace
-
-      - name: Build release
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleRelease --stacktrace
-
-      - name: Run local tests
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew testDebug --stacktrace
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-outputs
-          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
-
-      - name: Upload build reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-reports
-          path: ${{ env.SAMPLE_PATH }}/app/build/reports
+    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    with:
+      name: JetNews
+      path: JetNews
 
   androidTest:
     needs: build

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -16,8 +16,6 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
     uses: android/compose-samples/.github/workflows/build-sample.yml@main
     with:
       name: JetNews

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -11,69 +11,11 @@ on:
     paths:
       - '.github/workflows/Jetcaster.yaml'
       - 'Jetcaster/**'
-concurrency:
-  group: jetcaster-build-${{ github.ref }}
-  cancel-in-progress: true
-env:
-  SAMPLE_PATH: Jetcaster
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Generate cache key
-        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
-
-      - name: Check spotless
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck --stacktrace
-
-      - name: Check lint
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew lintDebug --stacktrace
-
-      - name: Build debug
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleDebug --stacktrace
-
-      - name: Build release
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleRelease --stacktrace
-
-      - name: Run local tests
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew testDebug --stacktrace
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-outputs
-          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
-
-      - name: Upload build reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-reports
-          path: ${{ env.SAMPLE_PATH }}/app/build/reports
+    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    with:
+      name: Jetcaster
+      path: Jetcaster

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -11,72 +11,15 @@ on:
     paths:
       - '.github/workflows/Jetchat.yaml'
       - 'Jetchat/**'
-concurrency:
-  group: jetchat-build-${{ github.ref }}
-  cancel-in-progress: true
 env:
   SAMPLE_PATH: Jetchat
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Generate cache key
-        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
-
-      - name: Check spotless
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck --stacktrace
-
-      - name: Check lint
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew lintDebug --stacktrace
-
-      - name: Build debug
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleDebug --stacktrace
-
-      - name: Build release
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleRelease --stacktrace
-
-      - name: Run local tests
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew testDebug --stacktrace
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-outputs
-          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
-
-      - name: Upload build reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-reports
-          path: ${{ env.SAMPLE_PATH }}/app/build/reports
+    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    with:
+      name: Jetchat
+      path: Jetchat
 
   test:
     needs: build

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -11,69 +11,10 @@ on:
     paths:
       - '.github/workflows/Jetsnack.yaml'
       - 'Jetsnack/**'
-concurrency:
-  group: jetsnack-build-${{ github.ref }}
-  cancel-in-progress: true
-env:
-  SAMPLE_PATH: Jetsnack
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Generate cache key
-        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
-
-      - name: Check spotless
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck --stacktrace
-
-      - name: Check lint
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew lintDebug --stacktrace
-
-      - name: Build debug
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleDebug --stacktrace
-
-      - name: Build release
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleRelease --stacktrace
-
-      - name: Run local tests
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew testDebug --stacktrace
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-outputs
-          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
-
-      - name: Upload build reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-reports
-          path: ${{ env.SAMPLE_PATH }}/app/build/reports
+    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    with:
+      name: Jetsnack
+      path: Jetsnack

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -11,69 +11,10 @@ on:
     paths:
       - '.github/workflows/Jetsurvey.yaml'
       - 'Jetsurvey/**'
-concurrency:
-  group: jetsurvey-build-${{ github.ref }}
-  cancel-in-progress: true
-env:
-  SAMPLE_PATH: Jetsurvey
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Generate cache key
-        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
-
-      - name: Check spotless
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck --stacktrace
-
-      - name: Check lint
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew lintDebug --stacktrace
-
-      - name: Build debug
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleDebug --stacktrace
-
-      - name: Build release
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleRelease --stacktrace
-
-      - name: Run local tests
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew testDebug --stacktrace
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-outputs
-          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
-
-      - name: Upload build reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-reports
-          path: ${{ env.SAMPLE_PATH }}/app/build/reports
+    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    with:
+      name: Jetsurvey
+      path: Jetsurvey

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -11,72 +11,15 @@ on:
     paths:
       - '.github/workflows/Owl.yaml'
       - 'Owl/**'
-concurrency:
-  group: owl-build-${{ github.ref }}
-  cancel-in-progress: true
 env:
   SAMPLE_PATH: Owl
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties        
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Generate cache key
-        run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
-
-      - name: Check spotless
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew spotlessCheck --stacktrace
-
-      - name: Check lint
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew lintDebug --stacktrace
-
-      - name: Build debug
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleDebug --stacktrace
-
-      - name: Build release
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew assembleRelease --stacktrace
-
-      - name: Run local tests
-        working-directory: ${{ env.SAMPLE_PATH }}
-        run: ./gradlew testDebug --stacktrace
-
-      - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-outputs
-          path: ${{ env.SAMPLE_PATH }}/app/build/outputs
-
-      - name: Upload build reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-reports
-          path: ${{ env.SAMPLE_PATH }}/app/build/reports
+    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    with:
+      name: Owl
+      path: Owl
 
   test:
     needs: build


### PR DESCRIPTION
* Reuse workflows (Re-revert 17db314ff3fd767d31c313de52ec6b346bc98677)
* Remove `runs-on` and `timeout-minutes` from `JetNews.yml` and inherits values from the reusable workflow

Fixes #817 