### PR TITLE
[Crane] Add default properties file.

### DIFF
--- a/Crane/README.md
+++ b/Crane/README.md
@@ -74,7 +74,7 @@ the [documentation says](https://developers.google.com/maps/documentation/androi
 and include it in the `local.properties` file as follows:
 
 ```
-googleMapsKey={insert_your_api_key_here}
+googleMapsKey=insert_your_api_key_here
 ```
 
 When restricting the Key to Android apps, use `androidx.compose.samples.crane` as package name, and

--- a/Crane/app/build.gradle
+++ b/Crane/app/build.gradle
@@ -150,3 +150,7 @@ dependencies {
     androidTestImplementation Libs.Hilt.testing
     kaptAndroidTest Libs.Hilt.compiler
 }
+
+secrets {
+    defaultPropertiesFileName 'local.defaults.properties'
+}

--- a/Crane/local.defaults.properties
+++ b/Crane/local.defaults.properties
@@ -1,0 +1,6 @@
+## Default values used by secrets-gradle-plugin
+# Do **not** put your secrets in this file, this is mainly so that
+# the app can compile and use a default value for the googleMapsKey.
+# Create a new entry for `googleMapsKey` and place your actual key
+# in the `local.properties` file instead.
+googleMapsKey=STUB_KEY


### PR DESCRIPTION
Add `local.defaults.properties` file so that Crane can build and run without a googleMapsKey. A key is still necessary to see the map load, however. See Crane's README for more info.

----

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #845 🦕
