### PR TITLE
[Jetcaster]: Podcast screen

### DIFF
--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
@@ -49,73 +49,73 @@ fun JetcasterApp(
     displayFeatures: List<DisplayFeature>,
     appState: JetcasterAppState = rememberJetcasterAppState()
 ) {
-    //if (appState.isOnline) {
-        NavHost(
-            navController = appState.navController,
-            startDestination = Screen.Home.route
-        ) {
-            composable(Screen.Home.route) { backStackEntry ->
-                Home(
-                    navigateToPodcastDetails = { podcast ->
-                        appState.navigateToPodcastDetails(podcast.uri, backStackEntry)
-                    },
-                )
-            }
-            composable(Screen.Player.route) { backStackEntry ->
-                val playerViewModel: PlayerViewModel = viewModel(
-                    factory = PlayerViewModel.provideFactory(
-                        owner = backStackEntry,
-                        defaultArgs = backStackEntry.arguments
-                    )
-                )
-                PlayerScreen(
-                    windowSizeClass,
-                    displayFeatures,
-                    playerViewModel,
-                    onBackPress = appState::navigateBack
-                )
-            }
-            composable(
-                route = Screen.PodcastDetails.route,
-                enterTransition = {
-                    fadeIn(
-                        animationSpec = tween(
-                            300, easing = LinearEasing
-                        )
-                    ) + slideIntoContainer(
-                        animationSpec = tween(300, easing = EaseIn),
-                        towards = AnimatedContentTransitionScope.SlideDirection.Start
-                    )
+    // if (appState.isOnline) {
+    NavHost(
+        navController = appState.navController,
+        startDestination = Screen.Home.route
+    ) {
+        composable(Screen.Home.route) { backStackEntry ->
+            Home(
+                navigateToPodcastDetails = { podcast ->
+                    appState.navigateToPodcastDetails(podcast.uri, backStackEntry)
                 },
-                exitTransition = {
-                    fadeOut(
-                        animationSpec = tween(
-                            300, easing = LinearEasing
-                        )
-                    ) + slideOutOfContainer(
-                        animationSpec = tween(300, easing = EaseOut),
-                        towards = AnimatedContentTransitionScope.SlideDirection.End
-                    )
-                }
-            ) { backStackEntry ->
-                val podcastDetailsViewModel: PodcastDetailsViewModel = viewModel(
-                    factory = PodcastDetailsViewModel.provideFactory(
-                        episodeStore = episodeStore,
-                        podcastStore = podcastStore,
-                        episodePlayer = episodePlayer,
-                        owner = backStackEntry,
-                        defaultArgs = backStackEntry.arguments
-                    )
+            )
+        }
+        composable(Screen.Player.route) { backStackEntry ->
+            val playerViewModel: PlayerViewModel = viewModel(
+                factory = PlayerViewModel.provideFactory(
+                    owner = backStackEntry,
+                    defaultArgs = backStackEntry.arguments
                 )
-                PodcastDetailsScreen(
-                    viewModel = podcastDetailsViewModel,
-                    navigateToPlayer = { episodePlayer ->
-                        appState.navigateToPlayer(episodePlayer.uri, backStackEntry)
-                    },
-                    navigateBack = appState::navigateBack
+            )
+            PlayerScreen(
+                windowSizeClass,
+                displayFeatures,
+                playerViewModel,
+                onBackPress = appState::navigateBack
+            )
+        }
+        composable(
+            route = Screen.PodcastDetails.route,
+            enterTransition = {
+                fadeIn(
+                    animationSpec = tween(
+                        300, easing = LinearEasing
+                    )
+                ) + slideIntoContainer(
+                    animationSpec = tween(300, easing = EaseIn),
+                    towards = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+            },
+            exitTransition = {
+                fadeOut(
+                    animationSpec = tween(
+                        300, easing = LinearEasing
+                    )
+                ) + slideOutOfContainer(
+                    animationSpec = tween(300, easing = EaseOut),
+                    towards = AnimatedContentTransitionScope.SlideDirection.End
                 )
             }
+        ) { backStackEntry ->
+            val podcastDetailsViewModel: PodcastDetailsViewModel = viewModel(
+                factory = PodcastDetailsViewModel.provideFactory(
+                    episodeStore = episodeStore,
+                    podcastStore = podcastStore,
+                    episodePlayer = episodePlayer,
+                    owner = backStackEntry,
+                    defaultArgs = backStackEntry.arguments
+                )
+            )
+            PodcastDetailsScreen(
+                viewModel = podcastDetailsViewModel,
+                navigateToPlayer = { episodePlayer ->
+                    appState.navigateToPlayer(episodePlayer.uri, backStackEntry)
+                },
+                navigateBack = appState::navigateBack
+            )
         }
+    }
 //    } else {
 //        OfflineDialog { appState.refreshOnline() }
 //    }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
@@ -49,76 +49,76 @@ fun JetcasterApp(
     displayFeatures: List<DisplayFeature>,
     appState: JetcasterAppState = rememberJetcasterAppState()
 ) {
-    // if (appState.isOnline) {
-    NavHost(
-        navController = appState.navController,
-        startDestination = Screen.Home.route
-    ) {
-        composable(Screen.Home.route) { backStackEntry ->
-            Home(
-                navigateToPodcastDetails = { podcast ->
-                    appState.navigateToPodcastDetails(podcast.uri, backStackEntry)
-                },
-            )
-        }
-        composable(Screen.Player.route) { backStackEntry ->
-            val playerViewModel: PlayerViewModel = viewModel(
-                factory = PlayerViewModel.provideFactory(
-                    owner = backStackEntry,
-                    defaultArgs = backStackEntry.arguments
-                )
-            )
-            PlayerScreen(
-                windowSizeClass,
-                displayFeatures,
-                playerViewModel,
-                onBackPress = appState::navigateBack
-            )
-        }
-        composable(
-            route = Screen.PodcastDetails.route,
-            enterTransition = {
-                fadeIn(
-                    animationSpec = tween(
-                        300, easing = LinearEasing
-                    )
-                ) + slideIntoContainer(
-                    animationSpec = tween(300, easing = EaseIn),
-                    towards = AnimatedContentTransitionScope.SlideDirection.Start
-                )
-            },
-            exitTransition = {
-                fadeOut(
-                    animationSpec = tween(
-                        300, easing = LinearEasing
-                    )
-                ) + slideOutOfContainer(
-                    animationSpec = tween(300, easing = EaseOut),
-                    towards = AnimatedContentTransitionScope.SlideDirection.End
+    if (appState.isOnline) {
+        NavHost(
+            navController = appState.navController,
+            startDestination = Screen.Home.route
+        ) {
+            composable(Screen.Home.route) { backStackEntry ->
+                Home(
+                    navigateToPodcastDetails = { podcast ->
+                        appState.navigateToPodcastDetails(podcast.uri, backStackEntry)
+                    },
                 )
             }
-        ) { backStackEntry ->
-            val podcastDetailsViewModel: PodcastDetailsViewModel = viewModel(
-                factory = PodcastDetailsViewModel.provideFactory(
-                    episodeStore = episodeStore,
-                    podcastStore = podcastStore,
-                    episodePlayer = episodePlayer,
-                    owner = backStackEntry,
-                    defaultArgs = backStackEntry.arguments
+            composable(Screen.Player.route) { backStackEntry ->
+                val playerViewModel: PlayerViewModel = viewModel(
+                    factory = PlayerViewModel.provideFactory(
+                        owner = backStackEntry,
+                        defaultArgs = backStackEntry.arguments
+                    )
                 )
-            )
-            PodcastDetailsScreen(
-                viewModel = podcastDetailsViewModel,
-                navigateToPlayer = { episodePlayer ->
-                    appState.navigateToPlayer(episodePlayer.uri, backStackEntry)
+                PlayerScreen(
+                    windowSizeClass,
+                    displayFeatures,
+                    playerViewModel,
+                    onBackPress = appState::navigateBack
+                )
+            }
+            composable(
+                route = Screen.PodcastDetails.route,
+                enterTransition = {
+                    fadeIn(
+                        animationSpec = tween(
+                            300, easing = LinearEasing
+                        )
+                    ) + slideIntoContainer(
+                        animationSpec = tween(300, easing = EaseIn),
+                        towards = AnimatedContentTransitionScope.SlideDirection.Start
+                    )
                 },
-                navigateBack = appState::navigateBack
-            )
+                exitTransition = {
+                    fadeOut(
+                        animationSpec = tween(
+                            300, easing = LinearEasing
+                        )
+                    ) + slideOutOfContainer(
+                        animationSpec = tween(300, easing = EaseOut),
+                        towards = AnimatedContentTransitionScope.SlideDirection.End
+                    )
+                }
+            ) { backStackEntry ->
+                val podcastDetailsViewModel: PodcastDetailsViewModel = viewModel(
+                    factory = PodcastDetailsViewModel.provideFactory(
+                        episodeStore = episodeStore,
+                        podcastStore = podcastStore,
+                        episodePlayer = episodePlayer,
+                        owner = backStackEntry,
+                        defaultArgs = backStackEntry.arguments
+                    )
+                )
+                PodcastDetailsScreen(
+                    viewModel = podcastDetailsViewModel,
+                    navigateToPlayer = { episodePlayer ->
+                        appState.navigateToPlayer(episodePlayer.uri, backStackEntry)
+                    },
+                    navigateBack = appState::navigateBack
+                )
+            }
         }
+    } else {
+        OfflineDialog { appState.refreshOnline() }
     }
-//    } else {
-//        OfflineDialog { appState.refreshOnline() }
-//    }
 }
 
 @Composable

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
@@ -59,6 +59,9 @@ fun JetcasterApp(
                     navigateToPodcastDetails = { podcast ->
                         appState.navigateToPodcastDetails(podcast.uri, backStackEntry)
                     },
+                    navigateToPlayer = { episode ->
+                        appState.navigateToPlayer(episode.uri, backStackEntry)
+                    }
                 )
             }
             composable(Screen.Player.route) { backStackEntry ->

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
@@ -49,18 +49,15 @@ fun JetcasterApp(
     displayFeatures: List<DisplayFeature>,
     appState: JetcasterAppState = rememberJetcasterAppState()
 ) {
-    if (appState.isOnline) {
+    //if (appState.isOnline) {
         NavHost(
             navController = appState.navController,
             startDestination = Screen.Home.route
         ) {
             composable(Screen.Home.route) { backStackEntry ->
                 Home(
-                    navigateToPlayer = { episodeUri ->
-                        appState.navigateToPlayer(episodeUri, backStackEntry)
-                    },
-                    navigateToPodcastDetails = { podcastUri ->
-                        appState.navigateToPodcastDetails(podcastUri, backStackEntry)
+                    navigateToPodcastDetails = { podcast ->
+                        appState.navigateToPodcastDetails(podcast.uri, backStackEntry)
                     },
                 )
             }
@@ -119,9 +116,9 @@ fun JetcasterApp(
                 )
             }
         }
-    } else {
-        OfflineDialog { appState.refreshOnline() }
-    }
+//    } else {
+//        OfflineDialog { appState.refreshOnline() }
+//    }
 }
 
 @Composable

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
@@ -16,6 +16,13 @@
 
 package com.example.jetcaster.ui
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.EaseIn
+import androidx.compose.animation.core.EaseOut
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -27,9 +34,14 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.window.layout.DisplayFeature
 import com.example.jetcaster.R
+import com.example.jetcaster.core.data.di.Graph.episodePlayer
+import com.example.jetcaster.core.data.di.Graph.episodeStore
+import com.example.jetcaster.core.data.di.Graph.podcastStore
 import com.example.jetcaster.ui.home.Home
 import com.example.jetcaster.ui.player.PlayerScreen
 import com.example.jetcaster.ui.player.PlayerViewModel
+import com.example.jetcaster.ui.podcast.PodcastDetailsScreen
+import com.example.jetcaster.ui.podcast.PodcastDetailsViewModel
 
 @Composable
 fun JetcasterApp(
@@ -46,7 +58,10 @@ fun JetcasterApp(
                 Home(
                     navigateToPlayer = { episodeUri ->
                         appState.navigateToPlayer(episodeUri, backStackEntry)
-                    }
+                    },
+                    navigateToPodcastDetails = { podcastUri ->
+                        appState.navigateToPodcastDetails(podcastUri, backStackEntry)
+                    },
                 )
             }
             composable(Screen.Player.route) { backStackEntry ->
@@ -61,6 +76,46 @@ fun JetcasterApp(
                     displayFeatures,
                     playerViewModel,
                     onBackPress = appState::navigateBack
+                )
+            }
+            composable(
+                route = Screen.PodcastDetails.route,
+                enterTransition = {
+                    fadeIn(
+                        animationSpec = tween(
+                            300, easing = LinearEasing
+                        )
+                    ) + slideIntoContainer(
+                        animationSpec = tween(300, easing = EaseIn),
+                        towards = AnimatedContentTransitionScope.SlideDirection.Start
+                    )
+                },
+                exitTransition = {
+                    fadeOut(
+                        animationSpec = tween(
+                            300, easing = LinearEasing
+                        )
+                    ) + slideOutOfContainer(
+                        animationSpec = tween(300, easing = EaseOut),
+                        towards = AnimatedContentTransitionScope.SlideDirection.End
+                    )
+                }
+            ) { backStackEntry ->
+                val podcastDetailsViewModel: PodcastDetailsViewModel = viewModel(
+                    factory = PodcastDetailsViewModel.provideFactory(
+                        episodeStore = episodeStore,
+                        podcastStore = podcastStore,
+                        episodePlayer = episodePlayer,
+                        owner = backStackEntry,
+                        defaultArgs = backStackEntry.arguments
+                    )
+                )
+                PodcastDetailsScreen(
+                    viewModel = podcastDetailsViewModel,
+                    navigateToPlayer = { episodePlayer ->
+                        appState.navigateToPlayer(episodePlayer.uri, backStackEntry)
+                    },
+                    navigateBack = appState::navigateBack
                 )
             }
         }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterAppState.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterAppState.kt
@@ -38,8 +38,19 @@ import androidx.navigation.compose.rememberNavController
  */
 sealed class Screen(val route: String) {
     object Home : Screen("home")
-    object Player : Screen("player/{episodeUri}") {
+    object Player : Screen("player/{$ARG_EPISODE_URI}") {
         fun createRoute(episodeUri: String) = "player/$episodeUri"
+    }
+
+    object PodcastDetails : Screen("podcast/{$ARG_PODCAST_URI}") {
+
+        val PODCAST_URI = "podcastUri"
+        fun createRoute(podcastUri: String) = "podcast/$podcastUri"
+    }
+
+    companion object {
+        val ARG_PODCAST_URI = "podcastUri"
+        val ARG_EPISODE_URI = "episodeUri"
     }
 }
 
@@ -67,6 +78,13 @@ class JetcasterAppState(
         if (from.lifecycleIsResumed()) {
             val encodedUri = Uri.encode(episodeUri)
             navController.navigate(Screen.Player.createRoute(encodedUri))
+        }
+    }
+
+    fun navigateToPodcastDetails(podcastUri: String, from: NavBackStackEntry) {
+        if (from.lifecycleIsResumed()) {
+            val encodedUri = Uri.encode(podcastUri)
+            navController.navigate(Screen.PodcastDetails.createRoute(encodedUri))
         }
     }
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -95,12 +95,12 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 
 @Composable
 fun Home(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -84,6 +84,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.example.jetcaster.R
 import com.example.jetcaster.core.data.model.CategoryInfo
+import com.example.jetcaster.core.data.model.EpisodeInfo
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
 import com.example.jetcaster.core.data.model.LibraryInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
@@ -105,6 +106,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun Home(
     navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
     viewModel: HomeViewModel = viewModel()
 ) {
     val viewState by viewModel.state.collectAsStateWithLifecycle()
@@ -121,6 +123,7 @@ fun Home(
             onCategorySelected = viewModel::onCategorySelected,
             onPodcastUnfollowed = viewModel::onPodcastUnfollowed,
             navigateToPodcastDetails = navigateToPodcastDetails,
+            navigateToPlayer = navigateToPlayer,
             onTogglePodcastFollowed = viewModel::onTogglePodcastFollowed,
             onLibraryPodcastSelected = viewModel::onLibraryPodcastSelected,
             onQueueEpisode = viewModel::onQueueEpisode,
@@ -187,6 +190,7 @@ fun Home(
     onHomeCategorySelected: (HomeCategory) -> Unit,
     onCategorySelected: (CategoryInfo) -> Unit,
     navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
     onTogglePodcastFollowed: (PodcastInfo) -> Unit,
     onLibraryPodcastSelected: (PodcastInfo?) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
@@ -231,6 +235,7 @@ fun Home(
             onHomeCategorySelected = onHomeCategorySelected,
             onCategorySelected = onCategorySelected,
             navigateToPodcastDetails = navigateToPodcastDetails,
+            navigateToPlayer = navigateToPlayer,
             onTogglePodcastFollowed = onTogglePodcastFollowed,
             onLibraryPodcastSelected = onLibraryPodcastSelected,
             onQueueEpisode = {
@@ -259,6 +264,7 @@ private fun HomeContent(
     onHomeCategorySelected: (HomeCategory) -> Unit,
     onCategorySelected: (CategoryInfo) -> Unit,
     navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
     onTogglePodcastFollowed: (PodcastInfo) -> Unit,
     onLibraryPodcastSelected: (PodcastInfo?) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
@@ -308,7 +314,7 @@ private fun HomeContent(
             HomeCategory.Library -> {
                 libraryItems(
                     library = library,
-                    navigateToPodcastDetails = navigateToPodcastDetails,
+                    navigateToPlayer = navigateToPlayer,
                     onQueueEpisode = onQueueEpisode
                 )
             }
@@ -318,6 +324,7 @@ private fun HomeContent(
                     filterableCategoriesModel = filterableCategoriesModel,
                     podcastCategoryFilterResult = podcastCategoryFilterResult,
                     navigateToPodcastDetails = navigateToPodcastDetails,
+                    navigateToPlayer = navigateToPlayer,
                     onCategorySelected = onCategorySelected,
                     onTogglePodcastFollowed = onTogglePodcastFollowed,
                     onQueueEpisode = onQueueEpisode
@@ -529,6 +536,7 @@ fun PreviewHomeContent() {
             onCategorySelected = {},
             onPodcastUnfollowed = {},
             navigateToPodcastDetails = {},
+            navigateToPlayer = {},
             onHomeCategorySelected = {},
             onTogglePodcastFollowed = {},
             onLibraryPodcastSelected = {},

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -96,11 +96,11 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.coroutines.launch
 
 @Composable
 fun Home(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -97,12 +97,12 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 
 @Composable
 fun Home(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -89,20 +89,18 @@ import com.example.jetcaster.core.data.model.LibraryInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
 import com.example.jetcaster.core.data.model.PodcastInfo
-import com.example.jetcaster.core.data.model.asExternalModel
-import com.example.jetcaster.core.data.model.asPodcastCategoryEpisode
 import com.example.jetcaster.ui.home.discover.discoverItems
 import com.example.jetcaster.ui.home.library.libraryItems
 import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import java.time.Duration
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 @Composable
 fun Home(
@@ -515,21 +513,17 @@ private fun lastUpdated(updated: OffsetDateTime): String {
 fun PreviewHomeContent() {
     JetcasterTheme {
         Home(
-            featuredPodcasts = PreviewPodcastsWithExtraInfo.map {
-                it.asExternalModel()
-            }.toPersistentList(),
+            featuredPodcasts = PreviewPodcasts.toPersistentList(),
             isRefreshing = false,
             homeCategories = HomeCategory.entries,
             selectedHomeCategory = HomeCategory.Discover,
             filterableCategoriesModel = FilterableCategoriesModel(
-                categories = PreviewCategories.map { it.asExternalModel() },
-                selectedCategory = PreviewCategories.firstOrNull()?.asExternalModel()
+                categories = PreviewCategories,
+                selectedCategory = PreviewCategories.firstOrNull()
             ),
             podcastCategoryFilterResult = PodcastCategoryFilterResult(
-                topPodcasts = PreviewPodcastsWithExtraInfo.map { it.asExternalModel() },
-                episodes = PreviewEpisodeToPodcasts.map {
-                    it.asPodcastCategoryEpisode()
-                }
+                topPodcasts = PreviewPodcasts,
+                episodes = PreviewPodcastCategoryEpisodes
             ),
             library = LibraryInfo(),
             onCategorySelected = {},

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
@@ -27,8 +27,8 @@ import com.example.jetcaster.core.data.domain.FilterableCategoriesUseCase
 import com.example.jetcaster.core.data.domain.GetLatestFollowedEpisodesUseCase
 import com.example.jetcaster.core.data.domain.PodcastCategoryFilterUseCase
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
-import com.example.jetcaster.core.data.model.toPlayerEpisode
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.data.repository.PodcastsRepository
@@ -166,8 +166,8 @@ class HomeViewModel(
         selectedLibraryPodcast.value = podcast
     }
 
-    fun onQueuePodcast(episodeToPodcast: EpisodeToPodcast) {
-        episodePlayer.addToQueue(episodeToPodcast.toPlayerEpisode())
+    fun onQueueEpisode(episode: PlayerEpisode) {
+        episodePlayer.addToQueue(episode)
     }
 }
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
@@ -18,17 +18,17 @@ package com.example.jetcaster.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.jetcaster.core.data.database.model.Category
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
-import com.example.jetcaster.core.data.database.model.Podcast
-import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
 import com.example.jetcaster.core.data.di.Graph
 import com.example.jetcaster.core.data.domain.FilterableCategoriesUseCase
-import com.example.jetcaster.core.data.domain.GetLatestFollowedEpisodesUseCase
 import com.example.jetcaster.core.data.domain.PodcastCategoryFilterUseCase
+import com.example.jetcaster.core.data.model.CategoryInfo
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
+import com.example.jetcaster.core.data.model.LibraryInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
+import com.example.jetcaster.core.data.model.PodcastInfo
+import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.data.repository.PodcastsRepository
@@ -49,8 +49,6 @@ class HomeViewModel(
     private val podcastsRepository: PodcastsRepository = Graph.podcastRepository,
     private val podcastStore: PodcastStore = Graph.podcastStore,
     private val episodeStore: EpisodeStore = Graph.episodeStore,
-    private val getLatestFollowedEpisodesUseCase: GetLatestFollowedEpisodesUseCase =
-        Graph.getLatestFollowedEpisodesUseCase,
     private val podcastCategoryFilterUseCase: PodcastCategoryFilterUseCase =
         Graph.podcastCategoryFilterUseCase,
     private val filterableCategoriesUseCase: FilterableCategoriesUseCase =
@@ -58,13 +56,13 @@ class HomeViewModel(
     private val episodePlayer: EpisodePlayer = Graph.episodePlayer
 ) : ViewModel() {
     // Holds our currently selected podcast in the library
-    private val selectedLibraryPodcast = MutableStateFlow<Podcast?>(null)
+    private val selectedLibraryPodcast = MutableStateFlow<PodcastInfo?>(null)
     // Holds our currently selected home category
     private val selectedHomeCategory = MutableStateFlow(HomeCategory.Discover)
     // Holds the currently available home categories
     private val homeCategories = MutableStateFlow(HomeCategory.entries)
     // Holds our currently selected category
-    private val _selectedCategory = MutableStateFlow<Category?>(null)
+    private val _selectedCategory = MutableStateFlow<CategoryInfo?>(null)
     // Holds our view state which the UI collects via [state]
     private val _state = MutableStateFlow(HomeViewState())
     // Holds the view state if the UI is refreshing for new data
@@ -112,11 +110,11 @@ class HomeViewModel(
                 HomeViewState(
                     homeCategories = homeCategories,
                     selectedHomeCategory = homeCategory,
-                    featuredPodcasts = podcasts.toPersistentList(),
+                    featuredPodcasts = podcasts.map { it.asExternalModel() }.toPersistentList(),
                     refreshing = refreshing,
                     filterableCategoriesModel = filterableCategories,
                     podcastCategoryFilterResult = podcastCategoryFilterResult,
-                    libraryEpisodes = libraryEpisodes,
+                    library = libraryEpisodes.asLibrary(),
                     errorMessage = null, /* TODO */
                 )
             }.catch { throwable ->
@@ -142,7 +140,7 @@ class HomeViewModel(
         }
     }
 
-    fun onCategorySelected(category: Category) {
+    fun onCategorySelected(category: CategoryInfo) {
         _selectedCategory.value = category
     }
 
@@ -150,19 +148,19 @@ class HomeViewModel(
         selectedHomeCategory.value = category
     }
 
-    fun onPodcastUnfollowed(podcastUri: String) {
+    fun onPodcastUnfollowed(podcast: PodcastInfo) {
         viewModelScope.launch {
-            podcastStore.unfollowPodcast(podcastUri)
+            podcastStore.unfollowPodcast(podcast.uri)
         }
     }
 
-    fun onTogglePodcastFollowed(podcastUri: String) {
+    fun onTogglePodcastFollowed(podcast: PodcastInfo) {
         viewModelScope.launch {
-            podcastStore.togglePodcastFollowed(podcastUri)
+            podcastStore.togglePodcastFollowed(podcast.uri)
         }
     }
 
-    fun onLibraryPodcastSelected(podcast: Podcast?) {
+    fun onLibraryPodcastSelected(podcast: PodcastInfo?) {
         selectedLibraryPodcast.value = podcast
     }
 
@@ -171,17 +169,23 @@ class HomeViewModel(
     }
 }
 
+private fun List<EpisodeToPodcast>.asLibrary(): LibraryInfo =
+    LibraryInfo(
+        podcast = this.firstOrNull()?.podcast?.asExternalModel(),
+        episodes = this.map { it.episode.asExternalModel() }
+    )
+
 enum class HomeCategory {
     Library, Discover
 }
 
 data class HomeViewState(
-    val featuredPodcasts: PersistentList<PodcastWithExtraInfo> = persistentListOf(),
+    val featuredPodcasts: PersistentList<PodcastInfo> = persistentListOf(),
     val refreshing: Boolean = false,
     val selectedHomeCategory: HomeCategory = HomeCategory.Discover,
     val homeCategories: List<HomeCategory> = emptyList(),
     val filterableCategoriesModel: FilterableCategoriesModel = FilterableCategoriesModel(),
     val podcastCategoryFilterResult: PodcastCategoryFilterResult = PodcastCategoryFilterResult(),
-    val libraryEpisodes: List<EpisodeToPodcast> = emptyList(),
+    val library: LibraryInfo = LibraryInfo(),
     val errorMessage: String? = null
 )

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/PreviewData.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/PreviewData.kt
@@ -23,7 +23,6 @@ import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import kotlinx.collections.immutable.toPersistentList
 
 val PreviewCategories = listOf(
     Category(name = "Crime"),
@@ -50,7 +49,7 @@ val PreviewPodcastsWithExtraInfo = PreviewPodcasts.mapIndexed { index, podcast -
         this.lastEpisodeDate = OffsetDateTime.now()
         this.isFollowed = index % 2 == 0
     }
-}.toPersistentList()
+}
 
 val PreviewEpisodes = listOf(
     Episode(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/PreviewData.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/PreviewData.kt
@@ -16,45 +16,38 @@
 
 package com.example.jetcaster.ui.home
 
-import com.example.jetcaster.core.data.database.model.Category
-import com.example.jetcaster.core.data.database.model.Episode
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
-import com.example.jetcaster.core.data.database.model.Podcast
-import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
+import com.example.jetcaster.core.data.model.CategoryInfo
+import com.example.jetcaster.core.data.model.EpisodeInfo
+import com.example.jetcaster.core.data.model.PodcastCategoryEpisode
+import com.example.jetcaster.core.data.model.PodcastInfo
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 val PreviewCategories = listOf(
-    Category(name = "Crime"),
-    Category(name = "News"),
-    Category(name = "Comedy")
+    CategoryInfo(id = 1, name = "Crime"),
+    CategoryInfo(id = 2, name = "News"),
+    CategoryInfo(id = 3, name = "Comedy")
 )
 
 val PreviewPodcasts = listOf(
-    Podcast(
+    PodcastInfo(
         uri = "fakeUri://podcast/1",
         title = "Android Developers Backstage",
-        author = "Android Developers"
+        author = "Android Developers",
+        isSubscribed = true,
+        lastEpisodeDate = OffsetDateTime.now()
     ),
-    Podcast(
+    PodcastInfo(
         uri = "fakeUri://podcast/2",
         title = "Google Developers podcast",
-        author = "Google Developers"
+        author = "Google Developers",
+        lastEpisodeDate = OffsetDateTime.now()
     )
 )
 
-val PreviewPodcastsWithExtraInfo = PreviewPodcasts.mapIndexed { index, podcast ->
-    PodcastWithExtraInfo().apply {
-        this.podcast = podcast
-        this.lastEpisodeDate = OffsetDateTime.now()
-        this.isFollowed = index % 2 == 0
-    }
-}
-
 val PreviewEpisodes = listOf(
-    Episode(
+    EpisodeInfo(
         uri = "fakeUri://episode/1",
-        podcastUri = PreviewPodcasts[0].uri,
         title = "Episode 140: Bubbles!",
         summary = "In this episode, Romain, Chet and Tor talked with Mady Melor and Artur " +
             "Tsurkan from the System UI team about... Bubbles!",
@@ -65,9 +58,9 @@ val PreviewEpisodes = listOf(
     )
 )
 
-val PreviewEpisodeToPodcasts = listOf(
-    EpisodeToPodcast().apply {
-        episode = PreviewEpisodes.first()
-        _podcasts = PreviewPodcasts
-    }
+val PreviewPodcastCategoryEpisodes = listOf(
+    PodcastCategoryEpisode(
+        podcast = PreviewPodcasts[0],
+        episode = PreviewEpisodes[0],
+    )
 )

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -44,9 +44,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
-import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
+import com.example.jetcaster.core.data.model.PodcastInfo
 import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.home.PreviewEpisodes
@@ -56,21 +56,20 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 
 fun LazyListScope.podcastCategory(
-    topPodcasts: List<PodcastWithExtraInfo>,
-    episodes: List<EpisodeToPodcast>,
-    navigateToPlayer: (String) -> Unit,
-    navigateToPodcastDetails: (String) -> Unit,
+    podcastCategoryFilterResult: PodcastCategoryFilterResult,
+    navigateToPodcastDetails: (PodcastInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
-    onTogglePodcastFollowed: (String) -> Unit,
+    onTogglePodcastFollowed: (PodcastInfo) -> Unit,
 ) {
     item {
         CategoryPodcasts(
-            topPodcasts = topPodcasts,
+            topPodcasts = podcastCategoryFilterResult.topPodcasts,
             navigateToPodcastDetails = navigateToPodcastDetails,
             onTogglePodcastFollowed = onTogglePodcastFollowed
         )
     }
 
+    val episodes = podcastCategoryFilterResult.episodes
     items(episodes, key = { it.episode.uri }) { item ->
         EpisodeListItem(
             episode = item.episode,
@@ -84,9 +83,9 @@ fun LazyListScope.podcastCategory(
 
 @Composable
 private fun CategoryPodcasts(
-    topPodcasts: List<PodcastWithExtraInfo>,
-    navigateToPodcastDetails: (String) -> Unit,
-    onTogglePodcastFollowed: (String) -> Unit
+    topPodcasts: List<PodcastInfo>,
+    navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    onTogglePodcastFollowed: (PodcastInfo) -> Unit
 ) {
     CategoryPodcastRow(
         podcasts = topPodcasts,
@@ -98,9 +97,9 @@ private fun CategoryPodcasts(
 
 @Composable
 private fun CategoryPodcastRow(
-    podcasts: List<PodcastWithExtraInfo>,
-    onTogglePodcastFollowed: (String) -> Unit,
-    navigateToPodcastDetails: (String) -> Unit,
+    podcasts: List<PodcastInfo>,
+    onTogglePodcastFollowed: (PodcastInfo) -> Unit,
+    navigateToPodcastDetails: (PodcastInfo) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val lastIndex = podcasts.size - 1
@@ -108,15 +107,17 @@ private fun CategoryPodcastRow(
         modifier = modifier,
         contentPadding = PaddingValues(start = Keyline1, top = 8.dp, end = Keyline1, bottom = 24.dp)
     ) {
-        itemsIndexed(items = podcasts) { index: Int,
-            (podcast, _, isFollowed): PodcastWithExtraInfo ->
+        itemsIndexed(
+            items = podcasts,
+            key = { _, p -> p.uri }
+        ) { index, podcast ->
             TopPodcastRowItem(
                 podcastTitle = podcast.title,
                 podcastImageUrl = podcast.imageUrl,
-                isFollowed = isFollowed,
-                onToggleFollowClicked = { onTogglePodcastFollowed(podcast.uri) },
+                isFollowed = podcast.isSubscribed ?: false,
+                onToggleFollowClicked = { onTogglePodcastFollowed(podcast) },
                 modifier = Modifier.width(128.dp).clickable {
-                    navigateToPodcastDetails(podcast.uri)
+                    navigateToPodcastDetails(podcast)
                 }
             )
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.example.jetcaster.core.data.model.EpisodeInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
 import com.example.jetcaster.core.data.model.PodcastInfo
@@ -57,6 +58,7 @@ import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 fun LazyListScope.podcastCategory(
     podcastCategoryFilterResult: PodcastCategoryFilterResult,
     navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
     onTogglePodcastFollowed: (PodcastInfo) -> Unit,
 ) {
@@ -73,7 +75,7 @@ fun LazyListScope.podcastCategory(
         EpisodeListItem(
             episode = item.episode,
             podcast = item.podcast,
-            onClick = navigateToPodcastDetails,
+            onClick = navigateToPlayer,
             onQueueEpisode = onQueueEpisode,
             modifier = Modifier.fillParentMaxWidth()
         )

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -16,9 +16,7 @@
 
 package com.example.jetcaster.ui.home.category
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,72 +25,58 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.rounded.PlayCircleFilled
-import androidx.compose.material.ripple.rememberRipple
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension.Companion.fillToConstraints
-import androidx.constraintlayout.compose.Dimension.Companion.preferredWrapContent
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.example.jetcaster.R
-import com.example.jetcaster.core.data.database.model.Episode
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
-import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.home.PreviewEpisodes
 import com.example.jetcaster.ui.home.PreviewPodcasts
+import com.example.jetcaster.ui.shared.EpisodeListItem
 import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 
 fun LazyListScope.podcastCategory(
     topPodcasts: List<PodcastWithExtraInfo>,
     episodes: List<EpisodeToPodcast>,
     navigateToPlayer: (String) -> Unit,
-    onQueuePodcast: (EpisodeToPodcast) -> Unit,
+    navigateToPodcastDetails: (String) -> Unit,
+    onQueueEpisode: (PlayerEpisode) -> Unit,
     onTogglePodcastFollowed: (String) -> Unit,
 ) {
     item {
-        CategoryPodcasts(topPodcasts, onTogglePodcastFollowed)
+        CategoryPodcasts(
+            topPodcasts = topPodcasts,
+            navigateToPodcastDetails = navigateToPodcastDetails,
+            onTogglePodcastFollowed = onTogglePodcastFollowed
+        )
     }
 
     items(episodes, key = { it.episode.uri }) { item ->
         EpisodeListItem(
             episode = item.episode,
             podcast = item.podcast,
-            onClick = navigateToPlayer,
-            onQueuePodcast = onQueuePodcast,
+            onClick = navigateToPodcastDetails,
+            onQueueEpisode = onQueueEpisode,
             modifier = Modifier.fillParentMaxWidth()
         )
     }
@@ -101,189 +85,22 @@ fun LazyListScope.podcastCategory(
 @Composable
 private fun CategoryPodcasts(
     topPodcasts: List<PodcastWithExtraInfo>,
+    navigateToPodcastDetails: (String) -> Unit,
     onTogglePodcastFollowed: (String) -> Unit
 ) {
     CategoryPodcastRow(
         podcasts = topPodcasts,
         onTogglePodcastFollowed = onTogglePodcastFollowed,
+        navigateToPodcastDetails = navigateToPodcastDetails,
         modifier = Modifier.fillMaxWidth()
     )
-}
-
-@Composable
-fun EpisodeListItem(
-    episode: Episode,
-    podcast: Podcast,
-    onClick: (String) -> Unit,
-    onQueuePodcast: (EpisodeToPodcast) -> Unit,
-    modifier: Modifier = Modifier,
-    showDivider: Boolean = true,
-) {
-    ConstraintLayout(modifier = modifier.clickable { onClick(episode.uri) }) {
-        val (
-            divider, episodeTitle, podcastTitle, image, playIcon,
-            date, addPlaylist, overflow
-        ) = createRefs()
-
-        if (showDivider) {
-            HorizontalDivider(
-                Modifier.constrainAs(divider) {
-                    top.linkTo(parent.top)
-                    centerHorizontallyTo(parent)
-                    width = fillToConstraints
-                }
-            )
-        }
-
-        // If we have an image Url, we can show it using Coil
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(podcast.imageUrl)
-                .crossfade(true)
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(56.dp)
-                .clip(MaterialTheme.shapes.medium)
-                .constrainAs(image) {
-                    end.linkTo(parent.end, 16.dp)
-                    top.linkTo(parent.top, 16.dp)
-                },
-        )
-
-        Text(
-            text = episode.title,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.constrainAs(episodeTitle) {
-                linkTo(
-                    start = parent.start,
-                    end = image.start,
-                    startMargin = Keyline1,
-                    endMargin = 16.dp,
-                    bias = 0f
-                )
-                top.linkTo(parent.top, 16.dp)
-                height = preferredWrapContent
-                width = preferredWrapContent
-            }
-        )
-
-        val titleImageBarrier = createBottomBarrier(podcastTitle, image)
-
-        Text(
-            text = podcast.title,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.titleSmall,
-            modifier = Modifier.constrainAs(podcastTitle) {
-                linkTo(
-                    start = parent.start,
-                    end = image.start,
-                    startMargin = Keyline1,
-                    endMargin = 16.dp,
-                    bias = 0f
-                )
-                top.linkTo(episodeTitle.bottom, 6.dp)
-                height = preferredWrapContent
-                width = preferredWrapContent
-            }
-        )
-
-        Image(
-            imageVector = Icons.Rounded.PlayCircleFilled,
-            contentDescription = stringResource(R.string.cd_play),
-            contentScale = ContentScale.Fit,
-            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary),
-            modifier = Modifier
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = rememberRipple(bounded = false, radius = 24.dp)
-                ) { /* TODO */ }
-                .size(48.dp)
-                .padding(6.dp)
-                .semantics { role = Role.Button }
-                .constrainAs(playIcon) {
-                    start.linkTo(parent.start, Keyline1)
-                    top.linkTo(titleImageBarrier, margin = 10.dp)
-                    bottom.linkTo(parent.bottom, 10.dp)
-                }
-        )
-
-        val duration = episode.duration
-        Text(
-            text = when {
-                duration != null -> {
-                    // If we have the duration, we combine the date/duration via a
-                    // formatted string
-                    stringResource(
-                        R.string.episode_date_duration,
-                        MediumDateFormatter.format(episode.published),
-                        duration.toMinutes().toInt()
-                    )
-                }
-                // Otherwise we just use the date
-                else -> MediumDateFormatter.format(episode.published)
-            },
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.constrainAs(date) {
-                centerVerticallyTo(playIcon)
-                linkTo(
-                    start = playIcon.end,
-                    startMargin = 12.dp,
-                    end = addPlaylist.start,
-                    endMargin = 16.dp,
-                    bias = 0f // float this towards the start
-                )
-                width = preferredWrapContent
-            }
-        )
-
-        IconButton(
-            onClick = {
-                onQueuePodcast(
-                    EpisodeToPodcast().apply {
-                        this.episode = episode
-                        this._podcasts = listOf(podcast)
-                    }
-                )
-            },
-            modifier = Modifier.constrainAs(addPlaylist) {
-                end.linkTo(overflow.start)
-                centerVerticallyTo(playIcon)
-            }
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
-                contentDescription = stringResource(R.string.cd_add),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-
-        IconButton(
-            onClick = { /* TODO */ },
-            modifier = Modifier.constrainAs(overflow) {
-                end.linkTo(parent.end, 8.dp)
-                centerVerticallyTo(playIcon)
-            }
-        ) {
-            Icon(
-                imageVector = Icons.Default.MoreVert,
-                contentDescription = stringResource(R.string.cd_more),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
 }
 
 @Composable
 private fun CategoryPodcastRow(
     podcasts: List<PodcastWithExtraInfo>,
     onTogglePodcastFollowed: (String) -> Unit,
+    navigateToPodcastDetails: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val lastIndex = podcasts.size - 1
@@ -298,7 +115,9 @@ private fun CategoryPodcastRow(
                 podcastImageUrl = podcast.imageUrl,
                 isFollowed = isFollowed,
                 onToggleFollowClicked = { onTogglePodcastFollowed(podcast.uri) },
-                modifier = Modifier.width(128.dp)
+                modifier = Modifier.width(128.dp).clickable {
+                    navigateToPodcastDetails(podcast.uri)
+                }
             )
 
             if (index < lastIndex) Spacer(Modifier.width(24.dp))
@@ -356,19 +175,15 @@ private fun TopPodcastRowItem(
     }
 }
 
-private val MediumDateFormatter by lazy {
-    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
-}
-
 @Preview
 @Composable
 fun PreviewEpisodeListItem() {
     JetcasterTheme {
         EpisodeListItem(
-            episode = PreviewEpisodes[0],
-            podcast = PreviewPodcasts[0],
+            episode = PreviewEpisodes[0].asExternalModel(),
+            podcast = PreviewPodcasts[0].asExternalModel(),
             onClick = { },
-            onQueuePodcast = { },
+            onQueueEpisode = { },
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/category/PodcastCategory.kt
@@ -47,7 +47,6 @@ import coil.request.ImageRequest
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
 import com.example.jetcaster.core.data.model.PodcastInfo
-import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.home.PreviewEpisodes
 import com.example.jetcaster.ui.home.PreviewPodcasts
@@ -181,8 +180,8 @@ private fun TopPodcastRowItem(
 fun PreviewEpisodeListItem() {
     JetcasterTheme {
         EpisodeListItem(
-            episode = PreviewEpisodes[0].asExternalModel(),
-            podcast = PreviewPodcasts[0].asExternalModel(),
+            episode = PreviewEpisodes[0],
+            podcast = PreviewPodcasts[0],
             onClick = { },
             onQueueEpisode = { },
             modifier = Modifier.fillMaxWidth()

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
@@ -38,8 +38,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
 import com.example.jetcaster.core.data.database.model.Category
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.home.category.podcastCategory
@@ -48,9 +48,10 @@ fun LazyListScope.discoverItems(
     filterableCategoriesModel: FilterableCategoriesModel,
     podcastCategoryFilterResult: PodcastCategoryFilterResult,
     navigateToPlayer: (String) -> Unit,
+    navigateToPodcastDetails: (String) -> Unit,
     onCategorySelected: (Category) -> Unit,
     onTogglePodcastFollowed: (String) -> Unit,
-    onQueuePodcast: (EpisodeToPodcast) -> Unit,
+    onQueueEpisode: (PlayerEpisode) -> Unit,
 ) {
     if (filterableCategoriesModel.isEmpty) {
         // TODO: empty state
@@ -73,8 +74,9 @@ fun LazyListScope.discoverItems(
         topPodcasts = podcastCategoryFilterResult.topPodcasts,
         episodes = podcastCategoryFilterResult.episodes,
         navigateToPlayer = navigateToPlayer,
+        navigateToPodcastDetails = navigateToPodcastDetails,
         onTogglePodcastFollowed = onTogglePodcastFollowed,
-        onQueuePodcast = onQueuePodcast,
+        onQueueEpisode = onQueueEpisode,
     )
 }
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
 import com.example.jetcaster.core.data.model.CategoryInfo
+import com.example.jetcaster.core.data.model.EpisodeInfo
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
@@ -49,6 +50,7 @@ fun LazyListScope.discoverItems(
     filterableCategoriesModel: FilterableCategoriesModel,
     podcastCategoryFilterResult: PodcastCategoryFilterResult,
     navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
     onCategorySelected: (CategoryInfo) -> Unit,
     onTogglePodcastFollowed: (PodcastInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
@@ -73,6 +75,7 @@ fun LazyListScope.discoverItems(
     podcastCategory(
         podcastCategoryFilterResult = podcastCategoryFilterResult,
         navigateToPodcastDetails = navigateToPodcastDetails,
+        navigateToPlayer = navigateToPlayer,
         onTogglePodcastFollowed = onTogglePodcastFollowed,
         onQueueEpisode = onQueueEpisode,
     )

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/discover/Discover.kt
@@ -37,20 +37,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
-import com.example.jetcaster.core.data.database.model.Category
+import com.example.jetcaster.core.data.model.CategoryInfo
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
+import com.example.jetcaster.core.data.model.PodcastInfo
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.home.category.podcastCategory
 
 fun LazyListScope.discoverItems(
     filterableCategoriesModel: FilterableCategoriesModel,
     podcastCategoryFilterResult: PodcastCategoryFilterResult,
-    navigateToPlayer: (String) -> Unit,
-    navigateToPodcastDetails: (String) -> Unit,
-    onCategorySelected: (Category) -> Unit,
-    onTogglePodcastFollowed: (String) -> Unit,
+    navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    onCategorySelected: (CategoryInfo) -> Unit,
+    onTogglePodcastFollowed: (PodcastInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
 ) {
     if (filterableCategoriesModel.isEmpty) {
@@ -71,9 +71,7 @@ fun LazyListScope.discoverItems(
     }
 
     podcastCategory(
-        topPodcasts = podcastCategoryFilterResult.topPodcasts,
-        episodes = podcastCategoryFilterResult.episodes,
-        navigateToPlayer = navigateToPlayer,
+        podcastCategoryFilterResult = podcastCategoryFilterResult,
         navigateToPodcastDetails = navigateToPodcastDetails,
         onTogglePodcastFollowed = onTogglePodcastFollowed,
         onQueueEpisode = onQueueEpisode,
@@ -85,7 +83,7 @@ private val emptyTabIndicator: @Composable (List<TabPosition>) -> Unit = {}
 @Composable
 private fun PodcastCategoryTabs(
     filterableCategoriesModel: FilterableCategoriesModel,
-    onCategorySelected: (Category) -> Unit,
+    onCategorySelected: (CategoryInfo) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val selectedIndex = filterableCategoriesModel.categories.indexOf(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
@@ -26,13 +26,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.designsystem.theme.Keyline1
-import com.example.jetcaster.ui.home.category.EpisodeListItem
+import com.example.jetcaster.ui.shared.EpisodeListItem
 
 fun LazyListScope.libraryItems(
     episodes: List<EpisodeToPodcast>,
     navigateToPlayer: (String) -> Unit,
-    onQueuePodcast: (EpisodeToPodcast) -> Unit
+    navigateToPodcastDetails: (String) -> Unit,
+    onQueueEpisode: (PlayerEpisode) -> Unit
 ) {
     if (episodes.isEmpty()) {
         // TODO: Empty state
@@ -57,8 +59,8 @@ fun LazyListScope.libraryItems(
         EpisodeListItem(
             episode = item.episode,
             podcast = item.podcast,
-            onClick = navigateToPlayer,
-            onQueuePodcast = onQueuePodcast,
+            onClick = navigateToPodcastDetails,
+            onQueueEpisode = onQueueEpisode,
             modifier = Modifier.fillParentMaxWidth(),
             showDivider = index != 0
         )

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
@@ -25,15 +25,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
+import com.example.jetcaster.core.data.model.EpisodeInfo
 import com.example.jetcaster.core.data.model.LibraryInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
-import com.example.jetcaster.core.data.model.PodcastInfo
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.shared.EpisodeListItem
 
 fun LazyListScope.libraryItems(
     library: LibraryInfo,
-    navigateToPodcastDetails: (PodcastInfo) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit
 ) {
     val podcast = library.podcast
@@ -60,7 +60,7 @@ fun LazyListScope.libraryItems(
         EpisodeListItem(
             episode = item,
             podcast = podcast,
-            onClick = navigateToPodcastDetails,
+            onClick = navigateToPlayer,
             onQueueEpisode = onQueueEpisode,
             modifier = Modifier.fillParentMaxWidth(),
             showDivider = index != 0

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
@@ -25,18 +25,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
+import com.example.jetcaster.core.data.model.LibraryInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.PodcastInfo
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.shared.EpisodeListItem
 
 fun LazyListScope.libraryItems(
-    episodes: List<EpisodeToPodcast>,
-    navigateToPlayer: (String) -> Unit,
-    navigateToPodcastDetails: (String) -> Unit,
+    library: LibraryInfo,
+    navigateToPodcastDetails: (PodcastInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit
 ) {
-    if (episodes.isEmpty()) {
+    val podcast = library.podcast
+    if (podcast == null || library.episodes.isEmpty()) {
         // TODO: Empty state
         return
     }
@@ -53,12 +54,12 @@ fun LazyListScope.libraryItems(
     }
 
     itemsIndexed(
-        episodes,
-        key = { _, item -> item.episode.uri }
+        library.episodes,
+        key = { _, item -> item.uri }
     ) { index, item ->
         EpisodeListItem(
-            episode = item.episode,
-            podcast = item.podcast,
+            episode = item,
+            podcast = podcast,
             onClick = navigateToPodcastDetails,
             onQueueEpisode = onQueueEpisode,
             modifier = Modifier.fillParentMaxWidth(),

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
@@ -33,11 +33,11 @@ import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.core.player.EpisodePlayerState
 import com.example.jetcaster.ui.Screen
+import java.time.Duration
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import java.time.Duration
 
 data class PlayerUiState(
     val episodePlayerState: EpisodePlayerState = EpisodePlayerState()

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
@@ -32,11 +32,12 @@ import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.core.player.EpisodePlayerState
-import java.time.Duration
+import com.example.jetcaster.ui.Screen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import java.time.Duration
 
 data class PlayerUiState(
     val episodePlayerState: EpisodePlayerState = EpisodePlayerState()
@@ -55,7 +56,8 @@ class PlayerViewModel(
 
     // episodeUri should always be present in the PlayerViewModel.
     // If that's not the case, fail crashing the app!
-    private val episodeUri: String = Uri.decode(savedStateHandle.get<String>("episodeUri")!!)
+    private val episodeUri: String =
+        Uri.decode(savedStateHandle.get<String>(Screen.ARG_EPISODE_URI)!!)
 
     var uiState by mutableStateOf(PlayerUiState())
         private set

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/player/PlayerViewModel.kt
@@ -29,7 +29,6 @@ import androidx.savedstate.SavedStateRegistryOwner
 import com.example.jetcaster.core.data.di.Graph
 import com.example.jetcaster.core.data.model.toPlayerEpisode
 import com.example.jetcaster.core.data.repository.EpisodeStore
-import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.core.player.EpisodePlayerState
 import com.example.jetcaster.ui.Screen
@@ -49,7 +48,6 @@ data class PlayerUiState(
 @OptIn(ExperimentalCoroutinesApi::class)
 class PlayerViewModel(
     episodeStore: EpisodeStore = Graph.episodeStore,
-    podcastStore: PodcastStore = Graph.podcastStore,
     private val episodePlayer: EpisodePlayer = Graph.episodePlayer,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -110,7 +108,6 @@ class PlayerViewModel(
     companion object {
         fun provideFactory(
             episodeStore: EpisodeStore = Graph.episodeStore,
-            podcastStore: PodcastStore = Graph.podcastStore,
             episodePlayer: EpisodePlayer = Graph.episodePlayer,
             owner: SavedStateRegistryOwner,
             defaultArgs: Bundle? = null,
@@ -122,7 +119,7 @@ class PlayerViewModel(
                     modelClass: Class<T>,
                     handle: SavedStateHandle
                 ): T {
-                    return PlayerViewModel(episodeStore, podcastStore, episodePlayer, handle) as T
+                    return PlayerViewModel(episodeStore, episodePlayer, handle) as T
                 }
             }
     }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.ui.podcast
 
 import androidx.compose.foundation.background

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -154,7 +154,7 @@ fun PodcastDetailsContent(
             EpisodeListItem(
                 episode = episode,
                 podcast = podcast,
-                onClick = { navigateToPlayer(episode) },
+                onClick = navigateToPlayer,
                 onQueueEpisode = onQueueEpisode,
                 modifier = Modifier.fillMaxWidth(),
                 showPodcastImage = false

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -1,0 +1,328 @@
+package com.example.jetcaster.ui.podcast
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.jetcaster.R
+import com.example.jetcaster.core.data.model.EpisodeInfo
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.PodcastInfo
+import com.example.jetcaster.core.data.model.asExternalModel
+import com.example.jetcaster.designsystem.theme.Keyline1
+import com.example.jetcaster.ui.home.PreviewEpisodes
+import com.example.jetcaster.ui.home.PreviewPodcasts
+import com.example.jetcaster.ui.shared.EpisodeListItem
+import kotlinx.coroutines.launch
+
+@Composable
+fun PodcastDetailsScreen(
+    viewModel: PodcastDetailsViewModel,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
+    navigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    PodcastDetailsScreen(
+        podcast = state.podcast,
+        isSubscribed = state.isSubscribed,
+        episodes = state.episodes,
+        toggleSubscribe = viewModel::toggleSusbcribe,
+        onQueueEpisode = viewModel::onQueueEpisode,
+        navigateToPlayer = navigateToPlayer,
+        navigateBack = navigateBack,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PodcastDetailsScreen(
+    podcast: PodcastInfo,
+    isSubscribed: Boolean,
+    episodes: List<EpisodeInfo>,
+    toggleSubscribe: (PodcastInfo) -> Unit,
+    onQueueEpisode: (PlayerEpisode) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
+    navigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val snackBarText = stringResource(id = R.string.episode_added_to_your_queue)
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            PodcastDetailsTopAppBar(
+                navigateBack = navigateBack,
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        }
+    ) { contentPadding ->
+        PodcastDetailsContent(
+            podcast = podcast,
+            isSubscribed = isSubscribed,
+            episodes = episodes,
+            toggleSubscribe = toggleSubscribe,
+            onQueueEpisode = {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(snackBarText)
+                }
+                onQueueEpisode(it)
+            },
+            navigateToPlayer = navigateToPlayer,
+            modifier = Modifier.padding(contentPadding)
+        )
+    }
+}
+
+@Composable
+fun PodcastDetailsContent(
+    podcast: PodcastInfo,
+    isSubscribed: Boolean,
+    episodes: List<EpisodeInfo>,
+    toggleSubscribe: (PodcastInfo) -> Unit,
+    onQueueEpisode: (PlayerEpisode) -> Unit,
+    navigateToPlayer: (EpisodeInfo) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier.fillMaxSize()
+    ) {
+        item {
+            PodcastDetailsHeaderItem(
+                podcast = podcast,
+                isSubscribed = isSubscribed,
+                toggleSubscribe = toggleSubscribe,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        items(episodes, key = { it.uri }) { episode ->
+            EpisodeListItem(
+                episode = episode,
+                podcast = podcast,
+                onClick = { navigateToPlayer(episode) },
+                onQueueEpisode = onQueueEpisode,
+                modifier = Modifier.fillMaxWidth(),
+                showPodcastImage = false
+            )
+        }
+    }
+}
+
+@Composable
+fun PodcastDetailsHeaderItem(
+    podcast: PodcastInfo,
+    isSubscribed: Boolean,
+    toggleSubscribe: (PodcastInfo) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(Keyline1)
+    ) {
+        Row(
+            verticalAlignment = Alignment.Bottom,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(podcast.imageUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(id = R.string.cd_podcast_image),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(148.dp)
+                    .clip(MaterialTheme.shapes.large)
+            )
+            Column(
+                modifier = Modifier.padding(start = 16.dp)
+            ) {
+                Text(
+                    text = podcast.title,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.headlineMedium
+                )
+                PodcastDetailsHeaderItemButtons(
+                    isSubscribed = isSubscribed,
+                    onClick = {
+                        toggleSubscribe(podcast)
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+        PodcastDetailsDescription(
+            podcast = podcast,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        )
+    }
+}
+
+@Composable
+fun PodcastDetailsDescription(
+    podcast: PodcastInfo,
+    modifier: Modifier
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+    var showSeeMore by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        Text(
+            text = podcast.description,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = if (isExpanded) Int.MAX_VALUE else 3,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { result ->
+                showSeeMore = result.hasVisualOverflow
+            },
+        )
+        if (showSeeMore) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .background(MaterialTheme.colorScheme.surface)
+            ) {
+                // TODO: Add gradient effect
+                Text(
+                    text = stringResource(id = R.string.see_more),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .padding(start = 16.dp)
+                        .clickable {
+                            isExpanded = !isExpanded
+                        }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun PodcastDetailsHeaderItemButtons(
+    isSubscribed: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier.padding(top = 16.dp)) {
+        Button(
+            onClick = onClick
+        ) {
+            Icon(
+                imageVector = if (isSubscribed)
+                    Icons.Default.Check
+                else
+                    Icons.Default.Add,
+                contentDescription = if (isSubscribed)
+                    stringResource(id = R.string.unsubscribe)
+                else
+                    stringResource(id = R.string.subscribe)
+            )
+            Text(
+                text = if (isSubscribed)
+                    stringResource(id = R.string.unsubscribe)
+                else
+                    stringResource(id = R.string.subscribe),
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+
+        IconButton(
+            onClick = { /* TODO */ },
+            modifier = Modifier.padding(start = 8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(R.string.cd_more)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PodcastDetailsTopAppBar(
+    navigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TopAppBar(
+        title = { },
+        navigationIcon = {
+            IconButton(onClick = navigateBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(id = R.string.cd_back)
+                )
+            }
+        },
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+fun PodcastDetailsHeaderItemPreview() {
+    PodcastDetailsHeaderItem(
+        podcast = PreviewPodcasts[0].asExternalModel(),
+        isSubscribed = false,
+        toggleSubscribe = { },
+    )
+}
+
+@Preview
+@Composable
+fun PodcastDetailsScreenPreview() {
+    PodcastDetailsScreen(
+        podcast = PreviewPodcasts[0].asExternalModel(),
+        isSubscribed = false,
+        episodes = PreviewEpisodes.map { it.asExternalModel() },
+        toggleSubscribe = { },
+        onQueueEpisode = { },
+        navigateToPlayer = { },
+        navigateBack = { }
+    )
+}

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -81,7 +81,6 @@ fun PodcastDetailsScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     PodcastDetailsScreen(
         podcast = state.podcast,
-        isSubscribed = state.isSubscribed,
         episodes = state.episodes,
         toggleSubscribe = viewModel::toggleSusbcribe,
         onQueueEpisode = viewModel::onQueueEpisode,
@@ -94,7 +93,6 @@ fun PodcastDetailsScreen(
 @Composable
 fun PodcastDetailsScreen(
     podcast: PodcastInfo,
-    isSubscribed: Boolean,
     episodes: List<EpisodeInfo>,
     toggleSubscribe: (PodcastInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
@@ -119,7 +117,6 @@ fun PodcastDetailsScreen(
     ) { contentPadding ->
         PodcastDetailsContent(
             podcast = podcast,
-            isSubscribed = isSubscribed,
             episodes = episodes,
             toggleSubscribe = toggleSubscribe,
             onQueueEpisode = {
@@ -137,7 +134,6 @@ fun PodcastDetailsScreen(
 @Composable
 fun PodcastDetailsContent(
     podcast: PodcastInfo,
-    isSubscribed: Boolean,
     episodes: List<EpisodeInfo>,
     toggleSubscribe: (PodcastInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
@@ -150,7 +146,6 @@ fun PodcastDetailsContent(
         item {
             PodcastDetailsHeaderItem(
                 podcast = podcast,
-                isSubscribed = isSubscribed,
                 toggleSubscribe = toggleSubscribe,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -171,7 +166,6 @@ fun PodcastDetailsContent(
 @Composable
 fun PodcastDetailsHeaderItem(
     podcast: PodcastInfo,
-    isSubscribed: Boolean,
     toggleSubscribe: (PodcastInfo) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -203,7 +197,7 @@ fun PodcastDetailsHeaderItem(
                     style = MaterialTheme.typography.headlineMedium
                 )
                 PodcastDetailsHeaderItemButtons(
-                    isSubscribed = isSubscribed,
+                    isSubscribed = podcast.isSubscribed ?: false,
                     onClick = {
                         toggleSubscribe(podcast)
                     },
@@ -324,7 +318,6 @@ fun PodcastDetailsTopAppBar(
 fun PodcastDetailsHeaderItemPreview() {
     PodcastDetailsHeaderItem(
         podcast = PreviewPodcasts[0].asExternalModel(),
-        isSubscribed = false,
         toggleSubscribe = { },
     )
 }
@@ -334,7 +327,6 @@ fun PodcastDetailsHeaderItemPreview() {
 fun PodcastDetailsScreenPreview() {
     PodcastDetailsScreen(
         podcast = PreviewPodcasts[0].asExternalModel(),
-        isSubscribed = false,
         episodes = PreviewEpisodes.map { it.asExternalModel() },
         toggleSubscribe = { },
         onQueueEpisode = { },

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -64,7 +65,6 @@ import com.example.jetcaster.R
 import com.example.jetcaster.core.data.model.EpisodeInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastInfo
-import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.home.PreviewEpisodes
 import com.example.jetcaster.ui.home.PreviewPodcasts
@@ -181,7 +181,7 @@ fun PodcastDetailsHeaderItem(
                     .data(podcast.imageUrl)
                     .crossfade(true)
                     .build(),
-                contentDescription = stringResource(id = R.string.cd_podcast_image),
+                contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(148.dp)
@@ -260,17 +260,15 @@ fun PodcastDetailsHeaderItemButtons(
 ) {
     Row(modifier.padding(top = 16.dp)) {
         Button(
-            onClick = onClick
+            onClick = onClick,
+            modifier = Modifier.semantics(mergeDescendants = true) { }
         ) {
             Icon(
                 imageVector = if (isSubscribed)
                     Icons.Default.Check
                 else
                     Icons.Default.Add,
-                contentDescription = if (isSubscribed)
-                    stringResource(id = R.string.unsubscribe)
-                else
-                    stringResource(id = R.string.subscribe)
+                contentDescription = null
             )
             Text(
                 text = if (isSubscribed)
@@ -317,7 +315,7 @@ fun PodcastDetailsTopAppBar(
 @Composable
 fun PodcastDetailsHeaderItemPreview() {
     PodcastDetailsHeaderItem(
-        podcast = PreviewPodcasts[0].asExternalModel(),
+        podcast = PreviewPodcasts[0],
         toggleSubscribe = { },
     )
 }
@@ -326,8 +324,8 @@ fun PodcastDetailsHeaderItemPreview() {
 @Composable
 fun PodcastDetailsScreenPreview() {
     PodcastDetailsScreen(
-        podcast = PreviewPodcasts[0].asExternalModel(),
-        episodes = PreviewEpisodes.map { it.asExternalModel() },
+        podcast = PreviewPodcasts[0],
+        episodes = PreviewEpisodes,
         toggleSubscribe = { },
         onQueueEpisode = { },
         navigateToPlayer = { },

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
@@ -40,7 +40,6 @@ import kotlinx.coroutines.launch
 
 data class PodcastUiState(
     val podcast: PodcastInfo = PodcastInfo(),
-    val isSubscribed: Boolean = false,
     val episodes: List<EpisodeInfo> = emptyList()
 )
 
@@ -64,8 +63,7 @@ class PodcastDetailsViewModel(
         ) { podcast, episodeToPodcasts ->
             val episodes = episodeToPodcasts.map { it.episode.asExternalModel() }
             PodcastUiState(
-                podcast = podcast.podcast.asExternalModel(),
-                isSubscribed = podcast.isFollowed,
+                podcast = podcast.podcast.asExternalModel().copy(isSubscribed = podcast.isFollowed),
                 episodes = episodes,
             )
         }.stateIn(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
@@ -1,0 +1,98 @@
+package com.example.jetcaster.ui.podcast
+
+import android.net.Uri
+import android.os.Bundle
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.savedstate.SavedStateRegistryOwner
+import com.example.jetcaster.core.data.di.Graph
+import com.example.jetcaster.core.data.model.EpisodeInfo
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.PodcastInfo
+import com.example.jetcaster.core.data.model.asExternalModel
+import com.example.jetcaster.core.data.repository.EpisodeStore
+import com.example.jetcaster.core.data.repository.PodcastStore
+import com.example.jetcaster.core.player.EpisodePlayer
+import com.example.jetcaster.ui.Screen
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class PodcastUiState(
+    val podcast: PodcastInfo = PodcastInfo(),
+    val isSubscribed: Boolean = false,
+    val episodes: List<EpisodeInfo> = emptyList()
+)
+
+/**
+ * ViewModel that handles the business logic and screen state of the Podcast details screen.
+ */
+class PodcastDetailsViewModel(
+    private val episodeStore: EpisodeStore = Graph.episodeStore,
+    private val episodePlayer: EpisodePlayer = Graph.episodePlayer,
+    private val podcastStore: PodcastStore = Graph.podcastStore,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val podcastUri: String =
+        Uri.decode(savedStateHandle.get<String>(Screen.ARG_PODCAST_URI)!!)
+
+    val state: StateFlow<PodcastUiState> =
+        combine(
+            podcastStore.podcastWithExtraInfo(podcastUri),
+            episodeStore.episodesInPodcast(podcastUri)
+        ) { podcast, episodeToPodcasts ->
+            val episodes = episodeToPodcasts.map { it.episode.asExternalModel() }
+            PodcastUiState(
+                podcast = podcast.podcast.asExternalModel(),
+                isSubscribed = podcast.isFollowed,
+                episodes = episodes,
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = PodcastUiState()
+        )
+
+    fun toggleSusbcribe(podcast: PodcastInfo) {
+        viewModelScope.launch {
+            podcastStore.togglePodcastFollowed(podcast.uri)
+        }
+    }
+
+    fun onQueueEpisode(playerEpisode: PlayerEpisode) {
+        episodePlayer.addToQueue(playerEpisode)
+    }
+
+    /**
+     * Factory for [PodcastDetailsViewModel].
+     */
+    companion object {
+        fun provideFactory(
+            episodeStore: EpisodeStore = Graph.episodeStore,
+            podcastStore: PodcastStore = Graph.podcastStore,
+            episodePlayer: EpisodePlayer = Graph.episodePlayer,
+            owner: SavedStateRegistryOwner,
+            defaultArgs: Bundle? = null,
+        ): AbstractSavedStateViewModelFactory =
+            object : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(
+                    key: String,
+                    modelClass: Class<T>,
+                    handle: SavedStateHandle
+                ): T {
+                    return PodcastDetailsViewModel(
+                        episodeStore = episodeStore,
+                        episodePlayer = episodePlayer,
+                        podcastStore = podcastStore,
+                        savedStateHandle = handle
+                    ) as T
+                }
+            }
+    }
+}

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.ui.podcast
 
 import android.net.Uri

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.ui.shared
 
 import androidx.compose.foundation.Image

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -61,7 +61,7 @@ import java.time.format.FormatStyle
 fun EpisodeListItem(
     episode: EpisodeInfo,
     podcast: PodcastInfo,
-    onClick: (PodcastInfo) -> Unit,
+    onClick: (EpisodeInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
     showDivider: Boolean = true,
@@ -69,7 +69,7 @@ fun EpisodeListItem(
 ) {
     ConstraintLayout(
         modifier = modifier.clickable {
-            onClick(podcast)
+            onClick(episode)
         }
     ) {
         val (

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -50,43 +50,18 @@ import androidx.constraintlayout.compose.Visibility
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.jetcaster.R
-import com.example.jetcaster.core.data.database.model.Episode
-import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.model.EpisodeInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastInfo
-import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.designsystem.theme.Keyline1
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
-
-@Deprecated("Use the EpisodeListItem overload that accepts external models instead.")
-@Composable
-fun EpisodeListItem(
-    episode: Episode,
-    podcast: Podcast,
-    onClick: (String) -> Unit,
-    onQueueEpisode: (PlayerEpisode) -> Unit,
-    modifier: Modifier = Modifier,
-    showDivider: Boolean = true,
-    showPodcastImage: Boolean = true,
-) {
-    EpisodeListItem(
-        episode = episode.asExternalModel(),
-        podcast = podcast.asExternalModel(),
-        onClick = onClick,
-        onQueueEpisode = onQueueEpisode,
-        modifier = modifier,
-        showDivider = showDivider,
-        showPodcastImage = showPodcastImage
-    )
-}
 
 @Composable
 fun EpisodeListItem(
     episode: EpisodeInfo,
     podcast: PodcastInfo,
-    onClick: (String) -> Unit,
+    onClick: (PodcastInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
     showDivider: Boolean = true,
@@ -94,7 +69,7 @@ fun EpisodeListItem(
 ) {
     ConstraintLayout(
         modifier = modifier.clickable {
-            onClick(podcast.uri)
+            onClick(podcast)
         }
     ) {
         val (

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -1,0 +1,247 @@
+package com.example.jetcaster.ui.shared
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.rounded.PlayCircleFilled
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.constraintlayout.compose.Visibility
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.jetcaster.R
+import com.example.jetcaster.core.data.database.model.Episode
+import com.example.jetcaster.core.data.database.model.Podcast
+import com.example.jetcaster.core.data.model.EpisodeInfo
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.PodcastInfo
+import com.example.jetcaster.core.data.model.asExternalModel
+import com.example.jetcaster.designsystem.theme.Keyline1
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@Deprecated("Use the EpisodeListItem overload that accepts external models instead.")
+@Composable
+fun EpisodeListItem(
+    episode: Episode,
+    podcast: Podcast,
+    onClick: (String) -> Unit,
+    onQueueEpisode: (PlayerEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
+    showPodcastImage: Boolean = true,
+) {
+    EpisodeListItem(
+        episode = episode.asExternalModel(),
+        podcast = podcast.asExternalModel(),
+        onClick = onClick,
+        onQueueEpisode = onQueueEpisode,
+        modifier = modifier,
+        showDivider = showDivider,
+        showPodcastImage = showPodcastImage
+    )
+}
+
+@Composable
+fun EpisodeListItem(
+    episode: EpisodeInfo,
+    podcast: PodcastInfo,
+    onClick: (String) -> Unit,
+    onQueueEpisode: (PlayerEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
+    showPodcastImage: Boolean = true,
+) {
+    ConstraintLayout(
+        modifier = modifier.clickable {
+            onClick(podcast.uri)
+        }
+    ) {
+        val (
+            divider, episodeTitle, podcastTitle, image, playIcon,
+            date, addPlaylist, overflow
+        ) = createRefs()
+
+        if (showDivider) {
+            HorizontalDivider(
+                Modifier.constrainAs(divider) {
+                    top.linkTo(parent.top)
+                    centerHorizontallyTo(parent)
+                    width = Dimension.fillToConstraints
+                }
+            )
+        }
+
+        // If we have an image Url, we can show it using Coil
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(podcast.imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(56.dp)
+                .clip(MaterialTheme.shapes.medium)
+                .constrainAs(image) {
+                    end.linkTo(parent.end, 16.dp)
+                    top.linkTo(parent.top, 16.dp)
+                    visibility = if (showPodcastImage) Visibility.Visible else Visibility.Gone
+                },
+        )
+
+        Text(
+            text = episode.title,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.constrainAs(episodeTitle) {
+                linkTo(
+                    start = parent.start,
+                    end = image.start,
+                    startMargin = Keyline1,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+                top.linkTo(parent.top, 16.dp)
+                height = Dimension.preferredWrapContent
+                width = Dimension.preferredWrapContent
+            }
+        )
+
+        val titleImageBarrier = createBottomBarrier(podcastTitle, image)
+
+        Text(
+            text = podcast.title,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.constrainAs(podcastTitle) {
+                linkTo(
+                    start = parent.start,
+                    end = image.start,
+                    startMargin = Keyline1,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+                top.linkTo(episodeTitle.bottom, 6.dp)
+                height = Dimension.preferredWrapContent
+                width = Dimension.preferredWrapContent
+            }
+        )
+
+        Image(
+            imageVector = Icons.Rounded.PlayCircleFilled,
+            contentDescription = stringResource(R.string.cd_play),
+            contentScale = ContentScale.Fit,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary),
+            modifier = Modifier
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(bounded = false, radius = 24.dp)
+                ) { /* TODO */ }
+                .size(48.dp)
+                .padding(6.dp)
+                .semantics { role = Role.Button }
+                .constrainAs(playIcon) {
+                    start.linkTo(parent.start, Keyline1)
+                    top.linkTo(titleImageBarrier, margin = 10.dp)
+                    bottom.linkTo(parent.bottom, 10.dp)
+                }
+        )
+
+        val duration = episode.duration
+        Text(
+            text = when {
+                duration != null -> {
+                    // If we have the duration, we combine the date/duration via a
+                    // formatted string
+                    stringResource(
+                        R.string.episode_date_duration,
+                        MediumDateFormatter.format(episode.published),
+                        duration.toMinutes().toInt()
+                    )
+                }
+                // Otherwise we just use the date
+                else -> MediumDateFormatter.format(episode.published)
+            },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.constrainAs(date) {
+                centerVerticallyTo(playIcon)
+                linkTo(
+                    start = playIcon.end,
+                    startMargin = 12.dp,
+                    end = addPlaylist.start,
+                    endMargin = 16.dp,
+                    bias = 0f // float this towards the start
+                )
+                width = Dimension.preferredWrapContent
+            }
+        )
+
+        IconButton(
+            onClick = {
+                onQueueEpisode(
+                    PlayerEpisode(
+                        podcastInfo = podcast,
+                        episodeInfo = episode
+                    )
+                )
+            },
+            modifier = Modifier.constrainAs(addPlaylist) {
+                end.linkTo(overflow.start)
+                centerVerticallyTo(playIcon)
+            }
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                contentDescription = stringResource(R.string.cd_add),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        IconButton(
+            onClick = { /* TODO */ },
+            modifier = Modifier.constrainAs(overflow) {
+                end.linkTo(parent.end, 8.dp)
+                centerVerticallyTo(playIcon)
+            }
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(R.string.cd_more),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private val MediumDateFormatter by lazy {
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+}

--- a/Jetcaster/app/src/main/res/values/strings.xml
+++ b/Jetcaster/app/src/main/res/values/strings.xml
@@ -56,6 +56,10 @@
     <string name="cd_skip_next">Skip next</string>
     <string name="cd_skip_previous">Skip previous</string>
     <string name="cd_unfollow">Unfollow</string>
-  <string name="episode_added_to_your_queue">Episode added to your queue</string>
+    <string name="episode_added_to_your_queue">Episode added to your queue</string>
+    <string name="cd_podcast_image">Podcast image</string>
+    <string name="subscribe">Subscribe</string>
+    <string name="unsubscribe">Unsubscribe</string>
+  <string name="see_more">see more</string>
 
 </resources>

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCase.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCase.kt
@@ -40,8 +40,8 @@ class FilterableCategoriesUseCase(
             .map { categories ->
                 FilterableCategoriesModel(
                     categories = categories.map { it.asExternalModel() },
-                    selectedCategory = selectedCategory ?:
-                        categories.firstOrNull()?.asExternalModel()
+                    selectedCategory = selectedCategory
+                        ?: categories.firstOrNull()?.asExternalModel()
                 )
             }
 }

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCase.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCase.kt
@@ -16,8 +16,9 @@
 
 package com.example.jetcaster.core.data.domain
 
-import com.example.jetcaster.core.data.database.model.Category
+import com.example.jetcaster.core.data.model.CategoryInfo
 import com.example.jetcaster.core.data.model.FilterableCategoriesModel
+import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.core.data.repository.CategoryStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -34,12 +35,13 @@ class FilterableCategoriesUseCase(
      *        returned by the backing category list will be selected in the returned
      *        FilterableCategoriesModel
      */
-    operator fun invoke(selectedCategory: Category?): Flow<FilterableCategoriesModel> =
+    operator fun invoke(selectedCategory: CategoryInfo?): Flow<FilterableCategoriesModel> =
         categoryStore.categoriesSortedByPodcastCount()
-            .map {
+            .map { categories ->
                 FilterableCategoriesModel(
-                    categories = it,
-                    selectedCategory = selectedCategory ?: it.firstOrNull()
+                    categories = categories.map { it.asExternalModel() },
+                    selectedCategory = selectedCategory ?:
+                        categories.firstOrNull()?.asExternalModel()
                 )
             }
 }

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCase.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCase.kt
@@ -17,7 +17,10 @@
 package com.example.jetcaster.core.data.domain
 
 import com.example.jetcaster.core.data.database.model.Category
+import com.example.jetcaster.core.data.model.CategoryInfo
 import com.example.jetcaster.core.data.model.PodcastCategoryFilterResult
+import com.example.jetcaster.core.data.model.asExternalModel
+import com.example.jetcaster.core.data.model.asPodcastCategoryEpisode
 import com.example.jetcaster.core.data.repository.CategoryStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -29,7 +32,7 @@ import kotlinx.coroutines.flow.flowOf
 class PodcastCategoryFilterUseCase(
     private val categoryStore: CategoryStore
 ) {
-    operator fun invoke(category: Category?): Flow<PodcastCategoryFilterResult> {
+    operator fun invoke(category: CategoryInfo?): Flow<PodcastCategoryFilterResult> {
         if (category == null) {
             return flowOf(PodcastCategoryFilterResult())
         }
@@ -47,8 +50,8 @@ class PodcastCategoryFilterUseCase(
         // Combine our flows and collect them into the view state StateFlow
         return combine(recentPodcastsFlow, episodesFlow) { topPodcasts, episodes ->
             PodcastCategoryFilterResult(
-                topPodcasts = topPodcasts,
-                episodes = episodes
+                topPodcasts = topPodcasts.map { it.asExternalModel() },
+                episodes = episodes.map { it.asPodcastCategoryEpisode() }
             )
         }
     }

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/CategoryInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/CategoryInfo.kt
@@ -1,0 +1,14 @@
+package com.example.jetcaster.core.data.model
+
+import com.example.jetcaster.core.data.database.model.Category
+
+data class CategoryInfo(
+    val id: Long,
+    val name: String
+)
+
+fun Category.asExternalModel() =
+    CategoryInfo(
+        id = id,
+        name = name
+    )

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/CategoryInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/CategoryInfo.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.core.data.model
 
 import com.example.jetcaster.core.data.database.model.Category

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/EpisodeInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/EpisodeInfo.kt
@@ -1,0 +1,29 @@
+package com.example.jetcaster.core.data.model
+
+import com.example.jetcaster.core.data.database.model.Episode
+import java.time.Duration
+import java.time.OffsetDateTime
+
+/**
+ * External data layer representation of an episode.
+ */
+data class EpisodeInfo(
+    val uri: String = "",
+    val title: String = "",
+    val subTitle: String = "",
+    val summary: String = "",
+    val author: String = "",
+    val published: OffsetDateTime = OffsetDateTime.MIN,
+    val duration: Duration? = null,
+)
+
+fun Episode.asExternalModel(): EpisodeInfo =
+    EpisodeInfo(
+        uri = uri,
+        title = title,
+        subTitle =  subtitle ?: "",
+        summary = summary ?: "",
+        author = author ?: "",
+        published = published,
+        duration = duration,
+    )

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/EpisodeInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/EpisodeInfo.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.core.data.model
 
 import com.example.jetcaster.core.data.database.model.Episode
@@ -21,7 +37,7 @@ fun Episode.asExternalModel(): EpisodeInfo =
     EpisodeInfo(
         uri = uri,
         title = title,
-        subTitle =  subtitle ?: "",
+        subTitle = subtitle ?: "",
         summary = summary ?: "",
         author = author ?: "",
         published = published,

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/FilterableCategoriesModel.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/FilterableCategoriesModel.kt
@@ -16,14 +16,12 @@
 
 package com.example.jetcaster.core.data.model
 
-import com.example.jetcaster.core.data.database.model.Category
-
 /**
  * Model holding a list of categories and a selected category in the collection
  */
 data class FilterableCategoriesModel(
-    val categories: List<Category> = emptyList(),
-    val selectedCategory: Category? = null
+    val categories: List<CategoryInfo> = emptyList(),
+    val selectedCategory: CategoryInfo? = null
 ) {
     val isEmpty = categories.isEmpty() || selectedCategory == null
 }

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/LibraryInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/LibraryInfo.kt
@@ -1,0 +1,6 @@
+package com.example.jetcaster.core.data.model
+
+data class LibraryInfo(
+    val podcast: PodcastInfo? = null,
+    val episodes: List<EpisodeInfo> = emptyList()
+)

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/LibraryInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/LibraryInfo.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.core.data.model
 
 data class LibraryInfo(

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
@@ -19,6 +19,9 @@ package com.example.jetcaster.core.data.model
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import java.time.Duration
 
+/**
+ * Episode data with necessary information to be used within a player.
+ */
 data class PlayerEpisode(
     val title: String = "",
     val subTitle: String = "",
@@ -27,7 +30,17 @@ data class PlayerEpisode(
     val author: String = "",
     val summary: String = "",
     val podcastImageUrl: String = "",
-)
+) {
+    constructor(podcastInfo: PodcastInfo, episodeInfo: EpisodeInfo): this(
+        title = episodeInfo.title,
+        subTitle = episodeInfo.subTitle,
+        duration = episodeInfo.duration,
+        podcastName = podcastInfo.title,
+        author = episodeInfo.author,
+        summary = episodeInfo.summary,
+        podcastImageUrl = podcastInfo.imageUrl,
+    )
+}
 
 fun EpisodeToPodcast.toPlayerEpisode(): PlayerEpisode =
     PlayerEpisode(

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PlayerEpisode.kt
@@ -31,7 +31,7 @@ data class PlayerEpisode(
     val summary: String = "",
     val podcastImageUrl: String = "",
 ) {
-    constructor(podcastInfo: PodcastInfo, episodeInfo: EpisodeInfo): this(
+    constructor(podcastInfo: PodcastInfo, episodeInfo: EpisodeInfo) : this(
         title = episodeInfo.title,
         subTitle = episodeInfo.subTitle,
         duration = episodeInfo.duration,

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastCategoryFilterResult.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastCategoryFilterResult.kt
@@ -17,12 +17,22 @@
 package com.example.jetcaster.core.data.model
 
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
-import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
 
 /**
  * A model holding top podcasts and matching episodes when filtering based on a category.
  */
 data class PodcastCategoryFilterResult(
-    val topPodcasts: List<PodcastWithExtraInfo> = emptyList(),
-    val episodes: List<EpisodeToPodcast> = emptyList()
+    val topPodcasts: List<PodcastInfo> = emptyList(),
+    val episodes: List<PodcastCategoryEpisode> = emptyList()
 )
+
+data class PodcastCategoryEpisode(
+    val episode: EpisodeInfo,
+    val podcast: PodcastInfo,
+)
+
+fun EpisodeToPodcast.asPodcastCategoryEpisode(): PodcastCategoryEpisode =
+    PodcastCategoryEpisode(
+        episode = episode.asExternalModel(),
+        podcast = podcast.asExternalModel(),
+    )

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastInfo.kt
@@ -1,0 +1,23 @@
+package com.example.jetcaster.core.data.model
+
+import com.example.jetcaster.core.data.database.model.Podcast
+
+/**
+ * External data layer representation of a podcast.
+ */
+data class PodcastInfo(
+    val uri: String = "",
+    val title: String = "",
+    val author: String = "",
+    val imageUrl: String = "",
+    val description: String = "",
+)
+
+fun Podcast.asExternalModel(): PodcastInfo =
+    PodcastInfo(
+        uri = this.uri,
+        title = this.title,
+        author = this.author ?: "",
+        imageUrl = this.imageUrl ?: "",
+        description = this.description ?: ""
+    )

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastInfo.kt
@@ -17,6 +17,8 @@
 package com.example.jetcaster.core.data.model
 
 import com.example.jetcaster.core.data.database.model.Podcast
+import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
+import java.time.OffsetDateTime
 
 /**
  * External data layer representation of a podcast.
@@ -27,6 +29,8 @@ data class PodcastInfo(
     val author: String = "",
     val imageUrl: String = "",
     val description: String = "",
+    val isSubscribed: Boolean? = null,
+    val lastEpisodeDate: OffsetDateTime? = null,
 )
 
 fun Podcast.asExternalModel(): PodcastInfo =
@@ -35,5 +39,11 @@ fun Podcast.asExternalModel(): PodcastInfo =
         title = this.title,
         author = this.author ?: "",
         imageUrl = this.imageUrl ?: "",
-        description = this.description ?: ""
+        description = this.description ?: "",
+    )
+
+fun PodcastWithExtraInfo.asExternalModel(): PodcastInfo =
+    this.podcast.asExternalModel().copy(
+        isSubscribed = isFollowed,
+        lastEpisodeDate = lastEpisodeDate,
     )

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastInfo.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/model/PodcastInfo.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.core.data.model
 
 import com.example.jetcaster.core.data.database.model.Podcast

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/repository/PodcastStore.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/repository/PodcastStore.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 interface PodcastStore {
     /**
      * Return a flow containing the [Podcast] with the given [uri].
-    */
+     */
     fun podcastWithUri(uri: String): Flow<Podcast>
 
     /**

--- a/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/repository/PodcastStore.kt
+++ b/Jetcaster/core/src/main/java/com/example/jetcaster/core/data/repository/PodcastStore.kt
@@ -28,8 +28,13 @@ import kotlinx.coroutines.flow.Flow
 interface PodcastStore {
     /**
      * Return a flow containing the [Podcast] with the given [uri].
-     */
+    */
     fun podcastWithUri(uri: String): Flow<Podcast>
+
+    /**
+     * Return a flow containing the [PodcastWithExtraInfo] with the given [podcastUri].
+     */
+    fun podcastWithExtraInfo(podcastUri: String): Flow<PodcastWithExtraInfo>
 
     /**
      * Returns a flow containing the entire collection of podcasts, sorted by the last episode
@@ -69,6 +74,8 @@ interface PodcastStore {
 
     suspend fun togglePodcastFollowed(podcastUri: String)
 
+    suspend fun followPodcast(podcastUri: String)
+
     suspend fun unfollowPodcast(podcastUri: String)
 
     /**
@@ -95,6 +102,12 @@ class LocalPodcastStore(
     override fun podcastWithUri(uri: String): Flow<Podcast> {
         return podcastDao.podcastWithUri(uri)
     }
+
+    /**
+     * Return a flow containing the [PodcastWithExtraInfo] with the given [podcastUri].
+     */
+    override fun podcastWithExtraInfo(podcastUri: String): Flow<PodcastWithExtraInfo> =
+        podcastDao.podcastWithExtraInfo(podcastUri)
 
     /**
      * Returns a flow containing the entire collection of podcasts, sorted by the last episode
@@ -132,7 +145,7 @@ class LocalPodcastStore(
         return podcastDao.searchPodcastByTitleAndCategory(keyword, categoryIdList, limit)
     }
 
-    private suspend fun followPodcast(podcastUri: String) {
+    override suspend fun followPodcast(podcastUri: String) {
         podcastFollowedEntryDao.insert(PodcastFollowedEntry(podcastUri = podcastUri))
     }
 

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCaseTest.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCaseTest.kt
@@ -58,7 +58,7 @@ class FilterableCategoriesUseCaseTest {
         val selectedCategory = testCategories[2]
         val filterableCategories = useCase(selectedCategory.asExternalModel()).first()
         assertEquals(
-            selectedCategory,
+            selectedCategory.asExternalModel(),
             filterableCategories.selectedCategory
         )
     }

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCaseTest.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/FilterableCategoriesUseCaseTest.kt
@@ -17,6 +17,7 @@
 package com.example.jetcaster.core.data.domain
 
 import com.example.jetcaster.core.data.database.model.Category
+import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.core.data.repository.TestCategoryStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -55,7 +56,7 @@ class FilterableCategoriesUseCaseTest {
     @Test
     fun whenSelectedCategory_correctFilterableCategoryIsSelected() = runTest {
         val selectedCategory = testCategories[2]
-        val filterableCategories = useCase(selectedCategory).first()
+        val filterableCategories = useCase(selectedCategory.asExternalModel()).first()
         assertEquals(
             selectedCategory,
             filterableCategories.selectedCategory

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
@@ -21,13 +21,14 @@ import com.example.jetcaster.core.data.database.model.Episode
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
+import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.core.data.repository.TestCategoryStore
-import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.OffsetDateTime
 
 class PodcastCategoryFilterUseCaseTest {
 
@@ -78,7 +79,7 @@ class PodcastCategoryFilterUseCaseTest {
 
     @Test
     fun whenCategoryNotNull_validFlow() = runTest {
-        val resultFlow = useCase(testCategory)
+        val resultFlow = useCase(testCategory.asExternalModel())
 
         categoriesStore.setEpisodesFromPodcast(testCategory.id, testEpisodeToPodcast)
         categoriesStore.setPodcastsInCategory(testCategory.id, testPodcasts)

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
@@ -23,12 +23,12 @@ import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
 import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.core.data.repository.TestCategoryStore
+import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.time.OffsetDateTime
 
 class PodcastCategoryFilterUseCaseTest {
 

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
@@ -24,12 +24,12 @@ import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
 import com.example.jetcaster.core.data.model.asExternalModel
 import com.example.jetcaster.core.data.model.asPodcastCategoryEpisode
 import com.example.jetcaster.core.data.repository.TestCategoryStore
+import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.time.OffsetDateTime
 
 class PodcastCategoryFilterUseCaseTest {
 

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
@@ -22,13 +22,14 @@ import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
 import com.example.jetcaster.core.data.model.asExternalModel
+import com.example.jetcaster.core.data.model.asPodcastCategoryEpisode
 import com.example.jetcaster.core.data.repository.TestCategoryStore
-import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.OffsetDateTime
 
 class PodcastCategoryFilterUseCaseTest {
 
@@ -41,13 +42,11 @@ class PodcastCategoryFilterUseCaseTest {
                 "Episode 1",
                 published = OffsetDateTime.now()
             )
-        },
-        EpisodeToPodcast().apply {
-            episode = Episode(
-                "",
-                "",
-                "Episode 2",
-                published = OffsetDateTime.now()
+            _podcasts = listOf(
+                Podcast(
+                    uri = "",
+                    title = "Podcast 1"
+                )
             )
         },
         EpisodeToPodcast().apply {
@@ -56,6 +55,26 @@ class PodcastCategoryFilterUseCaseTest {
                 "",
                 "Episode 2",
                 published = OffsetDateTime.now()
+            )
+            _podcasts = listOf(
+                Podcast(
+                    uri = "",
+                    title = "Podcast 2"
+                )
+            )
+        },
+        EpisodeToPodcast().apply {
+            episode = Episode(
+                "",
+                "",
+                "Episode 3",
+                published = OffsetDateTime.now()
+            )
+            _podcasts = listOf(
+                Podcast(
+                    uri = "",
+                    title = "Podcast 3"
+                )
             )
         }
     )
@@ -86,11 +105,11 @@ class PodcastCategoryFilterUseCaseTest {
 
         val result = resultFlow.first()
         assertEquals(
-            testPodcasts,
+            testPodcasts.map { it.asExternalModel() },
             result.topPodcasts
         )
         assertEquals(
-            testEpisodeToPodcast,
+            testEpisodeToPodcast.map { it.asPodcastCategoryEpisode() },
             result.episodes
         )
     }

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/repository/TestPodcastStore.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/repository/TestPodcastStore.kt
@@ -34,6 +34,14 @@ class TestPodcastStore : PodcastStore {
             podcasts.first { it.uri == uri }
         }
 
+    override fun podcastWithExtraInfo(podcastUri: String): Flow<PodcastWithExtraInfo> =
+        podcastFlow.map { podcasts ->
+            val podcast = podcasts.first { it.uri == podcastUri }
+            PodcastWithExtraInfo().apply {
+                this.podcast = podcast
+            }
+        }
+
     override fun podcastsSortedByLastEpisode(limit: Int): Flow<List<PodcastWithExtraInfo>> =
         podcastFlow.map { podcasts ->
             podcasts.map { p ->
@@ -89,10 +97,14 @@ class TestPodcastStore : PodcastStore {
 
     override suspend fun togglePodcastFollowed(podcastUri: String) {
         if (podcastUri in followedPodcasts) {
-            followedPodcasts.remove(podcastUri)
+            unfollowPodcast(podcastUri)
         } else {
-            followedPodcasts.add(podcastUri)
+            followPodcast(podcastUri)
         }
+    }
+
+    override suspend fun followPodcast(podcastUri: String) {
+        followedPodcasts.add(podcastUri)
     }
 
     override suspend fun unfollowPodcast(podcastUri: String) {

--- a/Jetcaster/designsystem/src/main/java/com/example/jetcaster/designsystem/theme/Keylines.kt
+++ b/Jetcaster/designsystem/src/main/java/com/example/jetcaster/designsystem/theme/Keylines.kt
@@ -18,4 +18,4 @@ package com.example.jetcaster.designsystem.theme
 
 import androidx.compose.ui.unit.dp
 
-val Keyline1 = 24.dp
+val Keyline1 = 16.dp

--- a/Jetcaster/designsystem/src/main/java/com/example/jetcaster/designsystem/theme/Shape.kt
+++ b/Jetcaster/designsystem/src/main/java/com/example/jetcaster/designsystem/theme/Shape.kt
@@ -23,5 +23,5 @@ import androidx.compose.ui.unit.dp
 val JetcasterShapes = Shapes(
     small = RoundedCornerShape(percent = 50),
     medium = RoundedCornerShape(size = 8.dp),
-    large = RoundedCornerShape(size = 0.dp)
+    large = RoundedCornerShape(size = 16.dp)
 )


### PR DESCRIPTION
Changes:
* Added podcast details screen. 
* Added external models `PodcastInfo`, `EpisodeInfo` and `CategoryInfo` so that composables don't depend on database entities (`Podcast`, `Episode` and `Category) directly.

Note that design is not final yet but will address that in another PR.

<img width="407" alt="image" src="https://github.com/android/compose-samples/assets/463186/e13e811e-5c30-4eea-bd11-50c8152674e0">


