### PR TITLE
[Crane|Jetsnack] Replace box with contentAlignment for wrapContentSize modifier in child

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/home/LandingScreen.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/home/LandingScreen.kt
@@ -17,14 +17,13 @@
 package androidx.compose.samples.crane.home
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.samples.crane.R
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import kotlinx.coroutines.delay
@@ -33,14 +32,18 @@ private const val SplashWaitTime: Long = 2000
 
 @Composable
 fun LandingScreen(modifier: Modifier = Modifier, onTimeout: () -> Unit) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        // Adds composition consistency. Use the value when LaunchedEffect is first called
-        val currentOnTimeout by rememberUpdatedState(onTimeout)
+    // Adds composition consistency. Use the value when LaunchedEffect is first called
+    val currentOnTimeout by rememberUpdatedState(onTimeout)
 
-        LaunchedEffect(Unit) {
-            delay(SplashWaitTime)
-            currentOnTimeout()
-        }
-        Image(painterResource(id = R.drawable.ic_crane_drawer), contentDescription = null)
+    LaunchedEffect(Unit) {
+        delay(SplashWaitTime)
+        currentOnTimeout()
     }
+    Image(
+        painterResource(id = R.drawable.ic_crane_drawer),
+        contentDescription = null,
+        modifier
+            .fillMaxSize()
+            .wrapContentSize()
+    )
 }

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
@@ -46,7 +46,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
@@ -260,27 +261,27 @@ fun JetsnackBottomNavigationItem(
     animSpec: AnimationSpec<Float>,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        modifier = modifier.selectable(selected = selected, onClick = onSelected),
-        contentAlignment = Alignment.Center
-    ) {
-        // Animate the icon/text positions within the item based on selection
-        val animationProgress by animateFloatAsState(if (selected) 1f else 0f, animSpec)
-        JetsnackBottomNavItemLayout(
-            icon = icon,
-            text = text,
-            animationProgress = animationProgress
-        )
-    }
+    // Animate the icon/text positions within the item based on selection
+    val animationProgress by animateFloatAsState(if (selected) 1f else 0f, animSpec)
+    JetsnackBottomNavItemLayout(
+        icon = icon,
+        text = text,
+        animationProgress = animationProgress,
+        modifier = modifier
+            .selectable(selected = selected, onClick = onSelected)
+            .wrapContentSize()
+    )
 }
 
 @Composable
 private fun JetsnackBottomNavItemLayout(
     icon: @Composable BoxScope.() -> Unit,
     text: @Composable BoxScope.() -> Unit,
-    @FloatRange(from = 0.0, to = 1.0) animationProgress: Float
+    @FloatRange(from = 0.0, to = 1.0) animationProgress: Float,
+    modifier: Modifier = Modifier
 ) {
     Layout(
+        modifier = modifier,
         content = {
             Box(
                 modifier = Modifier


### PR DESCRIPTION
In general, when you do

```
Box(contentAlignment = Alignment.Center) {
  MyOnlyChild()
}
```

this can be simplified by:

```
MyOnlyChild(Modifier.wrapContentSize())
```

Found two occurrences of this in the samples and simplified them.