### PR TITLE
Update DetailsActivity.kt

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/details/DetailsActivity.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/details/DetailsActivity.kt
@@ -67,6 +67,7 @@ import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 
 internal const val KEY_ARG_DETAILS_CITY_NAME = "KEY_ARG_DETAILS_CITY_NAME"
@@ -227,17 +228,20 @@ fun MapViewContainer(
         MapUiSettings(zoomControlsEnabled = false)
     }
 
+       val coroutineExceptionHandler = CoroutineExceptionHandler {
+            _, _ ->
+    }
     val animationScope = rememberCoroutineScope()
     Column {
         ZoomControls(
             onZoomIn = {
-                animationScope.launch {
+                animationScope.launch(coroutineExceptionHandler) {
                     cameraPositionState.animate(CameraUpdateFactory.zoomIn())
                     onZoomChanged?.invoke()
                 }
             },
             onZoomOut = {
-                animationScope.launch {
+                animationScope.launch(coroutineExceptionHandler) {
                     cameraPositionState.animate(CameraUpdateFactory.zoomOut())
                     onZoomChanged?.invoke()
                 }


### PR DESCRIPTION
When device doesn't have Google services, it crashes when I click the button
```
  java.lang.NullPointerException: CameraUpdateFactory is not initialized
        at com.google.android.gms.common.internal.Preconditions.checkNotNull(com.google.android.gms:play-services-basement@@18.0.0:2)
        at com.google.android.gms.maps.CameraUpdateFactory.zzb(com.google.android.gms:play-services-maps@@18.1.0:1)
        at com.google.android.gms.maps.CameraUpdateFactory.zoomIn(com.google.android.gms:play-services-maps@@18.1.0:1)
        at androidx.compose.samples.crane.details.DetailsActivityKt$MapViewContainer$2$1$1.invokeSuspend(DetailsActivity.kt:235)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at androidx.compose.ui.platform.AndroidUiDispatcher.performTrampolineDispatch(AndroidUiDispatcher.android.kt:81)
        at androidx.compose.ui.platform.AndroidUiDispatcher.access$performTrampolineDispatch(AndroidUiDispatcher.android.kt:41)
        at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.run(AndroidUiDispatcher.android.kt:57)
        at android.os.Handler.handleCallback(Handler.java:900)
        at android.os.Handler.dispatchMessage(Handler.java:103)
        at android.os.Looper.loop(Looper.java:219)
        at android.app.ActivityThread.main(ActivityThread.java:8387)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1055)
```