### PR TITLE
Jetsnack is laid out edge-to-edge in 2 & 3-button navigation mode

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/MainActivity.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/MainActivity.kt
@@ -20,11 +20,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.ViewCompat
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets -> insets }
         setContent { JetsnackApp() }
     }
 }


### PR DESCRIPTION
#1262

(before) Jetsnack is not laid out edge-to-edge in 2 & 3-button navigation mode (it is not drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240215_103236](https://github.com/android/compose-samples/assets/71050561/c55edb89-d0cd-4a6f-bb69-a5b25ba2ebd5)
(after) Jetsnack is laid out edge-to-edge in 2 & 3-button navigation mode (it is drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240215_103317](https://github.com/android/compose-samples/assets/71050561/8db7c089-736e-4fc0-b464-770af5c913b7)