### PR TITLE
Use github.actor as reviewer for updating dependencies

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -34,3 +34,5 @@ jobs:
         delete-branch: true
         title: '🤖 Update Dependencies'
         body: Updated depedencies
+        reviewers: ${{ github.actor }}
+        team-reviewers: android/performance-devrel

--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -35,4 +35,3 @@ jobs:
         title: '🤖 Update Dependencies'
         body: Updated depedencies
         reviewers: ${{ github.actor }}
-        team-reviewers: android/performance-devrel


### PR DESCRIPTION
This way, the workflow should always ask for review the person that triggered this workflow.
It also adds compose-devrel as a reviewer which might assign another person, but not sure how to remove that, since it's not defined in the action 🤔 


Tested here #1164 #1163 