### PR TITLE
[Jetcaster] Add mock support for playing an episode

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
@@ -57,9 +57,9 @@ fun JetcasterApp(
                     )
                 )
                 PlayerScreen(
-                    playerViewModel,
                     windowSizeClass,
                     displayFeatures,
+                    playerViewModel,
                     onBackPress = appState::navigateBack
                 )
             }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -37,11 +37,9 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PageSize
@@ -201,9 +199,6 @@ fun Home(
         // We dynamically theme this sub-section of the layout to match the selected
         // 'top podcast'
 
-        val surfaceColor = MaterialTheme.colorScheme.surface
-        val appBarColor = surfaceColor.copy(alpha = 0.87f)
-
         val scrimColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.38f)
 
         // Top Bar
@@ -213,14 +208,8 @@ fun Home(
                 .background(color = scrimColor)
         ) {
             // Draw a scrim over the status bar which matches the app bar
-            Spacer(
-                Modifier
-                    .background(appBarColor)
-                    .fillMaxWidth()
-                    .windowInsetsTopHeight(WindowInsets.statusBars)
-            )
             HomeAppBar(
-                backgroundColor = appBarColor,
+                backgroundColor = MaterialTheme.colorScheme.surface,
                 modifier = Modifier.fillMaxWidth()
             )
         }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -66,7 +66,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
