### PR TITLE
[Jetsurvey] Fix for radio button accessibility

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/question/ChoiceQuestion.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/survey/question/ChoiceQuestion.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -132,17 +133,18 @@ private fun Answer(
             }
         ),
         modifier = modifier
+            .clip(MaterialTheme.shapes.small)
+            .then(
+                if (isSingleChoice) {
+                    Modifier.selectable(selected, onClick = onOptionSelected, role = Role.RadioButton)
+                } else {
+                    Modifier.clickable(onClick = onOptionSelected)
+                }
+            )
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .then(
-                    if (isSingleChoice) {
-                        Modifier.selectable(selected, onClick = onOptionSelected)
-                    } else {
-                        Modifier.clickable(onClick = onOptionSelected)
-                    }
-                )
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {


### PR DESCRIPTION
This moves the selectable Modifier to the Surface of the Answer composable. Since the SingleChoiceQuestion composable adds the selectableGroup Modifier, the Answers will now act as a group of mutually exclusive radio buttons.

Note that the clip Modifier has to be added for the ripple. In the future, we can refactor this to use the selectable or clickable versions of Surface, which handle this already.

Fixes #1023 