### PR TITLE
Reply is laid out edge-to-edge in 2 & 3-button navigation mode

### DIFF
--- a/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
@@ -19,7 +19,6 @@ package com.example.reply.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -29,7 +28,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.core.view.ViewCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.reply.data.local.LocalEmailsDataProvider
 import com.example.reply.ui.theme.ReplyTheme
@@ -41,9 +39,7 @@ class MainActivity : ComponentActivity() {
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets -> insets }
 
         setContent {
             ReplyTheme {

--- a/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.reply.data.local.LocalEmailsDataProvider
 import com.example.reply.ui.theme.ReplyTheme
@@ -42,6 +43,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets -> insets }
 
         setContent {
             ReplyTheme {

--- a/Reply/app/src/main/java/com/example/reply/ui/theme/Theme.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/theme/Theme.kt
@@ -16,7 +16,11 @@
 
 package com.example.reply.ui.theme
 
+import android.graphics.Color
 import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -91,6 +95,13 @@ fun ReplyTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
+    val transparent = Color.TRANSPARENT
+    (LocalContext.current as ComponentActivity).enableEdgeToEdge(
+        navigationBarStyle = if (darkTheme)
+            SystemBarStyle.dark(transparent)
+        else
+            SystemBarStyle.light(transparent, transparent)
+    )
     val replyColorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current


### PR DESCRIPTION
#1260

(before) Reply is not laid out edge-to-edge in 2 & 3-button navigation mode (it is not drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240215_100721](https://github.com/android/compose-samples/assets/71050561/32345d55-4e61-49dd-b580-f34dcef2319a)
(after) Reply is laid out edge-to-edge in 2 & 3-button navigation mode (it is drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240215_100808](https://github.com/android/compose-samples/assets/71050561/4307cf29-fae1-48e9-92ae-2f3862fadd8c)