### PR TITLE
Jetchat is not laid out edge-to-edge in 2 & 3-button navigation mode

### DIFF
--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
@@ -48,6 +49,7 @@ class NavActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets -> insets }
 
         setContentView(
             ComposeView(this).apply {


### PR DESCRIPTION
#1256

(before) Jetchat is not laid out edge-to-edge in 2 & 3-button navigation mode (it is not drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240213_232305](https://github.com/android/compose-samples/assets/71050561/e2cb2c04-74a8-4b6b-8cf7-b9f7756ec425)
(after) Jetchat is laid out edge-to-edge in 2 & 3-button navigation mode (it is drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240213_232354](https://github.com/android/compose-samples/assets/71050561/4ca9f268-8c64-4d08-964b-8b553fbf9642)