### PR TITLE
[Jetsnack] Fix test adding junit4 dep and setting content from activity

### DIFF
--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -124,4 +124,5 @@ dependencies {
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.compose.ui.test)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 }

--- a/Jetsnack/app/src/androidTest/java/com/example/jetsnack/AppTest.kt
+++ b/Jetsnack/app/src/androidTest/java/com/example/jetsnack/AppTest.kt
@@ -16,6 +16,7 @@
 
 package com.example.jetsnack
 
+import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -33,7 +34,7 @@ class AppTest {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        composeTestRule.activity.setContent {
             JetsnackApp()
         }
     }


### PR DESCRIPTION
At the moment, test are not compiling, so I had to add junit4 dependency.

After adding it I was getting this error when running the tests:
> java.lang.IllegalStateException: com.example.jetsnack.ui.MainActivity@a887c6a has already set content. If you have populated the Activity with a ComposeView, make sure to call setContent on that ComposeView instead of on the test rule; and make sure that that call to `setContent {}` is done after the ComposeTestRule has run
> at androidx.compose.ui.test.AndroidComposeUiTestEnvironment$AndroidComposeUiTestImpl.setContent(ComposeUiTest.android.kt:488)
> at androidx.compose.ui.test.junit4.AndroidComposeTestRule.setContent(AndroidComposeTestRule.android.kt:340)
> at com.example.jetsnack.AppTest.setUp(AppTest.kt:37)

To fix it, I called setContent from test rule activity.
