### PR TITLE
Added bottom padding for home content

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -171,7 +171,7 @@ fun HomeContent(
 ) {
     Column(
         modifier = modifier.windowInsetsPadding(
-            WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)
+            WindowInsets.systemBars.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
         )
     ) {
         // We dynamically theme this sub-section of the layout to match the selected


### PR DESCRIPTION
![bottom nav](https://github.com/android/compose-samples/assets/101160207/c5052371-04a5-4bf5-9a4d-a4539d0d10a2)
added bottom padding for home content because of the cutting of the last content