### PR TITLE
first gif breaks the design!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Jetpack Compose Samples
-<img src="readme/samples_montage.gif" alt="Jetpack Compose Samples" width="1024" />
+<img src="readme/samples_montage.gif" alt="Jetpack Compose Samples" width="824" />
 
 This repository contains a set of individual Android Studio projects to help you learn about
 Compose in Android. Each sample demonstrates different use cases, complexity levels and APIs.


### PR DESCRIPTION
when i watched this repo, i noticed that [this gif](https://github.com/android/compose-samples/blob/main/readme/samples_montage.gif) breaks the readme section. i already reduce some of the gif width, but could be decreased or increased.

(in below i put the screenshot of readme in repo page)
![Screenshot 2022-08-04 140050](https://user-images.githubusercontent.com/70845998/182814952-959631a9-da74-440c-8f41-d2813fac9137.png)

