### PR TITLE
[All] Update to Compose 1.2.0-rc02

### DIFF
--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -57,7 +57,7 @@ object Libs {
         const val appcompat = "androidx.appcompat:appcompat:1.4.1"
 
         object Compose {
-            const val snapshot = "8738550"
+            const val snapshot = ""
             const val version = "1.2.0-rc02"
 
             const val runtime = "androidx.compose.runtime:runtime:$version"

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -57,8 +57,8 @@ object Libs {
         const val appcompat = "androidx.appcompat:appcompat:1.4.1"
 
         object Compose {
-            const val snapshot = ""
-            const val version = "1.2.0-rc01"
+            const val snapshot = "8738550"
+            const val version = "1.2.0-rc02"
 
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val runtimeLivedata = "androidx.compose.runtime:runtime-livedata:$version"

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -16,8 +16,8 @@
 
 buildscript {
     ext.kotlin_version = '1.6.21'
-    ext.compose_version = '1.2.0-rc01'
-    ext.compose_snapshot_version = ''
+    ext.compose_version = '1.2.0-rc02'
+    ext.compose_snapshot_version = '8738550'
     ext.coroutines_version = '1.6.0'
     ext.accompanist_version = '0.24.11-rc'
 

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     ext.compose_version = '1.2.0-rc02'
     ext.compose_snapshot_version = '8738550'
     ext.coroutines_version = '1.6.0'
-    ext.accompanist_version = '0.24.11-rc'
+    ext.accompanist_version = '0.24.12-rc'
 
     repositories {
         google()

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -17,7 +17,7 @@
 buildscript {
     ext.kotlin_version = '1.6.21'
     ext.compose_version = '1.2.0-rc02'
-    ext.compose_snapshot_version = '8738550'
+    ext.compose_snapshot_version = ''
     ext.coroutines_version = '1.6.0'
     ext.accompanist_version = '0.24.12-rc'
 

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -25,7 +25,7 @@ object Libs {
     const val jdkDesugar = "com.android.tools:desugar_jdk_libs:1.1.5"
 
     object Accompanist {
-        const val version = "0.24.11-rc"
+        const val version = "0.24.12-rc"
         const val pager = "com.google.accompanist:accompanist-pager:$version"
     }
 

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -69,7 +69,7 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = "8738550"
+            const val snapshot = ""
             const val version = "1.2.0-rc02"
 
             @get:JvmStatic

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -69,8 +69,8 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = ""
-            const val version = "1.2.0-rc01"
+            const val snapshot = "8738550"
+            const val version = "1.2.0-rc02"
 
             @get:JvmStatic
             val snapshotUrl: String

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -51,8 +51,8 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = ""
-            const val version = "1.2.0-rc01"
+            const val snapshot = "8738550"
+            const val version = "1.2.0-rc02"
 
             const val foundation = "androidx.compose.foundation:foundation:$version"
             const val layout = "androidx.compose.foundation:foundation-layout:$version"

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -51,7 +51,7 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = "8738550"
+            const val snapshot = ""
             const val version = "1.2.0-rc02"
 
             const val foundation = "androidx.compose.foundation:foundation:$version"

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -24,7 +24,7 @@ object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.2.1"
 
     object Accompanist {
-        const val version = "0.24.11-rc"
+        const val version = "0.24.12-rc"
         const val systemuicontroller = "com.google.accompanist:accompanist-systemuicontroller:$version"
         const val flowlayouts = "com.google.accompanist:accompanist-flowlayout:$version"
     }

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -47,7 +47,7 @@ object Libs {
         const val coreKtx = "androidx.core:core-ktx:1.7.0"
 
         object Compose {
-            const val snapshot = "8738550"
+            const val snapshot = ""
             const val version = "1.2.0-rc02"
 
             const val foundation = "androidx.compose.foundation:foundation:${version}"

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -47,8 +47,8 @@ object Libs {
         const val coreKtx = "androidx.core:core-ktx:1.7.0"
 
         object Compose {
-            const val snapshot = ""
-            const val version = "1.2.0-rc01"
+            const val snapshot = "8738550"
+            const val version = "1.2.0-rc02"
 
             const val foundation = "androidx.compose.foundation:foundation:${version}"
             const val layout = "androidx.compose.foundation:foundation-layout:${version}"

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -60,7 +60,7 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = "8738550"
+            const val snapshot = ""
             const val version = "1.2.0-rc02"
 
             @get:JvmStatic

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -27,7 +27,7 @@ object Libs {
     const val junit = "junit:junit:4.13.2"
 
     object Accompanist {
-        const val version = "0.24.11-rc"
+        const val version = "0.24.12-rc"
         const val permissions = "com.google.accompanist:accompanist-permissions:$version"
     }
 

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -60,8 +60,8 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = ""
-            const val version = "1.2.0-rc01"
+            const val snapshot = "8738550"
+            const val version = "1.2.0-rc02"
 
             @get:JvmStatic
             val snapshotUrl: String

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -51,7 +51,7 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = "8738550"
+            const val snapshot = ""
             const val version = "1.2.0-rc02"
 
             const val animation = "androidx.compose.animation:animation:$version"

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -51,8 +51,8 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = ""
-            const val version = "1.2.0-rc01"
+            const val snapshot = "8738550"
+            const val version = "1.2.0-rc02"
 
             const val animation = "androidx.compose.animation:animation:$version"
             const val foundation = "androidx.compose.foundation:foundation:$version"

--- a/scripts/upgrade_samples.sh
+++ b/scripts/upgrade_samples.sh
@@ -64,7 +64,7 @@ for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
         if [[ $line == *"val version ="* && "$compose_version" != "" ]] && $COMPOSE_BLOCK = true; then
             echo "$line" | sed -En 's/".*"/"'$compose_version'"/p'
             MADE_CHANGE=true;
-        elif [[ $line == *"val snapshot ="* && "$snapshot_version" != "" ]] && $COMPOSE_BLOCK = true; then
+        elif [[ $line == *"val snapshot ="* ]] && $COMPOSE_BLOCK = true; then
             echo "$line" | sed -En 's/".*"/"'$snapshot_version'"/p'
             MADE_CHANGE=true;
         elif [[ $line == *"val version ="* && "$accompanist_version" != "" ]] && $ACCOMPANIST_BLOCK = true; then
@@ -102,7 +102,7 @@ for DEPENDENCIES_FILE in `find . -type f -iname "build.gradle"` ; do
         if [[ $line == *"ext.compose_version ="* && "$compose_version" != "" ]]; then
             echo "$line" | sed -En "s/\'.*'/\'$compose_version\'/p"
             MADE_CHANGE=true;
-        elif [[ $line == *"ext.compose_snapshot_version ="* && "$snapshot_version" != "" ]]; then
+        elif [[ $line == *"ext.compose_snapshot_version ="* ]]; then
             echo "$line" | sed -En "s/\'.*'/\'$snapshot_version\'/p"
             MADE_CHANGE=true;
         elif [[ $line == *"ext.accompanist_version ="* && "$accompanist_version" != "" ]]; then


### PR DESCRIPTION
Updating all samples to use the latest version ([1.2.0-rc02](https://developer.android.com/jetpack/androidx/releases/compose#1.2.0-rc02)) of Compose.