### PR TITLE
Owl is laid out edge-to-edge in 2 & 3-button navigation mode

### DIFF
--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -16,13 +16,14 @@
 
 package com.example.owl.ui
 
+import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
 import com.example.owl.R
 
 class MainActivity : ComponentActivity() {
@@ -31,10 +32,13 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(
                 ContextCompat.getColor(this, R.color.immersive_sys_ui)
-            )
+            ),
+            navigationBarStyle = if (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES)
+                SystemBarStyle.dark(Color.TRANSPARENT)
+            else
+                SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
         )
         super.onCreate(savedInstanceState)
-        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets -> insets }
 
         setContent {
             OwlApp { finish() }

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -17,7 +17,6 @@
 package com.example.owl.ui
 
 import android.graphics.Color
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -35,9 +34,6 @@ class MainActivity : ComponentActivity() {
             ),
             navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
         )
-        if (Build.VERSION.SDK_INT >= 29) {
-            window.isNavigationBarContrastEnforced = false
-        }
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -33,7 +33,9 @@ class MainActivity : ComponentActivity() {
             statusBarStyle = SystemBarStyle.dark(
                 ContextCompat.getColor(this, R.color.immersive_sys_ui)
             ),
-            navigationBarStyle = if (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES)
+            navigationBarStyle =
+            if (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
+                Configuration.UI_MODE_NIGHT_YES)
                 SystemBarStyle.dark(Color.TRANSPARENT)
             else
                 SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import com.example.owl.R
 
 class MainActivity : ComponentActivity() {
@@ -33,6 +34,7 @@ class MainActivity : ComponentActivity() {
             )
         )
         super.onCreate(savedInstanceState)
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets -> insets }
 
         setContent {
             OwlApp { finish() }

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -35,7 +35,8 @@ class MainActivity : ComponentActivity() {
             ),
             navigationBarStyle =
             if (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
-                Configuration.UI_MODE_NIGHT_YES)
+                Configuration.UI_MODE_NIGHT_YES
+            )
                 SystemBarStyle.dark(Color.TRANSPARENT)
             else
                 SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -17,6 +17,7 @@
 package com.example.owl.ui
 
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -34,6 +35,9 @@ class MainActivity : ComponentActivity() {
             ),
             navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
         )
+        if (Build.VERSION.SDK_INT >= 29) {
+            window.isNavigationBarContrastEnforced = false
+        }
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -16,28 +16,13 @@
 
 package com.example.owl.ui
 
-import android.graphics.Color
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.core.content.ContextCompat
-import com.example.owl.R
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(
-                ContextCompat.getColor(this, R.color.immersive_sys_ui)
-            ),
-            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
-        )
-        if (Build.VERSION.SDK_INT >= 29) {
-            window.isNavigationBarContrastEnforced = false
-        }
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/MainActivity.kt
@@ -16,8 +16,8 @@
 
 package com.example.owl.ui
 
-import android.content.res.Configuration
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -33,14 +33,11 @@ class MainActivity : ComponentActivity() {
             statusBarStyle = SystemBarStyle.dark(
                 ContextCompat.getColor(this, R.color.immersive_sys_ui)
             ),
-            navigationBarStyle =
-            if (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
-                Configuration.UI_MODE_NIGHT_YES
-            )
-                SystemBarStyle.dark(Color.TRANSPARENT)
-            else
-                SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
         )
+        if (Build.VERSION.SDK_INT >= 29) {
+            window.isNavigationBarContrastEnforced = false
+        }
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/Owl/app/src/main/java/com/example/owl/ui/theme/Theme.kt
+++ b/Owl/app/src/main/java/com/example/owl/ui/theme/Theme.kt
@@ -16,6 +16,9 @@
 
 package com.example.owl.ui.theme
 
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
@@ -26,7 +29,9 @@ import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.example.owl.R
 
 private val YellowThemeLight = lightColors(
@@ -125,6 +130,17 @@ private fun OwlTheme(
     colors: Colors,
     content: @Composable () -> Unit
 ) {
+    val transparent = android.graphics.Color.TRANSPARENT
+    val activity = LocalContext.current as ComponentActivity
+    activity.enableEdgeToEdge(
+        statusBarStyle = SystemBarStyle.dark(
+            ContextCompat.getColor(activity, R.color.immersive_sys_ui)
+        ),
+        navigationBarStyle = if (darkTheme)
+            SystemBarStyle.dark(transparent)
+        else
+            SystemBarStyle.light(transparent, transparent)
+    )
     val elevation = if (darkTheme) DarkElevation else LightElevation
     val images = if (darkTheme) DarkImages else LightImages
     CompositionLocalProvider(


### PR DESCRIPTION
#1264

(before) Owl is not laid out edge-to-edge in 2 & 3-button navigation mode (it is not drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240215_105930](https://github.com/android/compose-samples/assets/71050561/b290dc75-6d7e-4a61-92f8-55d26c89564a)
(after) Owl is laid out edge-to-edge in 2 & 3-button navigation mode (it is drawn behind the system navigation bar in 2 & 3-button navigation mode).
![Screenshot_20240215_110222](https://github.com/android/compose-samples/assets/71050561/4894a9e8-0f13-4ec6-8f85-7c38a9002b67)