@@ -75,9 +74,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -63,6 +63,8 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -70,6 +72,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
@@ -28,9 +28,11 @@ import com.example.jetcaster.core.data.domain.GetLatestFollowedEpisodesUseCase
 import com.example.jetcaster.core.data.domain.PodcastCategoryFilterUseCase
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
+import com.example.jetcaster.core.data.model.toPlayerEpisode
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.data.repository.PodcastsRepository
+import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.util.combine
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -52,7 +54,8 @@ class HomeViewModel(
     private val podcastCategoryFilterUseCase: PodcastCategoryFilterUseCase =
         Graph.podcastCategoryFilterUseCase,
     private val filterableCategoriesUseCase: FilterableCategoriesUseCase =
-        Graph.filterableCategoriesUseCase
+        Graph.filterableCategoriesUseCase,
+    private val episodePlayer: EpisodePlayer = Graph.episodePlayer
 ) : ViewModel() {
     // Holds our currently selected podcast in the library
     private val selectedLibraryPodcast = MutableStateFlow<Podcast?>(null)
@@ -161,6 +164,10 @@ class HomeViewModel(
 
     fun onLibraryPodcastSelected(podcast: Podcast?) {
         selectedLibraryPodcast.value = podcast
+    }
+
+    fun onQueuePodcast(episodeToPodcast: EpisodeToPodcast) {
+        episodePlayer.addToQueue(episodeToPodcast.toPlayerEpisode())
     }
 }
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -245,10 +245,12 @@ fun EpisodeListItem(
 
         IconButton(
             onClick = {
-                onQueuePodcast(EpisodeToPodcast().apply {
-                    this.episode = episode
-                    this._podcasts = listOf(podcast)
-                })
+                onQueuePodcast(
+                    EpisodeToPodcast().apply {
+                        this.episode = episode
+                        this._podcasts = listOf(podcast)
+                    }
+                )
             },
             modifier = Modifier.constrainAs(addPlaylist) {
                 end.linkTo(overflow.start)

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -80,6 +80,7 @@ fun LazyListScope.podcastCategory(
     topPodcasts: List<PodcastWithExtraInfo>,
     episodes: List<EpisodeToPodcast>,
     navigateToPlayer: (String) -> Unit,
+    onQueuePodcast: (EpisodeToPodcast) -> Unit,
     onTogglePodcastFollowed: (String) -> Unit,
 ) {
     item {
@@ -91,6 +92,7 @@ fun LazyListScope.podcastCategory(
             episode = item.episode,
             podcast = item.podcast,
             onClick = navigateToPlayer,
+            onQueuePodcast = onQueuePodcast,
             modifier = Modifier.fillParentMaxWidth()
         )
     }
@@ -113,6 +115,7 @@ fun EpisodeListItem(
     episode: Episode,
     podcast: Podcast,
     onClick: (String) -> Unit,
+    onQueuePodcast: (EpisodeToPodcast) -> Unit,
     modifier: Modifier = Modifier,
     showDivider: Boolean = true,
 ) {
@@ -241,7 +244,12 @@ fun EpisodeListItem(
         )
 
         IconButton(
-            onClick = { /* TODO */ },
+            onClick = {
+                onQueuePodcast(EpisodeToPodcast().apply {
+                    this.episode = episode
+                    this._podcasts = listOf(podcast)
+                })
+            },
             modifier = Modifier.constrainAs(addPlaylist) {
                 end.linkTo(overflow.start)
                 centerVerticallyTo(playIcon)
@@ -358,6 +366,7 @@ fun PreviewEpisodeListItem() {
             episode = PreviewEpisodes[0],
             podcast = PreviewPodcasts[0],
             onClick = { },
+            onQueuePodcast = { },
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
 import com.example.jetcaster.core.data.database.model.Category
+import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
 import com.example.jetcaster.designsystem.theme.Keyline1
@@ -49,6 +50,7 @@ fun LazyListScope.discoverItems(
     navigateToPlayer: (String) -> Unit,
     onCategorySelected: (Category) -> Unit,
     onTogglePodcastFollowed: (String) -> Unit,
+    onQueuePodcast: (EpisodeToPodcast) -> Unit,
 ) {
     if (filterableCategoriesModel.isEmpty) {
         // TODO: empty state
@@ -71,7 +73,8 @@ fun LazyListScope.discoverItems(
         topPodcasts = podcastCategoryFilterResult.topPodcasts,
         episodes = podcastCategoryFilterResult.episodes,
         navigateToPlayer = navigateToPlayer,
-        onTogglePodcastFollowed = onTogglePodcastFollowed
+        onTogglePodcastFollowed = onTogglePodcastFollowed,
+        onQueuePodcast = onQueuePodcast,
     )
 }
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
@@ -31,7 +31,8 @@ import com.example.jetcaster.ui.home.category.EpisodeListItem
 
 fun LazyListScope.libraryItems(
     episodes: List<EpisodeToPodcast>,
-    navigateToPlayer: (String) -> Unit
+    navigateToPlayer: (String) -> Unit,
+    onQueuePodcast: (EpisodeToPodcast) -> Unit
 ) {
     if (episodes.isEmpty()) {
         // TODO: Empty state
@@ -57,6 +58,7 @@ fun LazyListScope.libraryItems(
             episode = item.episode,
             podcast = item.podcast,
             onClick = navigateToPlayer,
+            onQueuePodcast = onQueuePodcast,
             modifier = Modifier.fillParentMaxWidth(),
             showDivider = index != 0
         )

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
@@ -561,7 +561,7 @@ private fun PodcastInformation(
     }
 }
 
-fun Duration.formatString() : String {
+fun Duration.formatString(): String {
     val minutes = this.toMinutes().toString().padStart(2, '0')
     val secondsLeft = (this.toSeconds() % 60).toString().padStart(2, '0')
     return "$minutes:$secondsLeft"

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
@@ -31,8 +31,8 @@ import com.example.jetcaster.core.data.model.toPlayerEpisode
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.player.EpisodePlayer
-import java.time.Duration
 import com.example.jetcaster.core.player.EpisodePlayerState
+import java.time.Duration
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
@@ -29,9 +29,10 @@ import androidx.savedstate.SavedStateRegistryOwner
 import com.example.jetcaster.core.data.di.Graph
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
-import java.time.Duration
-import kotlinx.coroutines.flow.first
+import com.example.jetcaster.core.player.EpisodePlayer
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import java.time.Duration
 
 data class PlayerUiState(
     val title: String = "",
@@ -40,15 +41,18 @@ data class PlayerUiState(
     val podcastName: String = "",
     val author: String = "",
     val summary: String = "",
-    val podcastImageUrl: String = ""
+    val podcastImageUrl: String = "",
+    val isPlaying: Boolean = false,
+    val timeElapsed: Duration? = null,
 )
 
 /**
  * ViewModel that handles the business logic and screen state of the Player screen
  */
 class PlayerViewModel(
-    episodeStore: EpisodeStore,
-    podcastStore: PodcastStore,
+    episodeStore: EpisodeStore = Graph.episodeStore,
+    podcastStore: PodcastStore = Graph.podcastStore,
+    private val episodePlayer: EpisodePlayer = Graph.episodePlayer,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -61,25 +65,55 @@ class PlayerViewModel(
 
     init {
         viewModelScope.launch {
-            val episode = episodeStore.episodeWithUri(episodeUri).first()
-            val podcast = podcastStore.podcastWithUri(episode.podcastUri).first()
-            uiState = PlayerUiState(
-                title = episode.title,
-                duration = episode.duration,
-                podcastName = podcast.title,
-                summary = episode.summary ?: "",
-                podcastImageUrl = podcast.imageUrl ?: ""
-            )
+            combine(
+                episodeStore.episodeAndPodcastWithUri(episodeUri),
+                episodePlayer.playerState
+            ) { episodeToPlayer, playerState ->
+                episodePlayer.currentEpisode = episodeToPlayer.episode
+                PlayerUiState(
+                    title = episodeToPlayer.episode.title,
+                    duration = episodeToPlayer.episode.duration,
+                    podcastName = episodeToPlayer.episode.title,
+                    summary = episodeToPlayer.episode.summary ?: "",
+                    podcastImageUrl = episodeToPlayer.podcast.imageUrl ?: "",
+                    isPlaying = playerState.isPlaying,
+                    timeElapsed = playerState.timeElapsed
+                )
+            }.collect {
+                uiState = it
+            }
         }
     }
 
+    fun onPlay() {
+        episodePlayer.play()
+    }
+
+    fun onPause() {
+        episodePlayer.pause()
+    }
+
+    fun onStop() {
+        episodePlayer.stop()
+    }
+
+    fun onAdvanceBy(duration: Duration) {
+        episodePlayer.advanceBy(duration)
+    }
+
+    fun onRewindBy(duration: Duration) {
+        episodePlayer.rewindBy(duration)
+    }
+
     /**
-     * Factory for PlayerViewModel that takes EpisodeStore and PodcastStore as a dependency
+     * Factory for PlayerViewModel that takes EpisodeStore, PodcastStore and EpisodePlayer as a
+     * dependency
      */
     companion object {
         fun provideFactory(
             episodeStore: EpisodeStore = Graph.episodeStore,
             podcastStore: PodcastStore = Graph.podcastStore,
+            episodePlayer: EpisodePlayer = Graph.episodePlayer,
             owner: SavedStateRegistryOwner,
             defaultArgs: Bundle? = null,
         ): AbstractSavedStateViewModelFactory =
@@ -90,7 +124,7 @@ class PlayerViewModel(
                     modelClass: Class<T>,
                     handle: SavedStateHandle
                 ): T {
-                    return PlayerViewModel(episodeStore, podcastStore, handle) as T
+                    return PlayerViewModel(episodeStore, podcastStore, episodePlayer, handle) as T
                 }
             }
     }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
@@ -30,9 +30,9 @@ import com.example.jetcaster.core.data.di.Graph
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.player.EpisodePlayer
+import java.time.Duration
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import java.time.Duration
 
 data class PlayerUiState(
     val title: String = "",

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/theme/Theme.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/theme/Theme.kt
@@ -502,11 +502,10 @@ fun JetcasterTheme(
         else -> lightScheme
     }
     val view = LocalView.current
-    val statusBarColor = colorScheme.surface
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = statusBarColor.toArgb()
+            window.statusBarColor = Color.Transparent.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }

--- a/Jetcaster/app/src/main/res/values/strings.xml
+++ b/Jetcaster/app/src/main/res/values/strings.xml
@@ -40,20 +40,21 @@
 
     <string name="episode_date_duration">%1$s &#8226; %2$d mins</string>
 
-    <string name="cd_search">Search</string>
     <string name="cd_account">Account</string>
     <string name="cd_add">Add</string>
     <string name="cd_back">Back</string>
-    <string name="cd_more">More</string>
-    <string name="cd_play">Play</string>
-    <string name="cd_skip_previous">Skip previous</string>
-    <string name="cd_reply10">Reply 10 seconds</string>
-    <string name="cd_forward30">Forward 30 seconds</string>
-    <string name="cd_skip_next">Skip next</string>
-    <string name="cd_unfollow">Unfollow</string>
     <string name="cd_follow">Follow</string>
     <string name="cd_following">Following</string>
+    <string name="cd_forward10">Forward 10 seconds</string>
+    <string name="cd_more">More</string>
     <string name="cd_not_following">Not following</string>
+    <string name="cd_pause">Pause</string>
+    <string name="cd_play">Play</string>
+    <string name="cd_replay10">Replay 10 seconds</string>
+    <string name="cd_search">Search</string>
     <string name="cd_selected_category">Selected category</string>
+    <string name="cd_skip_next">Skip next</string>
+    <string name="cd_skip_previous">Skip previous</string>
+    <string name="cd_unfollow">Unfollow</string>
 
 </resources>

--- a/Jetcaster/app/src/main/res/values/strings.xml
+++ b/Jetcaster/app/src/main/res/values/strings.xml
@@ -56,5 +56,6 @@
     <string name="cd_skip_next">Skip next</string>
     <string name="cd_skip_previous">Skip previous</string>
     <string name="cd_unfollow">Unfollow</string>
+  <string name="episode_added_to_your_queue">Episode added to your queue</string>
 
 </resources>

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/database/dao/EpisodesDao.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/database/dao/EpisodesDao.kt
@@ -40,10 +40,10 @@ abstract class EpisodesDao : BaseDao<Episode> {
         """
         SELECT episodes.* FROM episodes
         INNER JOIN podcasts ON episodes.podcast_uri = podcasts.uri
-        WHERE episodes.uri = :uri
+        WHERE episodes.uri = :episodeUri
         """
     )
-    abstract fun episodeAndPodcast(uri: String): Flow<EpisodeToPodcast>
+    abstract fun episodeAndPodcast(episodeUri: String): Flow<EpisodeToPodcast>
 
     @Query(
         """

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/database/dao/EpisodesDao.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/database/dao/EpisodesDao.kt
@@ -38,6 +38,15 @@ abstract class EpisodesDao : BaseDao<Episode> {
 
     @Query(
         """
+        SELECT episodes.* FROM episodes
+        INNER JOIN podcasts ON episodes.podcast_uri = podcasts.uri
+        WHERE episodes.uri = :uri
+        """
+    )
+    abstract fun episodeAndPodcast(uri: String): Flow<EpisodeToPodcast>
+
+    @Query(
+        """
         SELECT * FROM episodes WHERE podcast_uri = :podcastUri
         ORDER BY datetime(published) DESC
         LIMIT :limit

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/di/Graph.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/di/Graph.kt
@@ -31,13 +31,14 @@ import com.example.jetcaster.core.data.repository.LocalCategoryStore
 import com.example.jetcaster.core.data.repository.LocalEpisodeStore
 import com.example.jetcaster.core.data.repository.LocalPodcastStore
 import com.example.jetcaster.core.data.repository.PodcastsRepository
+import com.example.jetcaster.core.player.MockEpisodePlayer
 import com.rometools.rome.io.SyndFeedInput
-import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.LoggingEventListener
+import java.io.File
 
 /**
  * A very simple global singleton dependency graph.
@@ -54,6 +55,10 @@ object Graph {
         get() = database.transactionRunnerDao()
 
     private val syndFeedInput by lazy { SyndFeedInput() }
+
+    val episodePlayer by lazy {
+        MockEpisodePlayer(mainDispatcher)
+    }
 
     val podcastRepository by lazy {
         PodcastsRepository(

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/di/Graph.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/di/Graph.kt
@@ -33,12 +33,12 @@ import com.example.jetcaster.core.data.repository.LocalPodcastStore
 import com.example.jetcaster.core.data.repository.PodcastsRepository
 import com.example.jetcaster.core.player.MockEpisodePlayer
 import com.rometools.rome.io.SyndFeedInput
+import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.LoggingEventListener
-import java.io.File
 
 /**
  * A very simple global singleton dependency graph.

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
@@ -1,0 +1,23 @@
+package com.example.jetcaster.core.data.model
+
+import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
+import java.time.Duration
+
+data class PlayerEpisode(
+    val title: String = "",
+    val subTitle: String = "",
+    val duration: Duration? = null,
+    val podcastName: String = "",
+    val author: String = "",
+    val summary: String = "",
+    val podcastImageUrl: String = "",
+)
+
+fun EpisodeToPodcast.toPlayerEpisode() : PlayerEpisode =
+    PlayerEpisode(
+        title = episode.title,
+        duration = episode.duration,
+        podcastName = podcast.title,
+        summary = episode.summary ?: "",
+        podcastImageUrl = podcast.imageUrl ?: "",
+    )

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.core.data.model
 
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
@@ -13,7 +29,7 @@ data class PlayerEpisode(
     val podcastImageUrl: String = "",
 )
 
-fun EpisodeToPodcast.toPlayerEpisode() : PlayerEpisode =
+fun EpisodeToPodcast.toPlayerEpisode(): PlayerEpisode =
     PlayerEpisode(
         title = episode.title,
         duration = episode.duration,

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/repository/EpisodeStore.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/repository/EpisodeStore.kt
@@ -28,6 +28,11 @@ interface EpisodeStore {
     fun episodeWithUri(episodeUri: String): Flow<Episode>
 
     /**
+     * Returns a flow containing the episode and corresponding podcast given an [episodeUri].
+     */
+    fun episodeAndPodcastWithUri(episodeUri: String): Flow<EpisodeToPodcast>
+
+    /**
      * Returns a flow containing the list of episodes associated with the podcast with the
      * given [podcastUri].
      */
@@ -67,6 +72,9 @@ class LocalEpisodeStore(
     override fun episodeWithUri(episodeUri: String): Flow<Episode> {
         return episodesDao.episode(episodeUri)
     }
+
+    override fun episodeAndPodcastWithUri(episodeUri: String): Flow<EpisodeToPodcast> =
+        episodesDao.episodeAndPodcast(episodeUri)
 
     /**
      * Returns a flow containing the list of episodes associated with the podcast with the

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
@@ -1,0 +1,64 @@
+package com.example.jetcaster.core.player
+
+import com.example.jetcaster.core.data.database.model.Episode
+import kotlinx.coroutines.flow.StateFlow
+import java.time.Duration
+
+data class EpisodePlayerState(
+    val currentEpisode: Episode? = null,
+    val isPlaying: Boolean = false,
+    val timeElapsed: Duration = Duration.ZERO,
+)
+
+/**
+ * Interface definition for an episode player defining high-level functions such as queuing
+ * episodes, playing an episode, pausing, seeking, etc.
+ */
+interface EpisodePlayer {
+
+    /**
+     * A StateFlow that emits the [EpisodePlayerState] as controls as invoked on this player.
+     */
+    val playerState: StateFlow<EpisodePlayerState>
+
+    /**
+     * Gets the current episode playing, or to be played, by this player.
+     */
+    var currentEpisode: Episode?
+
+    /**
+     * Plays the current episode
+     */
+    fun play()
+
+    /**
+     * Pauses the currently played episode
+     */
+    fun pause()
+
+    /**
+     * Stops the currently played episode
+     */
+    fun stop()
+
+    /**
+     * Plays another episode in the queue (if available)
+     */
+    fun next()
+
+    /**
+     * Plays the previous episode in the queue (if available). Or if an episode is currently
+     * playing this will start the episode from the beginning
+     */
+    fun previous()
+
+    /**
+     * Advances a currently played episode by a given time interval specified in [duration].
+     */
+    fun advanceBy(duration: Duration)
+
+    /**
+     * Rewinds a currently played episode by a given time interval specified in [duration].
+     */
+    fun rewindBy(duration: Duration)
+}

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.core.player
 
 import com.example.jetcaster.core.data.database.model.Episode
-import kotlinx.coroutines.flow.StateFlow
 import java.time.Duration
+import kotlinx.coroutines.flow.StateFlow
 
 data class EpisodePlayerState(
     val currentEpisode: Episode? = null,

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
@@ -16,12 +16,13 @@
 
 package com.example.jetcaster.core.player
 
-import com.example.jetcaster.core.data.database.model.Episode
-import java.time.Duration
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import kotlinx.coroutines.flow.StateFlow
+import java.time.Duration
 
 data class EpisodePlayerState(
-    val currentEpisode: Episode? = null,
+    val currentEpisode: PlayerEpisode? = null,
+    val queue: List<PlayerEpisode> = emptyList(),
     val isPlaying: Boolean = false,
     val timeElapsed: Duration = Duration.ZERO,
 )
@@ -40,7 +41,9 @@ interface EpisodePlayer {
     /**
      * Gets the current episode playing, or to be played, by this player.
      */
-    var currentEpisode: Episode?
+    var currentEpisode: PlayerEpisode?
+
+    fun addToQueue(episode: PlayerEpisode)
 
     /**
      * Plays the current episode

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/EpisodePlayer.kt
@@ -17,8 +17,8 @@
 package com.example.jetcaster.core.player
 
 import com.example.jetcaster.core.data.model.PlayerEpisode
-import kotlinx.coroutines.flow.StateFlow
 import java.time.Duration
+import kotlinx.coroutines.flow.StateFlow
 
 data class EpisodePlayerState(
     val currentEpisode: PlayerEpisode? = null,

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/MockEpisodePlayer.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/MockEpisodePlayer.kt
@@ -16,9 +16,9 @@
 
 package com.example.jetcaster.core.player
 
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import java.time.Duration
 import kotlin.reflect.KProperty
-import com.example.jetcaster.core.data.model.PlayerEpisode
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/MockEpisodePlayer.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/MockEpisodePlayer.kt
@@ -1,0 +1,125 @@
+package com.example.jetcaster.core.player
+
+import com.example.jetcaster.core.data.database.model.Episode
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.time.Duration
+import kotlin.reflect.KProperty
+
+class MockEpisodePlayer(
+    private val mainDispatcher: CoroutineDispatcher
+) : EpisodePlayer {
+
+    private val _playerState = MutableStateFlow(EpisodePlayerState())
+    private val _currentEpisode = MutableStateFlow<Episode?>(null)
+    private val isPlaying = MutableStateFlow(false)
+    private val timeElapsed = MutableStateFlow(Duration.ZERO)
+    private val coroutineScope = CoroutineScope(mainDispatcher)
+
+    private var timerJob: Job? = null
+    init {
+        coroutineScope.launch {
+            // Combine streams here
+            combine(
+                _currentEpisode,
+                isPlaying,
+                timeElapsed
+            ) { currentEpisode, isPlaying, timeElapsed ->
+                EpisodePlayerState(
+                    currentEpisode = currentEpisode,
+                    isPlaying = isPlaying,
+                    timeElapsed = timeElapsed
+                )
+            }.catch {
+                // TODO handle error state
+                throw it
+            }.collect {
+                _playerState.value = it
+            }
+        }
+    }
+
+    override val playerState: StateFlow<EpisodePlayerState> = _playerState.asStateFlow()
+
+    override var currentEpisode: Episode? by _currentEpisode
+
+    override fun play() {
+        // Do nothing if already playing
+        if (isPlaying.value) {
+            return
+        }
+
+        val episode = _currentEpisode.value ?: return
+
+        isPlaying.value = true
+        timerJob = coroutineScope.launch {
+            // Increment timer by a second
+            while (isActive && timeElapsed.value < episode.duration) {
+                delay(1000L)
+                timeElapsed.update { it + Duration.ofSeconds(1) }
+            }
+
+            // Stop playing
+            timeElapsed.value = Duration.ZERO
+            isPlaying.value = false
+        }
+    }
+
+    override fun pause() {
+        isPlaying.value = false
+
+        timerJob?.cancel()
+        timerJob = null
+    }
+
+    override fun stop() {
+        isPlaying.value = false
+        timeElapsed.value = Duration.ZERO
+
+        timerJob?.cancel()
+        timerJob = null
+    }
+
+    override fun advanceBy(duration: Duration) {
+        val currentEpisodeDuration = _currentEpisode.value?.duration ?: return
+        timeElapsed.update {
+            (it + duration).coerceAtMost(currentEpisodeDuration)
+        }
+    }
+
+    override fun rewindBy(duration: Duration) {
+        timeElapsed.update {
+            (it - duration).coerceAtLeast(Duration.ZERO)
+        }
+    }
+
+    override fun next() {
+        TODO("Not yet implemented")
+    }
+
+    override fun previous() {
+        TODO("Not yet implemented")
+    }
+}
+
+// Used to enable property delegation
+private operator fun <T> MutableStateFlow<T>.setValue(
+    thisObj: Any?,
+    property: KProperty<*>,
+    value: T
+) {
+    this.value = value
+}
+
+private operator fun <T> MutableStateFlow<T>.getValue(thisObj: Any?, property: KProperty<*>): T =
+    this.value

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/MockEpisodePlayer.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/player/MockEpisodePlayer.kt
@@ -1,6 +1,24 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.core.player
 
 import com.example.jetcaster.core.data.database.model.Episode
+import java.time.Duration
+import kotlin.reflect.KProperty
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -13,8 +31,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import java.time.Duration
-import kotlin.reflect.KProperty
 
 class MockEpisodePlayer(
     private val mainDispatcher: CoroutineDispatcher

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/repository/TestEpisodeStore.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/repository/TestEpisodeStore.kt
@@ -28,8 +28,19 @@ class TestEpisodeStore : EpisodeStore {
 
     private val episodesFlow = MutableStateFlow<List<Episode>>(listOf())
     override fun episodeWithUri(episodeUri: String): Flow<Episode> =
-        episodesFlow.map {
-            it.first { it.uri == episodeUri }
+        episodesFlow.map { episodes ->
+            episodes.first { it.uri == episodeUri }
+        }
+
+    override fun episodeAndPodcastWithUri(episodeUri: String): Flow<EpisodeToPodcast> =
+        episodesFlow.map { episodes ->
+            val e = episodes.first {
+                it.uri == episodeUri
+            }
+            EpisodeToPodcast().apply {
+                episode = e
+                _podcasts = emptyList()
+            }
         }
 
     override fun episodesInPodcast(podcastUri: String, limit: Int): Flow<List<EpisodeToPodcast>> =


### PR DESCRIPTION
Introduces `EpisodePlayer` interface and `MockEpisodePlayer` conforming class to mock playing an episode. This enables play/pause and the slider to update as you would expect in a real podcast app. 

[Screen_recording_20240322_160937.webm](https://github.com/android/compose-samples/assets/463186/09a4e7bd-7d99-4381-8ec2-9b2af3bfefac)

#1292 should be reviewed and merged first.