### PR TITLE
fixes issue#1137 - converting SnackDetail to dialog

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/JetsnackApp.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/JetsnackApp.kt
@@ -21,11 +21,12 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.SnackbarHost
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.example.jetsnack.ui.components.JetsnackScaffold
@@ -42,7 +43,7 @@ fun JetsnackApp() {
         val appState = rememberJetsnackAppState()
         JetsnackScaffold(
             bottomBar = {
-                if (appState.shouldShowBottomBar) {
+                if(appState.currentRoute != null){
                     JetsnackBottomBar(
                         tabs = appState.bottomBarTabs,
                         currentRoute = appState.currentRoute!!,
@@ -83,9 +84,10 @@ private fun NavGraphBuilder.jetsnackNavGraph(
     ) {
         addHomeGraph(onSnackSelected)
     }
-    composable(
-        "${MainDestinations.SNACK_DETAIL_ROUTE}/{${MainDestinations.SNACK_ID_KEY}}",
-        arguments = listOf(navArgument(MainDestinations.SNACK_ID_KEY) { type = NavType.LongType })
+    dialog(
+        route ="${MainDestinations.SNACK_DETAIL_ROUTE}/{${MainDestinations.SNACK_ID_KEY}}",
+        arguments = listOf(navArgument(MainDestinations.SNACK_ID_KEY) { type = NavType.LongType }),
+        dialogProperties = DialogProperties( decorFitsSystemWindows = false)
     ) { backStackEntry ->
         val arguments = requireNotNull(backStackEntry.arguments)
         val snackId = arguments.getLong(MainDestinations.SNACK_ID_KEY)


### PR DESCRIPTION
fixes #1137

Replacing SnackDetail screen composable with dialog on Jetsnack App to fix bug of #1137 - LazyColumn last element partially visible.

It's recommended by [Android official documentation](https://developer.android.com/reference/kotlin/androidx/navigation/compose/package-summary#(androidx.navigation.NavGraphBuilder).dialog(kotlin.String,kotlin.collections.List,kotlin.collections.List,androidx.compose.ui.window.DialogProperties,kotlin.Function1)).
>Use Compose navigation [dialog()](https://developer.android.com/reference/kotlin/androidx/navigation/compose/package-summary#(androidx.navigation.NavGraphBuilder).dialog(kotlin.String,kotlin.collections.List,kotlin.collections.List,androidx.compose.ui.window.DialogProperties,kotlin.Function1)) if dialog represents a separate screen in your app that needs its own lifecycle and saved state, independent of any other destination in your navigation graph

It also improves performance. Because the system doesn't need to draw and hide the bottom bar all the time.

Also, Popular food ordering applications prefer this approach.

Current:

https://github.com/android/compose-samples/assets/44626280/54bead96-fffd-4e0e-b405-2fd967fbb3d5



Fix:

https://github.com/android/compose-samples/assets/44626280/fe7af341-f42a-4234-865c-e397906f0997

