### PR TITLE
[Jetchat] Renamed JetchatScaffold to JetchatDrawer

### DIFF
--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
@@ -34,7 +34,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
-import com.example.compose.jetchat.components.JetchatScaffold
+import com.example.compose.jetchat.components.JetchatDrawer
 import com.example.compose.jetchat.conversation.BackPressHandler
 import com.example.compose.jetchat.conversation.LocalBackPressedDispatcher
 import com.example.compose.jetchat.databinding.ContentMainBinding
@@ -86,7 +86,7 @@ class NavActivity : AppCompatActivity() {
                             }
                         }
 
-                        JetchatScaffold(
+                        JetchatDrawer(
                             drawerState = drawerState,
                             onChatClicked = {
                                 findNavController().popBackStack(R.id.nav_home, false)

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
@@ -26,7 +26,7 @@ import com.example.compose.jetchat.theme.JetchatTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun JetchatScaffold(
+fun JetchatDrawer(
     drawerState: DrawerState = rememberDrawerState(initialValue = Closed),
     onProfileClicked: (String) -> Unit,
     onChatClicked: (String) -> Unit,


### PR DESCRIPTION
Renamed `JetchatScaffold` --> `JetchatDrawer` in file **JetchatScaffold.kt**

Though I personally think that this file **`JetchatScaffold.kt`** also got renamed as its responsibility got changed.

fixes #720 