### PR TITLE
Set kotlinOptions.jvmTarget to 1.8 #1109

### DIFF
--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -83,6 +83,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
 

--- a/JetLagged/app/build.gradle.kts
+++ b/JetLagged/app/build.gradle.kts
@@ -71,6 +71,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
         // Disable unused AGP features

--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -78,6 +78,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
     }

--- a/Jetcaster/app/build.gradle.kts
+++ b/Jetcaster/app/build.gradle.kts
@@ -62,6 +62,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
     }

--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -62,6 +62,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
         viewBinding = true

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -70,6 +70,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
         // Disable unused AGP features

--- a/Owl/app/build.gradle.kts
+++ b/Owl/app/build.gradle.kts
@@ -78,6 +78,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
     }

--- a/Reply/app/build.gradle.kts
+++ b/Reply/app/build.gradle.kts
@@ -78,6 +78,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildFeatures {
         compose = true
     }


### PR DESCRIPTION
...to make samples compatible with AGP 8.0.0
and Android Studio Flamingo