### PR TITLE
[Jetchat] Fixing top bar overlap

### DIFF
--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatAppBar.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatAppBar.kt
@@ -19,6 +19,7 @@
 package com.example.compose.jetchat.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -43,21 +44,23 @@ fun JetchatAppBar(
     title: @Composable () -> Unit,
     actions: @Composable RowScope.() -> Unit = {}
 ) {
-    CenterAlignedTopAppBar(
-        modifier = modifier,
-        actions = actions,
-        title = title,
-        scrollBehavior = scrollBehavior,
-        navigationIcon = {
-            JetchatIcon(
-                contentDescription = stringResource(id = R.string.navigation_drawer_open),
-                modifier = Modifier
-                    .size(64.dp)
-                    .clickable(onClick = onNavIconPressed)
-                    .padding(16.dp)
-            )
-        }
-    )
+    Box {
+        CenterAlignedTopAppBar(
+            modifier = modifier,
+            actions = actions,
+            title = title,
+            scrollBehavior = scrollBehavior,
+            navigationIcon = {
+                JetchatIcon(
+                    contentDescription = stringResource(id = R.string.navigation_drawer_open),
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clickable(onClick = onNavIconPressed)
+                        .padding(16.dp)
+                )
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
Fixing top bar in Jetchat's Profile screen where half of the top bar is not properly visible.
Bug introduced [here](https://github.com/android/compose-samples/compare/77fc82e64ddefaaf6481aaecfaf0e9ea9bc65199..07b0a268889ff09c2872e7efe3f7d9e1f7330e7a) with the change in `JetchatAppBar`.

before | after

<img width="792" alt="image" src="https://user-images.githubusercontent.com/8226593/221740917-21d36bd6-6aa9-42d3-9b51-86a180c80668.png">

