### PR TITLE
Fix accessibility bugs of overlay and missing text

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -186,7 +186,8 @@ fun EpisodeListItem(
 
         Text(
             text = episode.title,
-//            maxLines = 2,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.subtitle1,
             modifier = Modifier.constrainAs(episodeTitle) {
                 linkTo(
@@ -207,7 +208,8 @@ fun EpisodeListItem(
         CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
             Text(
                 text = podcast.title,
-//                maxLines = 2,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.subtitle2,
                 modifier = Modifier.constrainAs(podcastTitle) {
                     linkTo(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -187,7 +187,6 @@ fun EpisodeListItem(
         Text(
             text = episode.title,
             maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.subtitle1,
             modifier = Modifier.constrainAs(episodeTitle) {
                 linkTo(
@@ -198,7 +197,7 @@ fun EpisodeListItem(
                     bias = 0f
                 )
                 top.linkTo(parent.top, 16.dp)
-                height = preferredWrapContent
+
                 width = preferredWrapContent
             }
         )
@@ -209,7 +208,6 @@ fun EpisodeListItem(
             Text(
                 text = podcast.title,
                 maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.subtitle2,
                 modifier = Modifier.constrainAs(podcastTitle) {
                     linkTo(
@@ -220,7 +218,7 @@ fun EpisodeListItem(
                         bias = 0f
                     )
                     top.linkTo(episodeTitle.bottom, 6.dp)
-                    height = preferredWrapContent
+
                     width = preferredWrapContent
                 }
             )
@@ -273,7 +271,6 @@ fun EpisodeListItem(
                         endMargin = 16.dp,
                         bias = 0f // float this towards the start
                     )
-                    width = preferredWrapContent
                 }
             )
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -186,7 +186,7 @@ fun EpisodeListItem(
 
         Text(
             text = episode.title,
-            maxLines = 2,
+//            maxLines = 2,
             style = MaterialTheme.typography.subtitle1,
             modifier = Modifier.constrainAs(episodeTitle) {
                 linkTo(
@@ -197,7 +197,7 @@ fun EpisodeListItem(
                     bias = 0f
                 )
                 top.linkTo(parent.top, 16.dp)
-
+                height = preferredWrapContent
                 width = preferredWrapContent
             }
         )
@@ -207,7 +207,7 @@ fun EpisodeListItem(
         CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
             Text(
                 text = podcast.title,
-                maxLines = 2,
+//                maxLines = 2,
                 style = MaterialTheme.typography.subtitle2,
                 modifier = Modifier.constrainAs(podcastTitle) {
                     linkTo(
@@ -218,7 +218,7 @@ fun EpisodeListItem(
                         bias = 0f
                     )
                     top.linkTo(episodeTitle.bottom, 6.dp)
-
+                    height = preferredWrapContent
                     width = preferredWrapContent
                 }
             )
@@ -271,6 +271,7 @@ fun EpisodeListItem(
                         endMargin = 16.dp,
                         bias = 0f // float this towards the start
                     )
+                    width = preferredWrapContent
                 }
             )
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -187,6 +187,7 @@ fun EpisodeListItem(
         Text(
             text = episode.title,
             maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.subtitle1,
             modifier = Modifier.constrainAs(episodeTitle) {
                 linkTo(
@@ -208,6 +209,7 @@ fun EpisodeListItem(
             Text(
                 text = podcast.title,
                 maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.subtitle2,
                 modifier = Modifier.constrainAs(podcastTitle) {
                     linkTo(


### PR DESCRIPTION
I am the creator of issue #911, and I did some changes to the layout code inside to make this app more accessible. 

Because the title of one episode could be more than 2 lines, I commented out the corresponding statement of maxlines. And since the height of episode title is not wrap content, the play icon below could be placed above them, therefore I think it might be better to specify the width of the episode title and podcast title with `suggested wrap content (preferredWrapContent)`. The string of date could overlap the icon on its right, because the width of the string is not specified as `suggested wrap content (preferredWrapContent)`, so I changed its width as well.

Here is the effects before and after my modification.

<img src="https://user-images.githubusercontent.com/25502419/182028460-f2b2effc-ec9e-44f0-9f31-735102f7b7cb.png" width="200px"><img src="https://user-images.githubusercontent.com/25502419/182028465-0094afb3-daba-4ceb-ae80-dceef643df41.png" width="200px">

I tested the code on the emulator of Pixel 5 with the largest font size and display size. You could see all those composables are seperated now, and the episode title could also be seen fully (2 lines -> 3 lines).

Thank you! :)