### PR TITLE
[Reply] Allow multi-select of emails and highlight the opened email

### DIFF
--- a/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
@@ -55,7 +55,7 @@ class MainActivity : ComponentActivity() {
                         viewModel.closeDetailScreen()
                     },
                     navigateToDetail = { emailId, pane ->
-                        viewModel.setSelectedEmail(emailId, pane)
+                        viewModel.setOpenedEmail(emailId, pane)
                     }
                 )
             }

--- a/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
@@ -56,6 +56,9 @@ class MainActivity : ComponentActivity() {
                     },
                     navigateToDetail = { emailId, pane ->
                         viewModel.setOpenedEmail(emailId, pane)
+                    },
+                    toggleSelectedEmail = { emailId ->
+                        viewModel.toggleSelectedEmail(emailId)
                     }
                 )
             }

--- a/Reply/app/src/main/java/com/example/reply/ui/ReplyApp.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/ReplyApp.kt
@@ -64,7 +64,8 @@ fun ReplyApp(
     displayFeatures: List<DisplayFeature>,
     replyHomeUIState: ReplyHomeUIState,
     closeDetailScreen: () -> Unit = {},
-    navigateToDetail: (Long, ReplyContentType) -> Unit = { _, _ -> }
+    navigateToDetail: (Long, ReplyContentType) -> Unit = { _, _ -> },
+    toggleSelectedEmail: (Long) -> Unit = { }
 ) {
     /**
      * This will help us select type of navigation and content type depending on window size and
@@ -141,7 +142,8 @@ fun ReplyApp(
         navigationContentPosition = navigationContentPosition,
         replyHomeUIState = replyHomeUIState,
         closeDetailScreen = closeDetailScreen,
-        navigateToDetail = navigateToDetail
+        navigateToDetail = navigateToDetail,
+        toggleSelectedEmail = toggleSelectedEmail
     )
 }
 
@@ -154,7 +156,8 @@ private fun ReplyNavigationWrapper(
     navigationContentPosition: ReplyNavigationContentPosition,
     replyHomeUIState: ReplyHomeUIState,
     closeDetailScreen: () -> Unit,
-    navigateToDetail: (Long, ReplyContentType) -> Unit
+    navigateToDetail: (Long, ReplyContentType) -> Unit,
+    toggleSelectedEmail: (Long) -> Unit
 ) {
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -186,7 +189,8 @@ private fun ReplyNavigationWrapper(
                 selectedDestination = selectedDestination,
                 navigateToTopLevelDestination = navigationActions::navigateTo,
                 closeDetailScreen = closeDetailScreen,
-                navigateToDetail = navigateToDetail
+                navigateToDetail = navigateToDetail,
+                toggleSelectedEmail = toggleSelectedEmail
             )
         }
     } else {
@@ -215,7 +219,8 @@ private fun ReplyNavigationWrapper(
                 selectedDestination = selectedDestination,
                 navigateToTopLevelDestination = navigationActions::navigateTo,
                 closeDetailScreen = closeDetailScreen,
-                navigateToDetail = navigateToDetail
+                navigateToDetail = navigateToDetail,
+                toggleSelectedEmail = toggleSelectedEmail
             ) {
                 scope.launch {
                     drawerState.open()
@@ -238,6 +243,7 @@ fun ReplyAppContent(
     navigateToTopLevelDestination: (ReplyTopLevelDestination) -> Unit,
     closeDetailScreen: () -> Unit,
     navigateToDetail: (Long, ReplyContentType) -> Unit,
+    toggleSelectedEmail: (Long) -> Unit,
     onDrawerClicked: () -> Unit = {}
 ) {
     Row(modifier = modifier.fillMaxSize()) {
@@ -262,6 +268,7 @@ fun ReplyAppContent(
                 navigationType = navigationType,
                 closeDetailScreen = closeDetailScreen,
                 navigateToDetail = navigateToDetail,
+                toggleSelectedEmail = toggleSelectedEmail,
                 modifier = Modifier.weight(1f),
             )
             AnimatedVisibility(visible = navigationType == ReplyNavigationType.BOTTOM_NAVIGATION) {
@@ -283,6 +290,7 @@ private fun ReplyNavHost(
     navigationType: ReplyNavigationType,
     closeDetailScreen: () -> Unit,
     navigateToDetail: (Long, ReplyContentType) -> Unit,
+    toggleSelectedEmail: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -298,6 +306,7 @@ private fun ReplyNavHost(
                 displayFeatures = displayFeatures,
                 closeDetailScreen = closeDetailScreen,
                 navigateToDetail = navigateToDetail,
+                toggleSelectedEmail = toggleSelectedEmail
             )
         }
         composable(ReplyRoute.DM) {

--- a/Reply/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
@@ -67,6 +67,14 @@ class ReplyHomeViewModel(private val emailsRepository: EmailsRepository = Emails
         )
     }
 
+    fun toggleSelectedEmail(emailId: Long) {
+        val currentSelection = uiState.value.selectedEmails
+        _uiState.value = _uiState.value.copy(
+            selectedEmails = if (currentSelection.contains(emailId))
+                currentSelection.minus(emailId) else currentSelection.plus(emailId)
+        )
+    }
+
     fun closeDetailScreen() {
         _uiState.value = _uiState
             .value.copy(
@@ -78,6 +86,7 @@ class ReplyHomeViewModel(private val emailsRepository: EmailsRepository = Emails
 
 data class ReplyHomeUIState(
     val emails: List<Email> = emptyList(),
+    val selectedEmails: Set<Long> = emptySet(),
     val openedEmail: Email? = null,
     val isDetailOnlyOpen: Boolean = false,
     val loading: Boolean = false,

--- a/Reply/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/ReplyHomeViewModel.kt
@@ -50,19 +50,19 @@ class ReplyHomeViewModel(private val emailsRepository: EmailsRepository = Emails
                      */
                     _uiState.value = ReplyHomeUIState(
                         emails = emails,
-                        selectedEmail = emails.first()
+                        openedEmail = emails.first()
                     )
                 }
         }
     }
 
