### PR TITLE
[Jetsurvey] Remove extra spacers

### DIFF
--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/SignInSignUp.kt
@@ -161,6 +161,7 @@ fun Email(
                 onImeAction()
             }
         ),
+        singleLine = true
     )
 
     emailState.getError()?.let { error -> TextFieldError(textError = error) }
@@ -232,6 +233,7 @@ fun Password(
                 onImeAction()
             }
         ),
+        singleLine = true
     )
 }
 

--- a/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/WelcomeScreen.kt
+++ b/Jetsurvey/app/src/main/java/com/example/compose/jetsurvey/signinsignup/WelcomeScreen.kt
@@ -19,10 +19,8 @@ package com.example.compose.jetsurvey.signinsignup
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -36,7 +34,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -58,7 +55,7 @@ fun WelcomeScreen(
     onSignInSignUp: (email: String) -> Unit,
     onSignInAsGuest: () -> Unit,
 ) {
-    var showBranding by remember { mutableStateOf(true) }
+    var showBranding by rememberSaveable { mutableStateOf(true) }
 
     Surface(modifier = Modifier.supportWideScreen()) {
         Column(
@@ -66,24 +63,12 @@ fun WelcomeScreen(
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
         ) {
-            Spacer(
-                modifier = Modifier
-                    .weight(1f, fill = showBranding)
-                    .animateContentSize()
-            )
-
             AnimatedVisibility(
                 showBranding,
                 Modifier.fillMaxWidth()
             ) {
                 Branding()
             }
-
-            Spacer(
-                modifier = Modifier
-                    .weight(1f, fill = showBranding)
-                    .animateContentSize()
-            )
 
             SignInCreateAccount(
                 onSignInSignUp = onSignInSignUp,


### PR DESCRIPTION
Fixes #1208

I couldn't work out any reason for these Spacers to be included, please correct if wrong. @arriolac I can see you originally made this change so I am assigning you to review.

I tested small and big phones with rotation and the animated logo still works correctly when focussing on the text field.

Also some minor fixes I found during testing:
- Make the text fields single line
- Make the branding animation persist through rotation