### PR TITLE
[Crane] Location input state is restored on process/activity recreation

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/base/BaseUserInput.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/base/BaseUserInput.kt
@@ -32,7 +32,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.samples.crane.R
 import androidx.compose.samples.crane.ui.CraneTheme
@@ -87,7 +87,12 @@ fun CraneEditableUserInput(
     @DrawableRes vectorImageId: Int? = null,
     onInputChanged: (String) -> Unit
 ) {
-    var textFieldState by remember { mutableStateOf(TextFieldValue()) }
+
+    var textFieldState by rememberSaveable(stateSaver = TextFieldValue.Companion.Saver) {
+        mutableStateOf(
+            TextFieldValue()
+        )
+    }
     CraneBaseUserInput(
         caption = caption,
         tintIcon = {


### PR DESCRIPTION
Fixing "Choose Destination" state restoration.

<img width="421" alt="image" src="https://user-images.githubusercontent.com/8226593/207125425-e6e9a57c-5124-4eef-9ab8-c890776a2135.png">
