### PR TITLE
 Remove inefficient use of .then #1240 

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetail.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/snackdetail/SnackDetail.kt
@@ -293,7 +293,7 @@ private fun Image(
 
     CollapsingImageLayout(
         collapseFractionProvider = collapseFractionProvider,
-        modifier = HzPadding.then(Modifier.statusBarsPadding())
+        modifier = HzPadding.statusBarsPadding()
     ) {
         SnackImage(
             imageUrl = imageUrl,


### PR DESCRIPTION
Simply removes the superfluous .then().