### PR TITLE
[JetSurvey] Use AnimatedContent to slide in and out changes between questions

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
@@ -22,11 +22,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts.TakePicture
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.with
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
@@ -68,12 +68,11 @@ class SurveyFragment : Fragment() {
                     AnimatedContent(
                         targetState = state,
                         transitionSpec = {
-                            fadeIn() +
-                                slideInVertically(
-                                    animationSpec =
-                                    tween(400),
-                                    initialOffsetY = { fullWidth -> fullWidth }
-                                ) with
+                            fadeIn() + slideIntoContainer(
+                                towards = AnimatedContentScope
+                                    .SlideDirection.Up,
+                                animationSpec = tween(600)
+                            ) with
                                 fadeOut(animationSpec = tween(200))
                         }
                     ) { targetState ->

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
@@ -71,10 +71,10 @@ class SurveyFragment : Fragment() {
                             fadeIn() +
                                 slideInVertically(
                                     animationSpec =
-                                    tween(400 * 3),
+                                    tween(400),
                                     initialOffsetY = { fullWidth -> fullWidth }
                                 ) with
-                                fadeOut(animationSpec = tween(200 * 3))
+                                fadeOut(animationSpec = tween(200))
                         }
                     ) { targetState ->
                         // It's important to use targetState and not state, as its critical to ensure

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
@@ -71,9 +71,9 @@ class SurveyFragment : Fragment() {
                             fadeIn() + slideIntoContainer(
                                 towards = AnimatedContentScope
                                     .SlideDirection.Up,
-                                animationSpec = tween(600)
+                                animationSpec = tween(ANIMATION_SLIDE_IN_DURATION)
                             ) with
-                                fadeOut(animationSpec = tween(200))
+                                fadeOut(animationSpec = tween(ANIMATION_FADE_OUT_DURATION))
                         }
                     ) { targetState ->
                         // It's important to use targetState and not state, as its critical to ensure
@@ -131,5 +131,10 @@ class SurveyFragment : Fragment() {
     @Suppress("UNUSED_PARAMETER")
     private fun selectContact(questionId: Int) {
         // TODO: unsupported for now
+    }
+
+    companion object {
+        private const val ANIMATION_SLIDE_IN_DURATION = 600
+        private const val ANIMATION_FADE_OUT_DURATION = 200
     }
 }

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyFragment.kt
@@ -69,11 +69,12 @@ class SurveyFragment : Fragment() {
                         targetState = state,
                         transitionSpec = {
                             fadeIn() +
-                                    slideInVertically(animationSpec =
+                                slideInVertically(
+                                    animationSpec =
                                     tween(400 * 3),
-                                        initialOffsetY = { fullWidth -> fullWidth }) with
-                                    fadeOut(animationSpec = tween(200 * 3))
-
+                                    initialOffsetY = { fullWidth -> fullWidth }
+                                ) with
+                                fadeOut(animationSpec = tween(200 * 3))
                         }
                     ) { targetState ->
                         // It's important to use targetState and not state, as its critical to ensure

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -16,7 +16,13 @@
 
 package com.example.compose.jetsurvey.survey
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.with
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -56,6 +62,8 @@ import com.example.compose.jetsurvey.R
 import com.example.compose.jetsurvey.theme.progressIndicatorBackground
 import com.example.compose.jetsurvey.util.supportWideScreen
 
+private const val CONTENT_ANIMATION_DURATION = 500
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun SurveyQuestionsScreen(
     questions: SurveyState.Questions,
@@ -79,22 +87,53 @@ fun SurveyQuestionsScreen(
                 )
             },
             content = { innerPadding ->
-                Question(
-                    question = questionState.question,
-                    answer = questionState.answer,
-                    shouldAskPermissions = shouldAskPermissions,
-                    onAnswer = {
-                        if (it !is Answer.PermissionsDenied) {
-                            questionState.answer = it
+                AnimatedContent(
+                    targetState = questionState,
+                    transitionSpec = {
+                        if (targetState.questionIndex > initialState.questionIndex) {
+                            // Going forwards in the survey: Set the initial offset to start
+                            // at the size of the content so it slides in from right to left, and
+                            // slides out from the left of the screen to -fullWidth
+                            slideInHorizontally(
+                                animationSpec = tween(CONTENT_ANIMATION_DURATION),
+                                initialOffsetX = { fullWidth -> fullWidth }
+                            ) with
+                                slideOutHorizontally(
+                                    animationSpec = tween(CONTENT_ANIMATION_DURATION),
+                                    targetOffsetX = { fullWidth -> -fullWidth }
+                                )
+                        } else {
+                            // Going back to the previous question in the set, we do the same
+                            // transition as above, but with different offsets - the inverse of
+                            // above, negative fullWidth to enter, and fullWidth to exit.
+                            slideInHorizontally(
+                                animationSpec = tween(CONTENT_ANIMATION_DURATION),
+                                initialOffsetX = { fullWidth -> -fullWidth }
+                            ) with
+                                slideOutHorizontally(
+                                    animationSpec = tween(CONTENT_ANIMATION_DURATION),
+                                    targetOffsetX = { fullWidth -> fullWidth }
+                                )
                         }
-                        questionState.enableNext = true
-                    },
-                    onAction = onAction,
-                    onDoNotAskForPermissions = onDoNotAskForPermissions,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding)
-                )
+                    }
+                ) { targetState ->
+                    Question(
+                        question = targetState.question,
+                        answer = targetState.answer,
+                        shouldAskPermissions = shouldAskPermissions,
+                        onAnswer = {
+                            if (it !is Answer.PermissionsDenied) {
+                                targetState.answer = it
+                            }
+                            targetState.enableNext = true
+                        },
+                        onAction = onAction,
+                        onDoNotAskForPermissions = onDoNotAskForPermissions,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                    )
+                }
             },
             bottomBar = {
                 SurveyBottomBar(

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/SurveyScreen.kt
@@ -17,11 +17,11 @@
 package com.example.compose.jetsurvey.survey
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.TweenSpec
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.with
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -57,12 +57,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.example.compose.jetsurvey.R
 import com.example.compose.jetsurvey.theme.progressIndicatorBackground
 import com.example.compose.jetsurvey.util.supportWideScreen
 
 private const val CONTENT_ANIMATION_DURATION = 500
+
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun SurveyQuestionsScreen(
@@ -90,31 +92,27 @@ fun SurveyQuestionsScreen(
                 AnimatedContent(
                     targetState = questionState,
                     transitionSpec = {
-                        if (targetState.questionIndex > initialState.questionIndex) {
-                            // Going forwards in the survey: Set the initial offset to start
-                            // at the size of the content so it slides in from right to left, and
-                            // slides out from the left of the screen to -fullWidth
-                            slideInHorizontally(
-                                animationSpec = tween(CONTENT_ANIMATION_DURATION),
-                                initialOffsetX = { fullWidth -> fullWidth }
-                            ) with
-                                slideOutHorizontally(
-                                    animationSpec = tween(CONTENT_ANIMATION_DURATION),
-                                    targetOffsetX = { fullWidth -> -fullWidth }
-                                )
-                        } else {
-                            // Going back to the previous question in the set, we do the same
-                            // transition as above, but with different offsets - the inverse of
-                            // above, negative fullWidth to enter, and fullWidth to exit.
-                            slideInHorizontally(
-                                animationSpec = tween(CONTENT_ANIMATION_DURATION),
-                                initialOffsetX = { fullWidth -> -fullWidth }
-                            ) with
-                                slideOutHorizontally(
-                                    animationSpec = tween(CONTENT_ANIMATION_DURATION),
-                                    targetOffsetX = { fullWidth -> fullWidth }
-                                )
-                        }
+                        val animationSpec: TweenSpec<IntOffset> = tween(CONTENT_ANIMATION_DURATION)
+                        val direction =
+                            if (targetState.questionIndex > initialState.questionIndex) {
+                                // Going forwards in the survey: Set the initial offset to start
+                                // at the size of the content so it slides in from right to left, and
+                                // slides out from the left of the screen to -fullWidth
+                                AnimatedContentScope.SlideDirection.Left
+                            } else {
+                                // Going back to the previous question in the set, we do the same
+                                // transition as above, but with different offsets - the inverse of
+                                // above, negative fullWidth to enter, and fullWidth to exit.
+                                AnimatedContentScope.SlideDirection.Right
+                            }
+                        slideIntoContainer(
+                            towards = direction,
+                            animationSpec = animationSpec
+                        ) with
+                            slideOutOfContainer(
+                                towards = direction,
+                                animationSpec = animationSpec
+                            )
                     }
                 ) { targetState ->
                     Question(


### PR DESCRIPTION
Added two usages of AnimatedContent into JetSurvey.

1. Switching between Question Content

| Before  |  After |   
|---|---|
|![Survey_Questions_No_animation_Demo_Mode](https://user-images.githubusercontent.com/9973046/173243765-ce3ece43-22b8-41ca-954f-153e922e27dc.gif) | ![End_Questions_optimized](https://user-images.githubusercontent.com/9973046/173244109-18c88ca1-3dca-4926-adb1-cf75346e07c0.gif) |

3. Switching from questions to results

| Before  |  After |   
|---|---|
| ![End_Congrats_Before_DemoMode](https://user-images.githubusercontent.com/9973046/173244342-6ac00cdd-55ff-4c7e-9956-2369e7d77e8e.gif) | ![End_Congrats_Final_Demo_Mode](https://user-images.githubusercontent.com/9973046/173244394-1662d8e4-0b43-4a26-9eee-1bd56ec3c10a.gif) |



Animate the changes between different question screens, as well as the end result screen.