### PR TITLE
[Jetcaster] Adding SupportingPaneScaffold to Home

### DIFF
--- a/Jetcaster/app/build.gradle.kts
+++ b/Jetcaster/app/build.gradle.kts
@@ -101,6 +101,9 @@ dependencies {
 
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material3.adaptive)
+    implementation(libs.androidx.compose.material3.adaptive.layout)
+    implementation(libs.androidx.compose.material3.adaptive.navigation)
     implementation(libs.androidx.compose.material3.window)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/Jetcaster/app/build.gradle.kts
+++ b/Jetcaster/app/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout.compose)
 
     implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material3.adaptive)
     implementation(libs.androidx.compose.material3.adaptive.layout)

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/JetcasterApp.kt
@@ -56,9 +56,6 @@ fun JetcasterApp(
         ) {
             composable(Screen.Home.route) { backStackEntry ->
                 Home(
-                    navigateToPodcastDetails = { podcast ->
-                        appState.navigateToPodcastDetails(podcast.uri, backStackEntry)
-                    },
                     navigateToPlayer = { episode ->
                         appState.navigateToPlayer(episode.uri, backStackEntry)
                     }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -103,17 +103,16 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import java.time.Duration
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun Home(
-    navigateToPodcastDetails: (PodcastInfo) -> Unit,
     navigateToPlayer: (EpisodeInfo) -> Unit,
     viewModel: HomeViewModel = viewModel()
 ) {

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -103,12 +103,12 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
@@ -128,8 +128,8 @@ fun Home(
         value = navigator.scaffoldValue,
         directive = navigator.scaffoldDirective,
         supportingPane = {
-            val podcastUri = navigator.currentDestination?.content ?:
-                viewState.featuredPodcasts.firstOrNull()?.uri
+            val podcastUri = navigator.currentDestination?.content
+                ?: viewState.featuredPodcasts.firstOrNull()?.uri
             AnimatedPane {
                 if (podcastUri.isNullOrEmpty()) {
                     // TODO

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -104,12 +104,12 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -57,6 +57,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabPosition
 import androidx.compose.material3.TabRow
@@ -103,12 +104,12 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import java.time.Duration
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
@@ -124,54 +125,56 @@ fun Home(
     BackHandler(enabled = navigator.canNavigateBack()) {
         navigator.navigateBack()
     }
-    SupportingPaneScaffold(
-        value = navigator.scaffoldValue,
-        directive = navigator.scaffoldDirective,
-        supportingPane = {
-            val podcastUri = navigator.currentDestination?.content
-                ?: viewState.featuredPodcasts.firstOrNull()?.uri
-            AnimatedPane {
-                if (podcastUri.isNullOrEmpty()) {
-                    // TODO
-                    Text(text = "Empty State")
-                } else {
-                    val podcastDetailsViewModel = PodcastDetailsViewModel(podcastUri = podcastUri)
-                    PodcastDetailsScreen(
-                        viewModel = podcastDetailsViewModel,
-                        navigateToPlayer = navigateToPlayer,
-                        navigateBack = {
-                            if (navigator.canNavigateBack()) {
-                                navigator.navigateBack()
+    Surface {
+        SupportingPaneScaffold(
+            value = navigator.scaffoldValue,
+            directive = navigator.scaffoldDirective,
+            supportingPane = {
+                val podcastUri = navigator.currentDestination?.content
+                    ?: viewState.featuredPodcasts.firstOrNull()?.uri
+                AnimatedPane {
+                    if (podcastUri.isNullOrEmpty()) {
+                        // TODO
+                        Text(text = "Empty State")
+                    } else {
+                        val podcastDetailsViewModel = PodcastDetailsViewModel(podcastUri = podcastUri)
+                        PodcastDetailsScreen(
+                            viewModel = podcastDetailsViewModel,
+                            navigateToPlayer = navigateToPlayer,
+                            navigateBack = {
+                                if (navigator.canNavigateBack()) {
+                                    navigator.navigateBack()
+                                }
                             }
-                        }
-                    )
+                        )
+                    }
                 }
-            }
-        },
-        mainPane = {
-            Home(
-                featuredPodcasts = viewState.featuredPodcasts,
-                isRefreshing = viewState.refreshing,
-                homeCategories = viewState.homeCategories,
-                selectedHomeCategory = viewState.selectedHomeCategory,
-                filterableCategoriesModel = viewState.filterableCategoriesModel,
-                podcastCategoryFilterResult = viewState.podcastCategoryFilterResult,
-                library = viewState.library,
-                onHomeCategorySelected = viewModel::onHomeCategorySelected,
-                onCategorySelected = viewModel::onCategorySelected,
-                onPodcastUnfollowed = viewModel::onPodcastUnfollowed,
-                navigateToPodcastDetails = {
-                    navigator.navigateTo(SupportingPaneScaffoldRole.Supporting, it.uri)
-                },
-                navigateToPlayer = navigateToPlayer,
-                onTogglePodcastFollowed = viewModel::onTogglePodcastFollowed,
-                onLibraryPodcastSelected = viewModel::onLibraryPodcastSelected,
-                onQueueEpisode = viewModel::onQueueEpisode,
-                modifier = Modifier.fillMaxSize()
-            )
-        },
-        modifier = Modifier.fillMaxSize()
-    )
+            },
+            mainPane = {
+                Home(
+                    featuredPodcasts = viewState.featuredPodcasts,
+                    isRefreshing = viewState.refreshing,
+                    homeCategories = viewState.homeCategories,
+                    selectedHomeCategory = viewState.selectedHomeCategory,
+                    filterableCategoriesModel = viewState.filterableCategoriesModel,
+                    podcastCategoryFilterResult = viewState.podcastCategoryFilterResult,
+                    library = viewState.library,
+                    onHomeCategorySelected = viewModel::onHomeCategorySelected,
+                    onCategorySelected = viewModel::onCategorySelected,
+                    onPodcastUnfollowed = viewModel::onPodcastUnfollowed,
+                    navigateToPodcastDetails = {
+                        navigator.navigateTo(SupportingPaneScaffoldRole.Supporting, it.uri)
+                    },
+                    navigateToPlayer = navigateToPlayer,
+                    onTogglePodcastFollowed = viewModel::onTogglePodcastFollowed,
+                    onLibraryPodcastSelected = viewModel::onLibraryPodcastSelected,
+                    onQueueEpisode = viewModel::onQueueEpisode,
+                    modifier = Modifier.fillMaxSize()
+                )
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -133,7 +133,7 @@ fun Home(
             AnimatedPane {
                 if (podcastUri.isNullOrEmpty()) {
                     // TODO
-                    Text(text = "")
+                    Text(text = "Empty State")
                 } else {
                     val podcastDetailsViewModel = PodcastDetailsViewModel(podcastUri = podcastUri)
                     PodcastDetailsScreen(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -133,11 +133,10 @@ fun Home(
                 val podcastUri = navigator.currentDestination?.content
                     ?: viewState.featuredPodcasts.firstOrNull()?.uri
                 AnimatedPane {
-                    if (podcastUri.isNullOrEmpty()) {
-                        // TODO
-                        Text(text = "Empty State")
-                    } else {
-                        val podcastDetailsViewModel = PodcastDetailsViewModel(podcastUri = podcastUri)
+                    if (!podcastUri.isNullOrEmpty()) {
+                        val podcastDetailsViewModel = PodcastDetailsViewModel(
+                            podcastUri = podcastUri
+                        )
                         PodcastDetailsScreen(
                             viewModel = podcastDetailsViewModel,
                             navigateToPlayer = navigateToPlayer,

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -65,7 +65,6 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.SupportingPaneScaffold
 import androidx.compose.material3.adaptive.layout.SupportingPaneScaffoldRole
 import androidx.compose.material3.adaptive.navigation.rememberSupportingPaneScaffoldNavigator
@@ -132,21 +131,19 @@ fun Home(
             supportingPane = {
                 val podcastUri = navigator.currentDestination?.content
                     ?: viewState.featuredPodcasts.firstOrNull()?.uri
-                AnimatedPane {
-                    if (!podcastUri.isNullOrEmpty()) {
-                        val podcastDetailsViewModel = PodcastDetailsViewModel(
-                            podcastUri = podcastUri
-                        )
-                        PodcastDetailsScreen(
-                            viewModel = podcastDetailsViewModel,
-                            navigateToPlayer = navigateToPlayer,
-                            navigateBack = {
-                                if (navigator.canNavigateBack()) {
-                                    navigator.navigateBack()
-                                }
+                if (!podcastUri.isNullOrEmpty()) {
+                    val podcastDetailsViewModel = PodcastDetailsViewModel(
+                        podcastUri = podcastUri
+                    )
+                    PodcastDetailsScreen(
+                        viewModel = podcastDetailsViewModel,
+                        navigateToPlayer = navigateToPlayer,
+                        navigateBack = {
+                            if (navigator.canNavigateBack()) {
+                                navigator.navigateBack()
                             }
-                        )
-                    }
+                        }
+                    )
                 }
             },
             mainPane = {

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -103,12 +103,12 @@ import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.util.ToggleFollowPodcastIconButton
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.verticalGradientScrim
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/home/library/Library.kt
@@ -63,7 +63,6 @@ fun LazyListScope.libraryItems(
             onClick = navigateToPlayer,
             onQueueEpisode = onQueueEpisode,
             modifier = Modifier.fillParentMaxWidth(),
-            showDivider = index != 0
         )
     }
 }

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -69,6 +69,7 @@ import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.home.PreviewEpisodes
 import com.example.jetcaster.ui.home.PreviewPodcasts
 import com.example.jetcaster.ui.shared.EpisodeListItem
+import com.example.jetcaster.ui.shared.Loading
 import kotlinx.coroutines.launch
 
 @Composable
@@ -79,15 +80,31 @@ fun PodcastDetailsScreen(
     modifier: Modifier = Modifier
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    PodcastDetailsScreen(
-        podcast = state.podcast,
-        episodes = state.episodes,
-        toggleSubscribe = viewModel::toggleSusbcribe,
-        onQueueEpisode = viewModel::onQueueEpisode,
-        navigateToPlayer = navigateToPlayer,
-        navigateBack = navigateBack,
-        modifier = modifier,
-    )
+    when (val s = state) {
+        is PodcastUiState.Loading -> {
+            PodcastDetailsLoadingScreen(
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+        is PodcastUiState.Ready -> {
+            PodcastDetailsScreen(
+                podcast = s.podcast,
+                episodes = s.episodes,
+                toggleSubscribe = viewModel::toggleSusbcribe,
+                onQueueEpisode = viewModel::onQueueEpisode,
+                navigateToPlayer = navigateToPlayer,
+                navigateBack = navigateBack,
+                modifier = modifier,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PodcastDetailsLoadingScreen(
+    modifier: Modifier = Modifier
+) {
+    Loading(modifier = modifier)
 }
 
 @Composable

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
@@ -50,11 +50,20 @@ class PodcastDetailsViewModel(
     private val episodeStore: EpisodeStore = Graph.episodeStore,
     private val episodePlayer: EpisodePlayer = Graph.episodePlayer,
     private val podcastStore: PodcastStore = Graph.podcastStore,
-    savedStateHandle: SavedStateHandle
+    private val podcastUri: String
 ) : ViewModel() {
 
-    private val podcastUri: String =
-        Uri.decode(savedStateHandle.get<String>(Screen.ARG_PODCAST_URI)!!)
+    constructor(
+        episodeStore: EpisodeStore = Graph.episodeStore,
+        episodePlayer: EpisodePlayer = Graph.episodePlayer,
+        podcastStore: PodcastStore = Graph.podcastStore,
+        savedStateHandle: SavedStateHandle
+    ) : this(
+        episodeStore = episodeStore,
+        episodePlayer = episodePlayer,
+        podcastStore = podcastStore,
+        podcastUri = Uri.decode(savedStateHandle.get<String>(Screen.ARG_PODCAST_URI)!!)
+    )
 
     val state: StateFlow<PodcastUiState> =
         combine(

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsViewModel.kt
@@ -38,10 +38,13 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-data class PodcastUiState(
-    val podcast: PodcastInfo = PodcastInfo(),
-    val episodes: List<EpisodeInfo> = emptyList()
-)
+sealed interface PodcastUiState {
+    data object Loading : PodcastUiState
+    data class Ready(
+        val podcast: PodcastInfo,
+        val episodes: List<EpisodeInfo>,
+    ) : PodcastUiState
+}
 
 /**
  * ViewModel that handles the business logic and screen state of the Podcast details screen.
@@ -71,14 +74,14 @@ class PodcastDetailsViewModel(
             episodeStore.episodesInPodcast(podcastUri)
         ) { podcast, episodeToPodcasts ->
             val episodes = episodeToPodcasts.map { it.episode.asExternalModel() }
-            PodcastUiState(
+            PodcastUiState.Ready(
                 podcast = podcast.podcast.asExternalModel().copy(isSubscribed = podcast.isFollowed),
                 episodes = episodes,
             )
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = PodcastUiState()
+            initialValue = PodcastUiState.Loading
         )
 
     fun toggleSusbcribe(podcast: PodcastInfo) {

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -16,44 +16,51 @@
 
 package com.example.jetcaster.ui.shared
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.rounded.PlayCircleFilled
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
-import androidx.constraintlayout.compose.Visibility
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.jetcaster.R
 import com.example.jetcaster.core.data.model.EpisodeInfo
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.data.model.PodcastInfo
-import com.example.jetcaster.designsystem.theme.Keyline1
+import com.example.jetcaster.ui.home.PreviewEpisodes
+import com.example.jetcaster.ui.home.PreviewPodcasts
+import com.example.jetcaster.ui.theme.JetcasterTheme
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -64,87 +71,50 @@ fun EpisodeListItem(
     onClick: (EpisodeInfo) -> Unit,
     onQueueEpisode: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
-    showDivider: Boolean = true,
     showPodcastImage: Boolean = true,
 ) {
-    ConstraintLayout(
-        modifier = modifier.clickable {
-            onClick(episode)
+    Box(modifier = modifier.padding(vertical = 8.dp, horizontal = 16.dp)) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surfaceContainer
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .clickable {
+                        onClick(episode)
+                    },
+            ) {
+                // Top Part
+                EpisodeListItemHeader(
+                    episode = episode,
+                    podcast = podcast,
+                    showPodcastImage = showPodcastImage,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
+
+                // Bottom Part
+                EpisodeListItemFooter(
+                    episode = episode,
+                    podcast = podcast,
+                    onQueueEpisode = onQueueEpisode,
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun EpisodeListItemFooter(
+    episode: EpisodeInfo,
+    podcast: PodcastInfo,
+    onQueueEpisode: (PlayerEpisode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
     ) {
-        val (
-            divider, episodeTitle, podcastTitle, image, playIcon,
-            date, addPlaylist, overflow
-        ) = createRefs()
-
-        if (showDivider) {
-            HorizontalDivider(
-                Modifier.constrainAs(divider) {
-                    top.linkTo(parent.top)
-                    centerHorizontallyTo(parent)
-                    width = Dimension.fillToConstraints
-                }
-            )
-        }
-
-        // If we have an image Url, we can show it using Coil
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(podcast.imageUrl)
-                .crossfade(true)
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(56.dp)
-                .clip(MaterialTheme.shapes.medium)
-                .constrainAs(image) {
-                    end.linkTo(parent.end, 16.dp)
-                    top.linkTo(parent.top, 16.dp)
-                    visibility = if (showPodcastImage) Visibility.Visible else Visibility.Gone
-                },
-        )
-
-        Text(
-            text = episode.title,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.constrainAs(episodeTitle) {
-                linkTo(
-                    start = parent.start,
-                    end = image.start,
-                    startMargin = Keyline1,
-                    endMargin = 16.dp,
-                    bias = 0f
-                )
-                top.linkTo(parent.top, 16.dp)
-                height = Dimension.preferredWrapContent
-                width = Dimension.preferredWrapContent
-            }
-        )
-
-        val titleImageBarrier = createBottomBarrier(podcastTitle, image)
-
-        Text(
-            text = podcast.title,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.titleSmall,
-            modifier = Modifier.constrainAs(podcastTitle) {
-                linkTo(
-                    start = parent.start,
-                    end = image.start,
-                    startMargin = Keyline1,
-                    endMargin = 16.dp,
-                    bias = 0f
-                )
-                top.linkTo(episodeTitle.bottom, 6.dp)
-                height = Dimension.preferredWrapContent
-                width = Dimension.preferredWrapContent
-            }
-        )
-
         Image(
             imageVector = Icons.Rounded.PlayCircleFilled,
             contentDescription = stringResource(R.string.cd_play),
@@ -158,11 +128,6 @@ fun EpisodeListItem(
                 .size(48.dp)
                 .padding(6.dp)
                 .semantics { role = Role.Button }
-                .constrainAs(playIcon) {
-                    start.linkTo(parent.start, Keyline1)
-                    top.linkTo(titleImageBarrier, margin = 10.dp)
-                    bottom.linkTo(parent.bottom, 10.dp)
-                }
         )
 
         val duration = episode.duration
@@ -183,17 +148,9 @@ fun EpisodeListItem(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.constrainAs(date) {
-                centerVerticallyTo(playIcon)
-                linkTo(
-                    start = playIcon.end,
-                    startMargin = 12.dp,
-                    end = addPlaylist.start,
-                    endMargin = 16.dp,
-                    bias = 0f // float this towards the start
-                )
-                width = Dimension.preferredWrapContent
-            }
+            modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .weight(1f)
         )
 
         IconButton(
@@ -205,10 +162,6 @@ fun EpisodeListItem(
                     )
                 )
             },
-            modifier = Modifier.constrainAs(addPlaylist) {
-                end.linkTo(overflow.start)
-                centerVerticallyTo(playIcon)
-            }
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
@@ -219,10 +172,6 @@ fun EpisodeListItem(
 
         IconButton(
             onClick = { /* TODO */ },
-            modifier = Modifier.constrainAs(overflow) {
-                end.linkTo(parent.end, 8.dp)
-                centerVerticallyTo(playIcon)
-            }
         ) {
             Icon(
                 imageVector = Icons.Default.MoreVert,
@@ -230,6 +179,88 @@ fun EpisodeListItem(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+    }
+}
+
+@Composable
+fun EpisodeListItemHeader(
+    episode: EpisodeInfo,
+    podcast: PodcastInfo,
+    showPodcastImage: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier) {
+        Column(
+            modifier =
+            Modifier
+                .weight(1f)
+                .padding(end = 16.dp)
+        ) {
+            Text(
+                text = episode.title,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(vertical = 6.dp)
+            )
+
+            Text(
+                text = podcast.title,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleSmall,
+            )
+        }
+        if (showPodcastImage) {
+            EpisodeListItemImage(
+                podcast = podcast,
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(MaterialTheme.shapes.medium)
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodeListItemImage(
+    podcast: PodcastInfo,
+    modifier: Modifier = Modifier
+) {
+    if (LocalInspectionMode.current) {
+        Box(modifier = modifier.background(MaterialTheme.colorScheme.primary))
+    } else {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(podcast.imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = modifier
+        )
+    }
+}
+
+@Preview(
+    name = "Light Mode",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+@Preview(
+    name = "Dark Mode",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun EpisodeListItemPreview() {
+    JetcasterTheme {
+        EpisodeListItem(
+            episode = PreviewEpisodes[0],
+            podcast = PreviewPodcasts[0],
+            onClick = {},
+            onQueueEpisode = {}
+        )
     }
 }
 

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -25,12 +25,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.rounded.PlayCircleFilled
-import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -153,7 +153,7 @@ fun EpisodeListItem(
             modifier = Modifier
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
-                    indication = rememberRipple(bounded = false, radius = 24.dp)
+                    indication = ripple(bounded = false, radius = 24.dp)
                 ) { /* TODO */ }
                 .size(48.dp)
                 .padding(6.dp)

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/Loading.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/Loading.kt
@@ -1,0 +1,22 @@
+package com.example.jetcaster.ui.shared
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Loading(modifier: Modifier = Modifier) {
+    Surface(modifier = modifier) {
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            CircularProgressIndicator(
+                Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}

--- a/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/Loading.kt
+++ b/Jetcaster/app/src/main/java/com/example/jetcaster/ui/shared/Loading.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.jetcaster.ui.shared
 
 import androidx.compose.foundation.layout.Box

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.2.3"
 androidx-benchmark-junit4 = "1.2.3"
 androidx-compose-bom = "2024.03.00"
+androidx-compose-latest = "1.7.0-alpha05"
 androidx-compose-material3-adaptive = "1.0.0-alpha09"
 androidx-compose-material3-latest = "1.3.0-alpha03"
 androidx-constraintlayout = "1.0.1"
@@ -85,7 +86,6 @@ androidx-compose-animation = { module = "androidx.compose.animation:animation" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
-androidx-compose-material = { module = "androidx.compose.material:material" }
 androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3-latest" }
 androidx-compose-material3-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive", version.ref = "androidx-compose-material3-adaptive" }
@@ -94,7 +94,7 @@ androidx-compose-material3-adaptive-navigation = { group = "androidx.compose.mat
 androidx-compose-material3-window = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
-androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-latest" }
 androidx-compose-ui-googlefonts = { module = "androidx.compose.ui:ui-text-google-fonts" }
 androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test" }

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.2.3"
 androidx-benchmark-junit4 = "1.2.3"
 androidx-compose-bom = "2024.03.00"
+androidx-compose-material3-adaptive = "1.0.0-alpha09"
+androidx-compose-material3-latest = "1.3.0-alpha03"
 androidx-constraintlayout = "1.0.1"
 androidx-corektx = "1.13.0-beta01"
 androidx-glance = "1.0.0"
@@ -85,7 +87,10 @@ androidx-compose-foundation = { module = "androidx.compose.foundation:foundation
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
 androidx-compose-material = { module = "androidx.compose.material:material" }
 androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended" }
-androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3-latest" }
+androidx-compose-material3-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive", version.ref = "androidx-compose-material3-adaptive" }
+androidx-compose-material3-adaptive-layout = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout", version.ref = "androidx-compose-material3-adaptive" }
+androidx-compose-material3-adaptive-navigation = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation", version.ref = "androidx-compose-material3-adaptive" }
 androidx-compose-material3-window = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }


### PR DESCRIPTION
Adding `SupportingPaneScaffold` to the home screen of Jetcaster.

Remaining TODOs:
- [ ] Make expanded-width default to having the supporting pane be hidden
- [ ] Hide top app bar in supporting pane when 2 panes are shown


[Screen_recording_20240329_162553.webm](https://github.com/android/compose-samples/assets/463186/a5b185d3-de84-4962-a01f-d4976021dcfa)

