### PR TITLE
[Crane] Fix animation on backdrop sheet

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/base/ExploreSection.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/base/ExploreSection.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.samples.crane.R
 import androidx.compose.samples.crane.data.ExploreModel
 import androidx.compose.samples.crane.home.OnExploreItemClicked
-import androidx.compose.samples.crane.ui.BottomSheetShape
 import androidx.compose.samples.crane.ui.crane_caption
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -68,7 +67,7 @@ fun ExploreSection(
     exploreList: List<ExploreModel>,
     onItemClicked: OnExploreItemClicked
 ) {
-    Surface(modifier = modifier.fillMaxSize(), color = Color.White, shape = BottomSheetShape) {
+    Surface(modifier = modifier.fillMaxSize(), color = Color.White) {
         Column(modifier = Modifier.padding(start = 24.dp, top = 20.dp, end = 24.dp)) {
             Text(
                 text = title,


### PR DESCRIPTION
Fixed animation with backdrop sheet in AnimatedContent. 

Before:
https://miro.medium.com/max/960/1*DmBRNlc9Qy-FS3b_DTWHTQ.gif

After:

![](https://user-images.githubusercontent.com/9973046/178942787-68c45127-dca0-4e24-ac62-c9dec1d5247a.gif)

