### PR TITLE
[Crane] Implement updates to transition animation api under Crane's Home screen

### DIFF
--- a/Crane/app/src/main/java/androidx/compose/samples/crane/home/CraneHome.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/home/CraneHome.kt
@@ -17,7 +17,6 @@
 package androidx.compose.samples.crane.home
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.animation.core.EaseInOut
@@ -25,7 +24,7 @@ import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.with
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
@@ -204,7 +203,6 @@ private fun HomeTabBar(
 
 private const val TAB_SWITCH_ANIM_DURATION = 300
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun SearchContent(
     widthSize: WindowWidthSizeClass,
@@ -222,7 +220,7 @@ private fun SearchContent(
         transitionSpec = {
             fadeIn(
                 animationSpec = tween(TAB_SWITCH_ANIM_DURATION, easing = EaseIn)
-            ).with(
+            ).togetherWith(
                 fadeOut(
                     animationSpec = tween(TAB_SWITCH_ANIM_DURATION, easing = EaseOut)
                 )

--- a/Crane/app/src/main/java/androidx/compose/samples/crane/home/SearchUserInput.kt
+++ b/Crane/app/src/main/java/androidx/compose/samples/crane/home/SearchUserInput.kt
@@ -134,9 +134,9 @@ private fun tintPeopleUserInput(
     val validColor = MaterialTheme.colors.onSurface
     val invalidColor = MaterialTheme.colors.secondary
 
-    val transition = updateTransition(transitionState)
+    val transition = updateTransition(transitionState, label = stringResource(R.string.tint_transition))
     return transition.animateColor(
-        transitionSpec = { tween(durationMillis = 300) }
+        transitionSpec = { tween(durationMillis = 300) }, label = stringResource(R.string.tint_transition_spec)
     ) {
         if (it == Valid) validColor else invalidColor
     }

--- a/Crane/app/src/main/res/values/strings.xml
+++ b/Crane/app/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
     <string name="select_destination_to_caption">To</string>
     <string name="select_dates">Select Dates</string>
     <string name="error_max_people">Error: We don\'t support more than %d people</string>
+    <string name="tint_transition_spec">tintTransitionSpec</string>
+    <string name="tint_transition">tintTransition</string>
     <plurals name="number_adults_selected">
         <item quantity="one"> %d Adult%s</item>
         <item quantity="other"> %d Adults%s</item>


### PR DESCRIPTION
** The label parameter was added to color animation transitions for the non-editable input field on the Home screen. Adding this label makes it easier to inspect this transition in the Animation Preview. 

**   Replaced the experimental “with” extension function used alongside the fade-in animation with the stable “togetherWith” function.

No major logic was altered.