-    fun setSelectedEmail(emailId: Long, contentType: ReplyContentType) {
+    fun setOpenedEmail(emailId: Long, contentType: ReplyContentType) {
         /**
          * We only set isDetailOnlyOpen to true when it's only single pane layout
          */
         val email = uiState.value.emails.find { it.id == emailId }
         _uiState.value = _uiState.value.copy(
-            selectedEmail = email,
+            openedEmail = email,
             isDetailOnlyOpen = contentType == ReplyContentType.SINGLE_PANE
         )
     }
@@ -71,14 +71,14 @@ class ReplyHomeViewModel(private val emailsRepository: EmailsRepository = Emails
         _uiState.value = _uiState
             .value.copy(
                 isDetailOnlyOpen = false,
-                selectedEmail = _uiState.value.emails.first()
+                openedEmail = _uiState.value.emails.first()
             )
     }
 }
 
 data class ReplyHomeUIState(
     val emails: List<Email> = emptyList(),
-    val selectedEmail: Email? = null,
+    val openedEmail: Email? = null,
     val isDetailOnlyOpen: Boolean = false,
     val loading: Boolean = false,
     val error: String? = null

--- a/Reply/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
@@ -58,161 +58,163 @@ import com.google.accompanist.adaptive.TwoPane
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReplyInboxScreen(
-  contentType: ReplyContentType,
-  replyHomeUIState: ReplyHomeUIState,
-  navigationType: ReplyNavigationType,
-  displayFeatures: List<DisplayFeature>,
-  closeDetailScreen: () -> Unit,
-  navigateToDetail: (Long, ReplyContentType) -> Unit,
-  modifier: Modifier = Modifier
+    contentType: ReplyContentType,
+    replyHomeUIState: ReplyHomeUIState,
+    navigationType: ReplyNavigationType,
+    displayFeatures: List<DisplayFeature>,
+    closeDetailScreen: () -> Unit,
+    navigateToDetail: (Long, ReplyContentType) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-  /**
-   * When moving from LIST_AND_DETAIL page to LIST page clear the selection and user should see LIST screen.
-   */
-  LaunchedEffect(key1 = contentType) {
-    if (contentType == ReplyContentType.SINGLE_PANE && !replyHomeUIState.isDetailOnlyOpen) {
-      closeDetailScreen()
-    }
-  }
-
-  var selectedEmailIds by remember { mutableStateOf(setOf<Long>()) }
-  val swapEmailSelection = { id: Long ->
-    if (selectedEmailIds.contains(id))
-      selectedEmailIds -= id
-    else selectedEmailIds += id
-  }
-  val emailLazyListState = rememberLazyListState()
-
-  // TODO: Show top app bar over full width of app when in multi-select mode
-
-  if (contentType == ReplyContentType.DUAL_PANE) {
-    TwoPane(
-      first = {
-        ReplyEmailList(
-          emails = replyHomeUIState.emails,
-          openedEmail = replyHomeUIState.openedEmail,
-          selectedEmailIds = selectedEmailIds,
-          swapEmailSelection = swapEmailSelection,
-          emailLazyListState = emailLazyListState,
-          navigateToDetail = navigateToDetail
-        )
-      },
-      second = {
-        ReplyEmailDetail(
-          email = replyHomeUIState.openedEmail ?: replyHomeUIState.emails.first(),
-          isFullScreen = false
-        )
-      },
-      strategy = HorizontalTwoPaneStrategy(splitFraction = 0.5f, gapWidth = 16.dp),
-      displayFeatures = displayFeatures
-    )
-  } else {
-    Box(modifier = modifier.fillMaxSize()) {
-      ReplySinglePaneContent(
-        replyHomeUIState = replyHomeUIState,
-        selectedEmailIds = selectedEmailIds,
-        swapEmailSelection = swapEmailSelection,
-        emailLazyListState = emailLazyListState,
-        modifier = Modifier.fillMaxSize(),
-        closeDetailScreen = closeDetailScreen,
-        navigateToDetail = navigateToDetail
-      )
-      // When we have bottom navigation we show FAB at the bottom end.
-      if (navigationType == ReplyNavigationType.BOTTOM_NAVIGATION) {
-        LargeFloatingActionButton(
-          onClick = { /*TODO*/ },
-          modifier = Modifier
-            .align(Alignment.BottomEnd)
-            .padding(16.dp),
-          containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-          contentColor = MaterialTheme.colorScheme.onTertiaryContainer
-        ) {
-          Icon(
-            imageVector = Icons.Default.Edit,
-            contentDescription = stringResource(id = R.string.edit),
-            modifier = Modifier.size(28.dp)
-          )
+    /**
+     * When moving from LIST_AND_DETAIL page to LIST page clear the selection and user should see LIST screen.
+     */
+    LaunchedEffect(key1 = contentType) {
+        if (contentType == ReplyContentType.SINGLE_PANE && !replyHomeUIState.isDetailOnlyOpen) {
+            closeDetailScreen()
         }
-      }
     }
-  }
+
+    var selectedEmailIds by remember { mutableStateOf(setOf<Long>()) }
+    val swapEmailSelection = { id: Long ->
+        if (selectedEmailIds.contains(id))
+            selectedEmailIds -= id
+        else selectedEmailIds += id
+    }
+    val emailLazyListState = rememberLazyListState()
+
+    // TODO: Show top app bar over full width of app when in multi-select mode
+
+    if (contentType == ReplyContentType.DUAL_PANE) {
+        TwoPane(
+            first = {
+                ReplyEmailList(
+                    emails = replyHomeUIState.emails,
+                    openedEmail = replyHomeUIState.openedEmail,
+                    selectedEmailIds = selectedEmailIds,
+                    swapEmailSelection = swapEmailSelection,
+                    emailLazyListState = emailLazyListState,
+                    navigateToDetail = navigateToDetail
+                )
+            },
+            second = {
+                ReplyEmailDetail(
+                    email = replyHomeUIState.openedEmail ?: replyHomeUIState.emails.first(),
+                    isFullScreen = false
+                )
+            },
+            strategy = HorizontalTwoPaneStrategy(splitFraction = 0.5f, gapWidth = 16.dp),
+            displayFeatures = displayFeatures
+        )
+    } else {
+        Box(modifier = modifier.fillMaxSize()) {
+            ReplySinglePaneContent(
+                replyHomeUIState = replyHomeUIState,
+                selectedEmailIds = selectedEmailIds,
+                swapEmailSelection = swapEmailSelection,
+                emailLazyListState = emailLazyListState,
+                modifier = Modifier.fillMaxSize(),
+                closeDetailScreen = closeDetailScreen,
+                navigateToDetail = navigateToDetail
+            )
+            // When we have bottom navigation we show FAB at the bottom end.
+            if (navigationType == ReplyNavigationType.BOTTOM_NAVIGATION) {
+                LargeFloatingActionButton(
+                    onClick = { /*TODO*/ },
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = stringResource(id = R.string.edit),
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable
 fun ReplySinglePaneContent(
-  replyHomeUIState: ReplyHomeUIState,
-  selectedEmailIds: Set<Long>,
-  swapEmailSelection: (Long) -> Unit,
-  emailLazyListState: LazyListState,
-  modifier: Modifier = Modifier,
-  closeDetailScreen: () -> Unit,
-  navigateToDetail: (Long, ReplyContentType) -> Unit
+    replyHomeUIState: ReplyHomeUIState,
+    selectedEmailIds: Set<Long>,
+    swapEmailSelection: (Long) -> Unit,
+    emailLazyListState: LazyListState,
+    modifier: Modifier = Modifier,
+    closeDetailScreen: () -> Unit,
+    navigateToDetail: (Long, ReplyContentType) -> Unit
 ) {
-  if (replyHomeUIState.openedEmail != null && replyHomeUIState.isDetailOnlyOpen) {
-    BackHandler {
-      closeDetailScreen()
+    if (replyHomeUIState.openedEmail != null && replyHomeUIState.isDetailOnlyOpen) {
+        BackHandler {
+            closeDetailScreen()
+        }
+        ReplyEmailDetail(email = replyHomeUIState.openedEmail) {
+            closeDetailScreen()
+        }
+    } else {
+        ReplyEmailList(
+            emails = replyHomeUIState.emails,
+            openedEmail = replyHomeUIState.openedEmail,
+            selectedEmailIds = selectedEmailIds,
+            swapEmailSelection = swapEmailSelection,
+            emailLazyListState = emailLazyListState,
+            modifier = modifier,
+            navigateToDetail = navigateToDetail
+        )
     }
-    ReplyEmailDetail(email = replyHomeUIState.openedEmail) {
-      closeDetailScreen()
-    }
-  } else {
-    ReplyEmailList(
-      emails = replyHomeUIState.emails,
-      openedEmail = replyHomeUIState.openedEmail,
-      selectedEmailIds = selectedEmailIds,
-      swapEmailSelection = swapEmailSelection,
-      emailLazyListState = emailLazyListState,
-      modifier = modifier,
-      navigateToDetail = navigateToDetail
-    )
-  }
 }
 
 @Composable
 fun ReplyEmailList(
-  emails: List<Email>,
-  openedEmail: Email?,
-  selectedEmailIds: Set<Long>,
-  swapEmailSelection: (Long) -> Unit,
-  emailLazyListState: LazyListState,
-  modifier: Modifier = Modifier,
-  navigateToDetail: (Long, ReplyContentType) -> Unit
+    emails: List<Email>,
+    openedEmail: Email?,
+    selectedEmailIds: Set<Long>,
+    swapEmailSelection: (Long) -> Unit,
+    emailLazyListState: LazyListState,
+    modifier: Modifier = Modifier,
+    navigateToDetail: (Long, ReplyContentType) -> Unit
 ) {
-  LazyColumn(modifier = modifier, state = emailLazyListState) {
-    item {
-      ReplySearchBar(modifier = Modifier.fillMaxWidth())
+    LazyColumn(modifier = modifier, state = emailLazyListState) {
+        item {
+            ReplySearchBar(modifier = Modifier.fillMaxWidth())
+        }
+        items(items = emails, key = { it.id }) { email ->
+            ReplyEmailListItem(
+                email = email,
+                navigateToDetail = { emailId ->
+                    navigateToDetail(emailId, ReplyContentType.SINGLE_PANE)
+                },
+                swapSelection = swapEmailSelection,
+                isOpened = openedEmail?.id == email.id,
+                isSelected = selectedEmailIds.contains(email.id)
+            )
+        }
     }
-    items(items = emails, key = { it.id }) { email ->
-      ReplyEmailListItem(
-        email = email,
-        navigateToDetail = { emailId -> navigateToDetail(emailId, ReplyContentType.SINGLE_PANE) },
-        swapSelection = swapEmailSelection,
-        isOpened = openedEmail?.id == email.id,
-        isSelected = selectedEmailIds.contains(email.id)
-      )
-    }
-  }
 }
 
 @Composable
 fun ReplyEmailDetail(
-  email: Email,
-  isFullScreen: Boolean = true,
-  modifier: Modifier = Modifier.fillMaxSize(),
-  onBackPressed: () -> Unit = {}
+    email: Email,
+    isFullScreen: Boolean = true,
+    modifier: Modifier = Modifier.fillMaxSize(),
+    onBackPressed: () -> Unit = {}
 ) {
-  LazyColumn(
-    modifier = modifier
-      .background(MaterialTheme.colorScheme.inverseOnSurface)
-      .padding(top = 16.dp)
-  ) {
-    item {
-      EmailDetailAppBar(email, isFullScreen) {
-        onBackPressed()
-      }
+    LazyColumn(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.inverseOnSurface)
+            .padding(top = 16.dp)
+    ) {
+        item {
+            EmailDetailAppBar(email, isFullScreen) {
+                onBackPressed()
+            }
+        }
+        items(items = email.threads, key = { it.id }) { email ->
+            ReplyEmailThreadItem(email = email)
+        }
     }
-    items(items = email.threads, key = { it.id }) { email ->
-      ReplyEmailThreadItem(email = email)
-    }
-  }
 }

--- a/Reply/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
@@ -35,10 +35,6 @@ import androidx.compose.material3.LargeFloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -64,6 +60,7 @@ fun ReplyInboxScreen(
     displayFeatures: List<DisplayFeature>,
     closeDetailScreen: () -> Unit,
     navigateToDetail: (Long, ReplyContentType) -> Unit,
+    toggleSelectedEmail: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     /**
@@ -75,12 +72,6 @@ fun ReplyInboxScreen(
         }
     }
 
-    var selectedEmailIds by remember { mutableStateOf(setOf<Long>()) }
-    val swapEmailSelection = { id: Long ->
-        if (selectedEmailIds.contains(id))
-            selectedEmailIds -= id
-        else selectedEmailIds += id
-    }
     val emailLazyListState = rememberLazyListState()
 
     // TODO: Show top app bar over full width of app when in multi-select mode
@@ -91,8 +82,8 @@ fun ReplyInboxScreen(
                 ReplyEmailList(
                     emails = replyHomeUIState.emails,
                     openedEmail = replyHomeUIState.openedEmail,
-                    selectedEmailIds = selectedEmailIds,
-                    swapEmailSelection = swapEmailSelection,
+                    selectedEmailIds = replyHomeUIState.selectedEmails,
+                    toggleEmailSelection = toggleSelectedEmail,
                     emailLazyListState = emailLazyListState,
                     navigateToDetail = navigateToDetail
                 )
@@ -110,8 +101,7 @@ fun ReplyInboxScreen(
         Box(modifier = modifier.fillMaxSize()) {
             ReplySinglePaneContent(
                 replyHomeUIState = replyHomeUIState,
-                selectedEmailIds = selectedEmailIds,
-                swapEmailSelection = swapEmailSelection,
+                toggleEmailSelection = toggleSelectedEmail,
                 emailLazyListState = emailLazyListState,
                 modifier = Modifier.fillMaxSize(),
                 closeDetailScreen = closeDetailScreen,
@@ -141,8 +131,7 @@ fun ReplyInboxScreen(
 @Composable
 fun ReplySinglePaneContent(
     replyHomeUIState: ReplyHomeUIState,
-    selectedEmailIds: Set<Long>,
-    swapEmailSelection: (Long) -> Unit,
+    toggleEmailSelection: (Long) -> Unit,
     emailLazyListState: LazyListState,
     modifier: Modifier = Modifier,
     closeDetailScreen: () -> Unit,
@@ -159,8 +148,8 @@ fun ReplySinglePaneContent(
         ReplyEmailList(
             emails = replyHomeUIState.emails,
             openedEmail = replyHomeUIState.openedEmail,
-            selectedEmailIds = selectedEmailIds,
-            swapEmailSelection = swapEmailSelection,
+            selectedEmailIds = replyHomeUIState.selectedEmails,
+            toggleEmailSelection = toggleEmailSelection,
             emailLazyListState = emailLazyListState,
             modifier = modifier,
             navigateToDetail = navigateToDetail
@@ -173,7 +162,7 @@ fun ReplyEmailList(
     emails: List<Email>,
     openedEmail: Email?,
     selectedEmailIds: Set<Long>,
-    swapEmailSelection: (Long) -> Unit,
+    toggleEmailSelection: (Long) -> Unit,
     emailLazyListState: LazyListState,
     modifier: Modifier = Modifier,
     navigateToDetail: (Long, ReplyContentType) -> Unit
@@ -188,7 +177,7 @@ fun ReplyEmailList(
                 navigateToDetail = { emailId ->
                     navigateToDetail(emailId, ReplyContentType.SINGLE_PANE)
                 },
-                swapSelection = swapEmailSelection,
+                toggleSelection = toggleEmailSelection,
                 isOpened = openedEmail?.id == email.id,
                 isSelected = selectedEmailIds.contains(email.id)
             )

--- a/Reply/app/src/main/java/com/example/reply/ui/components/ReplyEmailListItem.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/components/ReplyEmailListItem.kt
@@ -52,119 +52,119 @@ import androidx.compose.ui.unit.dp
 import com.example.reply.data.Email
 
 @OptIn(
-  ExperimentalFoundationApi::class,
-  ExperimentalAnimationApi::class
+    ExperimentalFoundationApi::class,
+    ExperimentalAnimationApi::class
 )
 @Composable
 fun ReplyEmailListItem(
-  email: Email,
-  navigateToDetail: (Long) -> Unit,
-  swapSelection: (Long) -> Unit,
-  modifier: Modifier = Modifier,
-  isOpened: Boolean = false,
-  isSelected: Boolean = false,
+    email: Email,
+    navigateToDetail: (Long) -> Unit,
+    swapSelection: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    isOpened: Boolean = false,
+    isSelected: Boolean = false,
 ) {
-  Card(
-    modifier = modifier
-      .padding(horizontal = 16.dp, vertical = 4.dp)
-      .semantics { selected = isSelected }
-      .clip(CardDefaults.shape)
-      .combinedClickable(
-        onClick = { navigateToDetail(email.id) },
-        onLongClick = { swapSelection(email.id) }
-      )
-      .clip(CardDefaults.shape),
-    colors = CardDefaults.cardColors(
-      containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer
-      else if (isOpened) MaterialTheme.colorScheme.secondaryContainer
-      else MaterialTheme.colorScheme.surfaceVariant
-    )
-  ) {
-    Column(
-      modifier = Modifier
-        .fillMaxWidth()
-        .padding(20.dp)
-    ) {
-      Row(modifier = Modifier.fillMaxWidth()) {
-        val clickModifier = Modifier.clickable(
-          interactionSource = remember { MutableInteractionSource() },
-          indication = null
-        ) { swapSelection(email.id) }
-        AnimatedContent(targetState = isSelected, label = "avatar") { selected ->
-          if (selected) {
-            SelectedProfileImage(clickModifier)
-          } else {
-            ReplyProfileImage(
-              email.sender.avatar,
-              email.sender.fullName,
-              clickModifier
+    Card(
+        modifier = modifier
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .semantics { selected = isSelected }
+            .clip(CardDefaults.shape)
+            .combinedClickable(
+                onClick = { navigateToDetail(email.id) },
+                onLongClick = { swapSelection(email.id) }
             )
-          }
-        }
-
+            .clip(CardDefaults.shape),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer
+            else if (isOpened) MaterialTheme.colorScheme.secondaryContainer
+            else MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
         Column(
-          modifier = Modifier
-            .weight(1f)
-            .padding(horizontal = 12.dp, vertical = 4.dp),
-          verticalArrangement = Arrangement.Center
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
         ) {
-          Text(
-            text = email.sender.firstName,
-            style = MaterialTheme.typography.labelMedium
-          )
-          Text(
-            text = email.createdAt,
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.outline
-          )
-        }
-        IconButton(
-          onClick = { /*TODO*/ },
-          modifier = Modifier
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surface)
-        ) {
-          Icon(
-            imageVector = Icons.Default.StarBorder,
-            contentDescription = "Favorite",
-            tint = MaterialTheme.colorScheme.outline
-          )
-        }
-      }
+            Row(modifier = Modifier.fillMaxWidth()) {
+                val clickModifier = Modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) { swapSelection(email.id) }
+                AnimatedContent(targetState = isSelected, label = "avatar") { selected ->
+                    if (selected) {
+                        SelectedProfileImage(clickModifier)
+                    } else {
+                        ReplyProfileImage(
+                            email.sender.avatar,
+                            email.sender.fullName,
+                            clickModifier
+                        )
+                    }
+                }
 
-      Text(
-        text = email.subject,
-        style = MaterialTheme.typography.bodyLarge,
-        color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
-        else MaterialTheme.colorScheme.onSurface,
-        modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
-      )
-      Text(
-        text = email.body,
-        style = MaterialTheme.typography.bodyMedium,
-        maxLines = 2,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        overflow = TextOverflow.Ellipsis
-      )
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 12.dp, vertical = 4.dp),
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = email.sender.firstName,
+                        style = MaterialTheme.typography.labelMedium
+                    )
+                    Text(
+                        text = email.createdAt,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.outline
+                    )
+                }
+                IconButton(
+                    onClick = { /*TODO*/ },
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surface)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.StarBorder,
+                        contentDescription = "Favorite",
+                        tint = MaterialTheme.colorScheme.outline
+                    )
+                }
+            }
+
+            Text(
+                text = email.subject,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
+                else MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
+            )
+            Text(
+                text = email.body,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
-  }
 }
 
 @Composable
 fun SelectedProfileImage(modifier: Modifier = Modifier) {
-  Box(
-    modifier
-      .size(40.dp)
-      .clip(CircleShape)
-      .background(MaterialTheme.colorScheme.primary)
-  ) {
-    Icon(
-      Icons.Default.Check,
-      contentDescription = null,
-      modifier = Modifier
-        .size(24.dp)
-        .align(Alignment.Center),
-      tint = MaterialTheme.colorScheme.onPrimary
-    )
-  }
+    Box(
+        modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primary)
+    ) {
+        Icon(
+            Icons.Default.Check,
+            contentDescription = null,
+            modifier = Modifier
+                .size(24.dp)
+                .align(Alignment.Center),
+            tint = MaterialTheme.colorScheme.onPrimary
+        )
+    }
 }

