### PR TITLE
Disable auto creation of deps PRs for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base", ":dependencyDashboard"
   ],
+  "dependencyDashboardApproval": true,
   "packageRules": [
     {
       "groupName": "Androidx Lifecycle deps",


### PR DESCRIPTION
According to - https://docs.renovatebot.com/faq/#tell-renovate-to-ask-for-approval-before-creating-a-pull-request we can add this option to enforce manual creation of PRs from the dashboard