### PR TITLE
Add support for workflow_dispatch on all GH workflows.

### DIFF
--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -11,6 +11,8 @@ on:
     paths:
       - '.github/workflows/JetNews.yaml'
       - 'JetNews/**'
+  workflow_dispatch:
+
 env:
   SAMPLE_PATH: JetNews
 

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -11,6 +11,8 @@ on:
     paths:
       - '.github/workflows/Jetchat.yaml'
       - 'Jetchat/**'
+  workflow_dispatch:
+
 env:
   SAMPLE_PATH: Jetchat
 

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -11,6 +11,7 @@ on:
     paths:
       - '.github/workflows/Jetsnack.yaml'
       - 'Jetsnack/**'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -11,6 +11,7 @@ on:
     paths:
       - '.github/workflows/Jetsurvey.yaml'
       - 'Jetsurvey/**'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -11,6 +11,8 @@ on:
     paths:
       - '.github/workflows/Owl.yaml'
       - 'Owl/**'
+  workflow_dispatch:
+
 env:
   SAMPLE_PATH: Owl
 


### PR DESCRIPTION
Adding `workflow_dispatch` trigger to all workflows so that they can be manually run from the Actions tab. A number of workflows already supported this (like Crane). This would allow us to build samples from any branch without having to open a pull request.

<img width="1333" alt="Screen Shot 2022-06-17 at 1 00 23 PM" src="https://user-images.githubusercontent.com/463186/174393902-6022f1ff-b5fa-4742-869a-4a6cd61fdede.png">