--- a/Reply/app/src/main/java/com/example/reply/ui/components/ReplyEmailListItem.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/components/ReplyEmailListItem.kt
@@ -59,7 +59,7 @@ import com.example.reply.data.Email
 fun ReplyEmailListItem(
     email: Email,
     navigateToDetail: (Long) -> Unit,
-    swapSelection: (Long) -> Unit,
+    toggleSelection: (Long) -> Unit,
     modifier: Modifier = Modifier,
     isOpened: Boolean = false,
     isSelected: Boolean = false,
@@ -71,7 +71,7 @@ fun ReplyEmailListItem(
             .clip(CardDefaults.shape)
             .combinedClickable(
                 onClick = { navigateToDetail(email.id) },
-                onLongClick = { swapSelection(email.id) }
+                onLongClick = { toggleSelection(email.id) }
             )
             .clip(CardDefaults.shape),
         colors = CardDefaults.cardColors(
@@ -89,7 +89,7 @@ fun ReplyEmailListItem(
                 val clickModifier = Modifier.clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null
-                ) { swapSelection(email.id) }
+                ) { toggleSelection(email.id) }
                 AnimatedContent(targetState = isSelected, label = "avatar") { selected ->
                     if (selected) {
                         SelectedProfileImage(clickModifier)


### PR DESCRIPTION
Allow multi-select of emails, by:
- tapping the avatar
- long-pressing the card

A selected email (during multi-select) is highlighted with a different background and a checkmark instead of the Avatar. The opened email is highlighted with a different container color.

This PR also fixes issue #1122 (ripple not clipped)

![Screenshot_20230430_135836](https://user-images.githubusercontent.com/6952116/235368797-92bcb393-7cf3-41cb-b740-5de0379fe677.png)

