### PR TITLE
[JetNews] fix jetnews empty add or remove issue on MapExtensions.kt

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/utils/MapExtensions.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/utils/MapExtensions.kt
@@ -17,9 +17,9 @@
 package com.example.jetnews.utils
 
 internal fun <E> Set<E>.addOrRemove(element: E): Set<E> {
-    this as MutableSet
-    if (!add(element)) {
-        remove(element)
-    }
-    return this.toSet()
+    return this.toMutableSet().apply {
+        if (!add(element)) {
+            remove(element)
+        }
+    }.toSet()
 }


### PR DESCRIPTION
When I clicke any item (topic, people and publication) on Interest Screen the app crashed because of initial state (emptySet). I changed the conversion style with .toMutableSet()

![Screenshot 2022-12-07 at 03 48 09](https://user-images.githubusercontent.com/31517818/206060587-521960b6-c761-432b-97bc-0d87274b7330.png)
