### PR TITLE
[JetNews] Use derived state of for scrolled state to avoid recomposition on scrolling

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/utils/LazyListUtils.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/utils/LazyListUtils.kt
@@ -17,6 +17,7 @@
 package com.example.jetnews.utils
 
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.derivedStateOf
 
 val LazyListState.isScrolled: Boolean
-    get() = firstVisibleItemIndex > 0 || firstVisibleItemScrollOffset > 0
+    get() = derivedStateOf { firstVisibleItemIndex > 0 || firstVisibleItemScrollOffset > 0 }.value


### PR DESCRIPTION
This should fix  #841  😃 
