### PR TITLE
[All] Migrate to AGP 8.0

### DIFF
--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -38,10 +38,11 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
+          distribution: 'zulu'
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: Crane
       path: Crane

--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: Crane
       path: Crane

--- a/.github/workflows/JetLagged.yaml
+++ b/.github/workflows/JetLagged.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/JetLagged.yaml
+++ b/.github/workflows/JetLagged.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: JetLagged
       path: JetLagged

--- a/.github/workflows/JetLagged.yaml
+++ b/.github/workflows/JetLagged.yaml
@@ -38,10 +38,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/JetLagged.yaml
+++ b/.github/workflows/JetLagged.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: JetLagged
       path: JetLagged

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -38,10 +38,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: JetNews
       path: JetNews

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: JetNews
       path: JetNews

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: Jetcaster
       path: Jetcaster

--- a/.github/workflows/Jetcaster.yaml
+++ b/.github/workflows/Jetcaster.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: Jetcaster
       path: Jetcaster

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: Jetchat
       path: Jetchat

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: Jetchat
       path: Jetchat

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -38,10 +38,11 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
+          distribution: 'zulu'
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: Jetsnack
       path: Jetsnack

--- a/.github/workflows/Jetsnack.yaml
+++ b/.github/workflows/Jetsnack.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: Jetsnack
       path: Jetsnack

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: Jetsurvey
       path: Jetsurvey

--- a/.github/workflows/Jetsurvey.yaml
+++ b/.github/workflows/Jetsurvey.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: Jetsurvey
       path: Jetsurvey

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: Owl
       path: Owl

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: Owl
       path: Owl

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -38,10 +38,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Build all projects
         run: ./scripts/gradlew_recursive.sh assembleDebug

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Build all projects
         run: ./scripts/gradlew_recursive.sh assembleDebug

--- a/.github/workflows/Reply.yaml
+++ b/.github/workflows/Reply.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/Reply.yaml
+++ b/.github/workflows/Reply.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml
+    uses: ./.github/workflows/build-sample.yml
     with:
       name: Reply
       path: Reply

--- a/.github/workflows/Reply.yaml
+++ b/.github/workflows/Reply.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    uses: android/compose-samples/.github/workflows/build-sample.yml@main
+    uses: android/compose-samples/.github/workflows/build-sample.yml
     with:
       name: Reply
       path: Reply

--- a/.github/workflows/Reply.yaml
+++ b/.github/workflows/Reply.yaml
@@ -38,10 +38,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Generate cache key
         run: ./scripts/checksum.sh $SAMPLE_PATH checksum.txt

--- a/.github/workflows/build-sample.yml
+++ b/.github/workflows/build-sample.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Generate cache key
         run: ./scripts/checksum.sh ${{ inputs.path }} checksum.txt

--- a/.github/workflows/build-sample.yml
+++ b/.github/workflows/build-sample.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Generate cache key
         run: ./scripts/checksum.sh ${{ inputs.path }} checksum.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: set up Java 11
-      uses: actions/setup-java@v2
+    - name: set up Java 17
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
-        java-version: '11'
+        java-version: '17'
 
     - name: Apply spotless formatting
       run: ./scripts/format.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,8 @@ jobs:
     - name: set up Java 17
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
-        java-version: '17'
+        distribution: 'zulu'
+        java-version: 17
 
     - name: Apply spotless formatting
       run: ./scripts/format.sh

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Check snapshot
         working-directory: ${{ inputs.path }}

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Check snapshot
         working-directory: ${{ inputs.path }}

--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -13,8 +13,8 @@ jobs:
     - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: 'temurin'
+        java-version: 17
+        distribution: 'zulu'
         cache: gradle
 
     - name: Update dependencies

--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -10,10 +10,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Copy CI gradle.properties
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: gradle
 

