### PR TITLE
[All] Update Compose Compiler to 1.2.0

### DIFF
--- a/Crane/app/build.gradle
+++ b/Crane/app/build.gradle
@@ -91,7 +91,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.compilerVersion
     }
 
     packagingOptions {

--- a/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
+++ b/Crane/buildSrc/src/main/java/com/example/crane/buildsrc/Dependencies.kt
@@ -37,7 +37,7 @@ object Libs {
     }
 
     object Kotlin {
-        private const val version = "1.6.21"
+        private const val version = "1.7.0"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
@@ -57,6 +57,7 @@ object Libs {
         const val appcompat = "androidx.appcompat:appcompat:1.4.1"
 
         object Compose {
+            const val compilerVersion = "1.2.0"
             const val snapshot = ""
             const val version = "1.2.0-rc02"
 

--- a/JetNews/app/build.gradle
+++ b/JetNews/app/build.gradle
@@ -79,7 +79,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerExtensionVersion compose_compiler_version
     }
 
     packagingOptions {

--- a/JetNews/build.gradle
+++ b/JetNews/build.gradle
@@ -15,7 +15,8 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.7.0'
+    ext.compose_compiler_version = '1.2.0'
     ext.compose_version = '1.2.0-rc02'
     ext.compose_snapshot_version = ''
     ext.coroutines_version = '1.6.0'

--- a/Jetcaster/app/build.gradle
+++ b/Jetcaster/app/build.gradle
@@ -88,7 +88,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.compilerVersion
     }
 }
 

--- a/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
+++ b/Jetcaster/buildSrc/src/main/java/com/example/jetcaster/buildsrc/dependencies.kt
@@ -30,7 +30,7 @@ object Libs {
     }
 
     object Kotlin {
-        private const val version = "1.6.21"
+        private const val version = "1.7.0"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
@@ -69,6 +69,7 @@ object Libs {
         }
 
         object Compose {
+            const val compilerVersion = "1.2.0"
             const val snapshot = ""
             const val version = "1.2.0-rc02"
 
@@ -113,7 +114,7 @@ object Libs {
         }
 
         object Room {
-            private const val version = "2.4.2"
+            private const val version = "2.5.0-alpha02"
             const val runtime = "androidx.room:room-runtime:${version}"
             const val ktx = "androidx.room:room-ktx:${version}"
             const val compiler = "androidx.room:room-compiler:${version}"

--- a/Jetchat/app/build.gradle
+++ b/Jetchat/app/build.gradle
@@ -78,7 +78,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.compilerVersion
     }
 
     packagingOptions {

--- a/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
+++ b/Jetchat/buildSrc/src/main/java/com/example/compose/jetchat/buildsrc/dependencies.kt
@@ -29,7 +29,7 @@ object Libs {
     const val material3 = "com.google.android.material:material:1.6.0-alpha03"
 
     object Kotlin {
-        private const val version = "1.6.21"
+        private const val version = "1.7.0"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
@@ -51,6 +51,7 @@ object Libs {
         }
 
         object Compose {
+            const val compilerVersion = "1.2.0"
             const val snapshot = ""
             const val version = "1.2.0-rc02"
 

--- a/Jetsnack/app/build.gradle
+++ b/Jetsnack/app/build.gradle
@@ -82,7 +82,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.compilerVersion
     }
 
     packagingOptions {

--- a/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
+++ b/Jetsnack/buildSrc/src/main/java/com/example/jetsnack/buildsrc/Dependencies.kt
@@ -30,7 +30,7 @@ object Libs {
     }
 
     object Kotlin {
-        private const val version = "1.6.21"
+        private const val version = "1.7.0"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
@@ -47,6 +47,7 @@ object Libs {
         const val coreKtx = "androidx.core:core-ktx:1.7.0"
 
         object Compose {
+            const val compilerVersion = "1.2.0"
             const val snapshot = ""
             const val version = "1.2.0-rc02"
 

--- a/Jetsurvey/app/build.gradle
+++ b/Jetsurvey/app/build.gradle
@@ -75,7 +75,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.compilerVersion
     }
 
     packagingOptions {

--- a/Jetsurvey/build.gradle
+++ b/Jetsurvey/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         google()
         mavenCentral()
 
-        if (Libs.AndroidX.Compose.version.endsWith('SNAPSHOT')) {
+        if (!Libs.AndroidX.Compose.snapshot.isEmpty()) {
             maven { url Libs.AndroidX.Compose.snapshotUrl }
         }
         if (Libs.Accompanist.version.endsWith('SNAPSHOT')) {

--- a/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
+++ b/Jetsurvey/buildSrc/src/main/java/com/example/compose/jetsurvey/buildsrc/dependencies.kt
@@ -32,7 +32,7 @@ object Libs {
     }
 
     object Kotlin {
-        private const val version = "1.6.21"
+        private const val version = "1.7.0"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
@@ -60,6 +60,7 @@ object Libs {
         }
 
         object Compose {
+            const val compilerVersion = "1.2.0"
             const val snapshot = ""
             const val version = "1.2.0-rc02"
 

--- a/Owl/app/build.gradle
+++ b/Owl/app/build.gradle
@@ -70,7 +70,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.compilerVersion
     }
 
     packagingOptions {

--- a/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
+++ b/Owl/buildSrc/src/main/java/com/example/owl/buildsrc/Dependencies.kt
@@ -24,7 +24,7 @@ object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.2.1"
 
     object Kotlin {
-        private const val version = "1.6.21"
+        private const val version = "1.7.0"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
         const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:$version"
@@ -51,6 +51,7 @@ object Libs {
         }
 
         object Compose {
+            const val compilerVersion = "1.2.0"
             const val snapshot = ""
             const val version = "1.2.0-rc02"
 

--- a/scripts/upgrade_samples.sh
+++ b/scripts/upgrade_samples.sh
@@ -48,6 +48,9 @@ read ktlint_version;
 echo "Version to change Accompanist to (e.g 0.24.9-beta): ";
 read accompanist_version;
 
+echo "Version to change Kotlin to (e.g 1.7.0): ";
+read kotlin_version;
+
 if [ -z "$snapshot_version" ]; then
     echo "Changing Compose version to $compose_version"
 else
@@ -58,6 +61,7 @@ fi
 for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
     COMPOSE_BLOCK=false;
     ACCOMPANIST_BLOCK=false;
+    KOTLIN_BLOCK=false;
     MADE_CHANGE=false;
     TEMP_FILENAME="${DEPENDENCIES_FILE}_new";
     while IFS= read -r line; do
@@ -70,6 +74,9 @@ for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
         elif [[ $line == *"val version ="* && "$accompanist_version" != "" ]] && $ACCOMPANIST_BLOCK = true; then
             echo "$line" | sed -En 's/".*"/"'$accompanist_version'"/p'
             MADE_CHANGE=true;
+        elif [[ $line == *"val version ="* && "$kotlin_version" != "" ]] && $KOTLIN_BLOCK = true; then
+            echo "$line" | sed -En 's/".*"/"'$kotlin_version'"/p'
+            MADE_CHANGE=true;
         elif [[ $line == *"val ktlint ="* && "$ktlint_version" != "" ]]; then
             echo "$line" | sed -En 's/".*"/"'$ktlint_version'"/p'
             MADE_CHANGE=true;
@@ -78,9 +85,12 @@ for DEPENDENCIES_FILE in `find . -type f -iname "dependencies.kt"` ; do
                 COMPOSE_BLOCK=true;
             elif [[ $line == *"object Accompanist {"* ]]; then
                 ACCOMPANIST_BLOCK=true;
+            elif [[ $line == *"object Kotlin {"* ]]; then
+                KOTLIN_BLOCK=true;
             elif [[ $line == *"}"* ]]; then
                 COMPOSE_BLOCK=false;
                 ACCOMPANIST_BLOCK=false;
+                KOTLIN_BLOCK=false;
             fi
             echo "$line";
         fi


### PR DESCRIPTION
Updating samples to use latest Compose Compiler 1.2.0 and Kotlin 1.7.0. This is the start of [independent versioning](https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html) of the compiler and various Compose libraries.

Also updated Room on Jetchat to 2.5.0-alpha02 which supports Kotlin 1.7.0.