### PR TITLE
Added bottomsheet implementation

### DIFF
--- a/Reply/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/ReplyListContent.kt
@@ -18,7 +18,9 @@ package com.example.reply.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -39,11 +41,22 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFloatingActionButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextField
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.window.layout.DisplayFeature
 import com.example.reply.R
@@ -56,8 +69,8 @@ import com.example.reply.ui.utils.ReplyContentType
 import com.example.reply.ui.utils.ReplyNavigationType
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReplyInboxScreen(
     contentType: ReplyContentType,
@@ -67,6 +80,7 @@ fun ReplyInboxScreen(
     closeDetailScreen: () -> Unit,
     navigateToDetail: (Long, ReplyContentType) -> Unit,
     toggleSelectedEmail: (Long) -> Unit,
+    onFABClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     /**
@@ -116,7 +130,7 @@ fun ReplyInboxScreen(
             // When we have bottom navigation we show FAB at the bottom end.
             if (navigationType == ReplyNavigationType.BOTTOM_NAVIGATION) {
                 LargeFloatingActionButton(
-                    onClick = { /*TODO*/ },
+                    onClick = onFABClicked,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
                         .padding(16.dp),

--- a/Reply/app/src/main/java/com/example/reply/ui/navigation/ReplyNavigationComponents.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/navigation/ReplyNavigationComponents.kt
@@ -68,6 +68,7 @@ fun ReplyNavigationRail(
     selectedDestination: String,
     navigationContentPosition: ReplyNavigationContentPosition,
     navigateToTopLevelDestination: (ReplyTopLevelDestination) -> Unit,
+    onFABClicked: () -> Unit = {},
     onDrawerClicked: () -> Unit = {},
 ) {
     NavigationRail(
@@ -90,7 +91,7 @@ fun ReplyNavigationRail(
                 }
             )
             FloatingActionButton(
-                onClick = { /*TODO*/ },
+                onClick = onFABClicked,
                 modifier = Modifier.padding(top = 8.dp, bottom = 32.dp),
                 containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                 contentColor = MaterialTheme.colorScheme.onTertiaryContainer
@@ -153,6 +154,7 @@ fun ReplyBottomNavigationBar(
 fun PermanentNavigationDrawerContent(
     selectedDestination: String,
     navigationContentPosition: ReplyNavigationContentPosition,
+    onFABClicked: () -> Unit,
     navigateToTopLevelDestination: (ReplyTopLevelDestination) -> Unit,
 ) {
     PermanentDrawerSheet(
@@ -178,7 +180,7 @@ fun PermanentNavigationDrawerContent(
                         color = MaterialTheme.colorScheme.primary
                     )
                     ExtendedFloatingActionButton(
-                        onClick = { /*TODO*/ },
+                        onClick = onFABClicked,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 8.dp, bottom = 40.dp),
@@ -240,6 +242,7 @@ fun ModalNavigationDrawerContent(
     selectedDestination: String,
     navigationContentPosition: ReplyNavigationContentPosition,
     navigateToTopLevelDestination: (ReplyTopLevelDestination) -> Unit,
+    onFABClicked: () -> Unit,
     onDrawerClicked: () -> Unit = {}
 ) {
     ModalDrawerSheet {
@@ -275,7 +278,7 @@ fun ModalNavigationDrawerContent(
                     }
 
                     ExtendedFloatingActionButton(
-                        onClick = { /*TODO*/ },
+                        onClick = onFABClicked,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 8.dp, bottom = 40.dp),

--- a/Reply/app/src/main/res/values/strings.xml
+++ b/Reply/app/src/main/res/values/strings.xml
@@ -35,4 +35,9 @@
     <string name="search_emails">Search emails</string>
     <string name="no_item_found">No item found</string>
     <string name="no_search_history">No search history</string>
+
+    <string name="create_email_to">To</string>
+    <string name="create_email_subject">Subject</string>
+    <string name="create_email_content">Content</string>
+    <string name="create_email_send">Send</string>
 </resources>


### PR DESCRIPTION
Add Material 3 bottom sheet implementation with adaptive guidance.

<img width="600" alt="Screenshot 2023-12-06 at 2 28 10 PM" src="https://github.com/android/compose-samples/assets/4903762/3631b735-9b61-4b0b-97d4-c2a7811b0e5e">
<img width="350" alt="Screenshot 2023-12-06 at 2 28 26 PM" src="https://github.com/android/compose-samples/assets/4903762/e40015b5-55c5-46b9-a184-c2273b1f2375">
<img width="966" alt="Screenshot 2023-12-06 at 2 28 39 PM" src="https://github.com/android/compose-samples/assets/4903762/9aec47c8-6f7e-40de-9b48-993d43e83bab">
