### PR TITLE
[Jetcaster] Center followed podcast and improve scrolling.

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -338,7 +337,7 @@ fun FollowedPodcasts(
             lastEpisodeDateText = lastEpisodeDate?.let { lastUpdated(it) },
             modifier = Modifier
                 .padding(4.dp)
-                .fillMaxHeight()
+                .fillMaxSize()
         )
     }
 }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -106,9 +106,23 @@ fun PodcastCategory(
     /**
      * TODO: reset scroll position when category changes
      */
-    Column(modifier = modifier) {
-        CategoryPodcasts(viewState.topPodcasts, viewModel)
-        EpisodeList(viewState.episodes, navigateToPlayer)
+    LazyColumn(
+        contentPadding = PaddingValues(0.dp),
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+    ) {
+        item {
+            CategoryPodcasts(viewState.topPodcasts, viewModel)
+        }
+
+        items(viewState.episodes, key = { it.episode.uri }) { item ->
+            EpisodeListItem(
+                episode = item.episode,
+                podcast = item.podcast,
+                onClick = navigateToPlayer,
+                modifier = Modifier.fillParentMaxWidth()
+            )
+        }
     }
 }
 
@@ -122,27 +136,6 @@ private fun CategoryPodcasts(
         onTogglePodcastFollowed = viewModel::onTogglePodcastFollowed,
         modifier = Modifier.fillMaxWidth()
     )
-}
-
-@Composable
-private fun EpisodeList(
-    episodes: List<EpisodeToPodcast>,
-    navigateToPlayer: (String) -> Unit
-) {
-    LazyColumn(
-        contentPadding = PaddingValues(0.dp),
-        verticalArrangement = Arrangement.Center
-    ) {
-
-        items(episodes, key = { it.episode.uri }) { item ->
-            EpisodeListItem(
-                episode = item.episode,
-                podcast = item.podcast,
-                onClick = navigateToPlayer,
-                modifier = Modifier.fillParentMaxWidth()
-            )
-        }
-    }
 }
 
 @Composable

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -73,7 +73,6 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.jetcaster.R
 import com.example.jetcaster.data.Episode
-import com.example.jetcaster.data.EpisodeToPodcast
 import com.example.jetcaster.data.Podcast
 import com.example.jetcaster.data.PodcastWithExtraInfo
 import com.example.jetcaster.ui.home.PreviewEpisodes


### PR DESCRIPTION
Center followed podcast and improve scrolling by allowing `CategoryPodcasts` to scroll along with individual episode items.

Before change:
[Screen_recording_20240226_17441dsaf1.webm](https://github.com/android/compose-samples/assets/463186/bc445db9-8337-4f17-ab30-c67e5a76c530)

With change:
[Screen_recording_20240226_173942.webm](https://github.com/android/compose-samples/assets/463186/edbfe116-b3cc-4480-aae9-5da5feacafac)
