### PR TITLE
improved preview for CourseListItem

### DIFF
--- a/Owl/app/src/main/java/com/example/owl/ui/common/CourseListItem.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/common/CourseListItem.kt
@@ -137,7 +137,10 @@ private fun CourseListItemPreview(darkTheme: Boolean) {
     BlueTheme(darkTheme) {
         CourseListItem(
             course = courses.first(),
-            onClick = {}
+            onClick = {},
+            modifier = Modifier
+                .padding(end = 8.dp)
+                .size(288.dp, 80.dp),
         )
     }
 }


### PR DESCRIPTION
<img width="715" alt="Screenshot 2023-03-21 at 19 45 02" src="https://user-images.githubusercontent.com/50506/226711184-4f64aa80-81f0-4361-ba6a-51f01513c6aa.png">
preview without size was not useful