### PR TITLE
[Jetcaster] Migrate Jetcaster to edge to edge API

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/MainActivity.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/MainActivity.kt
@@ -16,12 +16,14 @@
 
 package com.example.jetcaster.ui
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
-import androidx.core.view.WindowCompat
 import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.google.accompanist.adaptive.calculateDisplayFeatures
 
@@ -30,8 +32,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // This app draws behind the system bars, so we want to handle fitting system windows
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge(
+            // This app is only ever in dark mode, so hard code detectDarkMode to true.
+            SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT, detectDarkMode = { true })
+        )
 
         setContent {
             val windowSizeClass = calculateWindowSizeClass(this)

--- a/Jetcaster/app/src/main/res/values/themes.xml
+++ b/Jetcaster/app/src/main/res/values/themes.xml
@@ -19,8 +19,6 @@
     <style name="Theme.Jetcaster" parent="android:Theme.Material.NoActionBar">
         <item name="android:colorPrimary">#ff00ff</item>
         <item name="android:colorAccent">#ff00ff</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This app already supported edge to edge layout so migrating to the new API was simple.

Phone Portrait
![Screenshot_20231121_102813](https://github.com/android/compose-samples/assets/19445/a7bcc934-a04f-4bec-89d7-6febea195ba6)

Tablet Landscape
![Screenshot_20231121_103044](https://github.com/android/compose-samples/assets/19445/03b1cf28-fe5e-4c50-a5ca-c1b2fd112e5b)