--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -16,7 +16,6 @@
 * limitations under the License.
 */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "androidx.compose.samples.crane"
 
     defaultConfig {
         applicationId = "androidx.compose.samples.crane"
@@ -79,8 +80,8 @@ android {
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
 
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -86,7 +86,7 @@ android {
 
     buildFeatures {
         compose = true
-
+        buildConfig = true
     }
 
     composeOptions {

--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -93,7 +93,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // Multiple dependency bring these files in. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
         excludes += "/META-INF/AL2.0"

--- a/Crane/app/proguard-rules.pro
+++ b/Crane/app/proguard-rules.pro
@@ -22,3 +22,14 @@
 
 # Repackage classes into the top-level.
 -repackageclasses
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/Crane/app/src/androidTest/AndroidManifest.xml
+++ b/Crane/app/src/androidTest/AndroidManifest.xml
@@ -16,8 +16,7 @@
   -->
 <!-- Added as workaround for https://github.com/android/android-test/issues/1412 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.compose.samples.crane">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
 

--- a/Crane/app/src/main/AndroidManifest.xml
+++ b/Crane/app/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
   ~
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.compose.samples.crane">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <!--

--- a/Crane/benchmark/build.gradle.kts
+++ b/Crane/benchmark/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.test)
     alias(libs.plugins.kotlin.android)

--- a/Crane/build.gradle.kts
+++ b/Crane/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/Crane/gradle/libs.versions.toml
+++ b/Crane/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Crane/gradle/libs.versions.toml
+++ b/Crane/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Crane/gradle/wrapper/gradle-wrapper.properties
+++ b/Crane/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/JetLagged/app/build.gradle.kts
+++ b/JetLagged/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/JetLagged/app/build.gradle.kts
+++ b/JetLagged/app/build.gradle.kts
@@ -86,7 +86,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // Multiple dependency bring these files in. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
         excludes += "/META-INF/AL2.0"

--- a/JetLagged/app/build.gradle.kts
+++ b/JetLagged/app/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.jetlagged"
 
     defaultConfig {
         applicationId = "com.example.jetlagged"
@@ -67,8 +68,8 @@ android {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/JetLagged/app/proguard-rules.pro
+++ b/JetLagged/app/proguard-rules.pro
@@ -22,3 +22,14 @@
 
 # Repackage classes into the top-level.
 -repackageclasses
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/JetLagged/app/src/main/AndroidManifest.xml
+++ b/JetLagged/app/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
   the License.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.jetlagged">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!--Load images from Unsplash-->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/JetLagged/build.gradle.kts
+++ b/JetLagged/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/JetLagged/gradle/wrapper/gradle-wrapper.properties
+++ b/JetLagged/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -88,7 +88,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // Multiple dependency bring these files in. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
         excludes += "/META-INF/AL2.0"

--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.jetnews"
+
     defaultConfig {
         applicationId = "com.example.jetnews"
         minSdk = libs.versions.minSdk.get().toInt()
@@ -74,8 +76,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/JetNews/app/proguard-rules.pro
+++ b/JetNews/app/proguard-rules.pro
@@ -22,3 +22,14 @@
 
 # Repackage classes into the top-level.
 -repackageclasses
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/JetNews/app/src/main/AndroidManifest.xml
+++ b/JetNews/app/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
   or implied. See the License for the specific language governing permissions and limitations under
   the License.
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.jetnews">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".JetnewsApplication"

--- a/JetNews/build.gradle.kts
+++ b/JetNews/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/JetNews/gradle/wrapper/gradle-wrapper.properties
+++ b/JetNews/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Jetcaster/app/build.gradle.kts
+++ b/Jetcaster/app/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.jetcaster"
 
     defaultConfig {
         applicationId = "com.example.jetcaster"
@@ -58,8 +59,8 @@ android {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/Jetcaster/app/build.gradle.kts
+++ b/Jetcaster/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/Jetcaster/app/build.gradle.kts
+++ b/Jetcaster/app/build.gradle.kts
@@ -65,13 +65,14 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // The Rome library JARs embed some internal utils libraries in nested JARs.
         // We don't need them so we exclude them in the final package.
         excludes += "/*.jar"

--- a/Jetcaster/app/proguard-rules.pro
+++ b/Jetcaster/app/proguard-rules.pro
@@ -36,3 +36,14 @@
 -dontwarn org.jaxen.DefaultNavigator
 -dontwarn org.jaxen.NamespaceContext
 -dontwarn org.jaxen.VariableContext
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/Jetcaster/app/proguard-rules.pro
+++ b/Jetcaster/app/proguard-rules.pro
@@ -38,6 +38,7 @@
 -dontwarn org.jaxen.VariableContext
 
 # This is generated automatically by the Android Gradle plugin.
+-dontwarn org.slf4j.impl.StaticLoggerBinder
 -dontwarn org.bouncycastle.jsse.BCSSLParameters
 -dontwarn org.bouncycastle.jsse.BCSSLSocket
 -dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider

--- a/Jetcaster/app/src/main/AndroidManifest.xml
+++ b/Jetcaster/app/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.jetcaster">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Uses ACCESS_NETWORK_STATE to check if the device is connected to internet or not -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/Jetcaster/build.gradle.kts
+++ b/Jetcaster/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetcaster/gradle/wrapper/gradle-wrapper.properties
+++ b/Jetcaster/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.compose.jetchat"
 
     defaultConfig {
         applicationId = "com.example.compose.jetchat"
@@ -58,8 +59,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -72,7 +72,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // Multiple dependency bring these files in. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
         excludes += "/META-INF/AL2.0"

--- a/Jetchat/app/proguard-rules.pro
+++ b/Jetchat/app/proguard-rules.pro
@@ -22,3 +22,14 @@
 
 # Repackage classes into the top-level.
 -repackageclasses
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/Jetchat/app/src/androidTest/AndroidManifest.xml
+++ b/Jetchat/app/src/androidTest/AndroidManifest.xml
@@ -16,8 +16,7 @@
   -->
 <!-- Added as workaround for https://github.com/android/android-test/issues/1412 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.compose.jetchat">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
 

--- a/Jetchat/app/src/main/AndroidManifest.xml
+++ b/Jetchat/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.compose.jetchat">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/Jetchat/build.gradle.kts
+++ b/Jetchat/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetchat/gradle/wrapper/gradle-wrapper.properties
+++ b/Jetchat/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -85,7 +85,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // Multiple dependency bring these files in. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
         excludes += "/META-INF/AL2.0"

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -67,18 +67,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {
         compose = true
-        // Disable unused AGP features
-        buildConfig = false
-        aidl = false
-        renderScript = false
-        resValues = false
-        shaders = false
     }
 
     composeOptions {

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.jetsnack"
 
     defaultConfig {
         applicationId = "com.example.jetsnack"

--- a/Jetsnack/app/proguard-rules.pro
+++ b/Jetsnack/app/proguard-rules.pro
@@ -22,3 +22,14 @@
 
 # Repackage classes into the top-level.
 -repackageclasses
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/Jetsnack/app/src/main/AndroidManifest.xml
+++ b/Jetsnack/app/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
   the License.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.jetsnack">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!--Load images from Unsplash-->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/Jetsnack/build.gradle.kts
+++ b/Jetsnack/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetsnack/gradle/wrapper/gradle-wrapper.properties
+++ b/Jetsnack/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Jetsurvey/app/build.gradle.kts
+++ b/Jetsurvey/app/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.compose.jetsurvey"
 
     defaultConfig {
         applicationId = "com.example.compose.jetsurvey"

--- a/Jetsurvey/app/build.gradle.kts
+++ b/Jetsurvey/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/Jetsurvey/app/build.gradle.kts
+++ b/Jetsurvey/app/build.gradle.kts
@@ -47,11 +47,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
     buildFeatures {
         compose = true

--- a/Jetsurvey/app/proguard-rules.pro
+++ b/Jetsurvey/app/proguard-rules.pro
@@ -22,3 +22,14 @@
 
 # Repackage classes into the top-level.
 -repackageclasses
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/Jetsurvey/app/src/main/AndroidManifest.xml
+++ b/Jetsurvey/app/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
   ~   limitations under the License.
   ~
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.compose.jetsurvey">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/Jetsurvey/build.gradle.kts
+++ b/Jetsurvey/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/Jetsurvey/gradle/libs.versions.toml
+++ b/Jetsurvey/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetsurvey/gradle/libs.versions.toml
+++ b/Jetsurvey/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Jetsurvey/gradle/wrapper/gradle-wrapper.properties
+++ b/Jetsurvey/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Owl/app/build.gradle.kts
+++ b/Owl/app/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.owl"
+
     defaultConfig {
         applicationId = "com.example.owl"
         minSdk = libs.versions.minSdk.get().toInt()
@@ -74,8 +76,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/Owl/app/build.gradle.kts
+++ b/Owl/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/Owl/app/build.gradle.kts
+++ b/Owl/app/build.gradle.kts
@@ -88,7 +88,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // Multiple dependency bring these files in. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
         excludes += "/META-INF/AL2.0"

--- a/Owl/app/proguard-rules.pro
+++ b/Owl/app/proguard-rules.pro
@@ -22,3 +22,14 @@
 
 # Repackage classes into the top-level.
 -repackageclasses
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/Owl/app/src/main/AndroidManifest.xml
+++ b/Owl/app/src/main/AndroidManifest.xml
@@ -13,9 +13,7 @@
   the License.
   -->
 
-<manifest
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        package="com.example.owl">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!--Load images from Unsplash-->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/Owl/build.gradle.kts
+++ b/Owl/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/Owl/gradle/libs.versions.toml
+++ b/Owl/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Owl/gradle/libs.versions.toml
+++ b/Owl/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Owl/gradle/wrapper/gradle-wrapper.properties
+++ b/Owl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Reply/app/build.gradle.kts
+++ b/Reply/app/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
+    namespace = "com.example.reply"
+
     defaultConfig {
         applicationId = "com.example.reply"
         minSdk = libs.versions.minSdk.get().toInt()
@@ -74,8 +76,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/Reply/app/build.gradle.kts
+++ b/Reply/app/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/Reply/app/build.gradle.kts
+++ b/Reply/app/build.gradle.kts
@@ -88,7 +88,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
-    packagingOptions {
+    packaging.resources {
         // Multiple dependency bring these files in. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
         excludes += "/META-INF/AL2.0"

--- a/Reply/app/proguard-rules.pro
+++ b/Reply/app/proguard-rules.pro
@@ -33,3 +33,14 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# This is generated automatically by the Android Gradle plugin.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/Reply/app/src/main/AndroidManifest.xml
+++ b/Reply/app/src/main/AndroidManifest.xml
@@ -10,8 +10,7 @@
   the License.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.reply">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/Reply/build.gradle.kts
+++ b/Reply/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove when updating to Gradle 8.1 (https://github.com/gradle/gradle/issues/22797)
 plugins {
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.version.catalog.update)

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/Reply/gradle/wrapper/gradle-wrapper.properties
+++ b/Reply/gradle/wrapper/gradle-wrapper.properties
@@ -14,7 +14,7 @@
 
 #Fri Mar 04 12:02:05 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/scripts/libs.versions.toml
+++ b/scripts/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "8.0.0-rc01"
+androidGradlePlugin = "8.0.0"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"

--- a/scripts/libs.versions.toml
+++ b/scripts/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.28.0"
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0-rc01"
 androidx-activity-compose = "1.7.0"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.0"


### PR DESCRIPTION
- update to Gradle 8.1 and removes DSL_SCOPE_VIOLATION
- updates to AGP 8.0 in all projects
- updates to JAVA_VERSION.VERSION_17
- migrates packagingOptions --> packaging.resources
- updates workflows to use JDK 17 + zulu distribution
- updates workflows to use build-sample.yml from current commit rather than using it from `@main`
