### PR TITLE
TV app: update action of the episode selection to navigate the player screen 

### DIFF
--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/model/EpisodeList.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/model/EpisodeList.kt
@@ -17,12 +17,7 @@
 package com.example.jetcaster.tv.model
 
 import androidx.compose.runtime.Immutable
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.model.PlayerEpisode
 
 @Immutable
-data class EpisodeList(val member: List<EpisodeToPodcast>) : List<EpisodeToPodcast> by member
-
-// ToDo: merge into EpisodeList as PlayerEpisode is the exposed data structure of EpisodeToPodcast
-@Immutable
-data class PlayerEpisodeList(val member: List<PlayerEpisode>) : List<PlayerEpisode> by member
+data class EpisodeList(val member: List<PlayerEpisode>) : List<PlayerEpisode> by member

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
@@ -122,8 +122,8 @@ private fun Route(jetcasterAppState: JetcasterAppState) {
                     showPodcastDetails = {
                         jetcasterAppState.showPodcastDetails(it.uri)
                     },
-                    showEpisodeDetails = {
-                        jetcasterAppState.showEpisodeDetails(it.episode.uri)
+                    playEpisode = {
+                        jetcasterAppState.playEpisode()
                     },
                     modifier = Modifier
                         .padding(JetcasterAppDefaults.overScanMargin.default.intoPaddingValues())
@@ -139,8 +139,8 @@ private fun Route(jetcasterAppState: JetcasterAppState) {
                     showPodcastDetails = {
                         jetcasterAppState.showPodcastDetails(it.podcast.uri)
                     },
-                    showEpisodeDetails = {
-                        jetcasterAppState.showEpisodeDetails(it.episode.uri)
+                    playEpisode = {
+                        jetcasterAppState.playEpisode()
                     },
                     modifier = Modifier
                         .padding(JetcasterAppDefaults.overScanMargin.default.intoPaddingValues())
@@ -164,8 +164,9 @@ private fun Route(jetcasterAppState: JetcasterAppState) {
             PodcastScreen(
                 backToHomeScreen = jetcasterAppState::navigateToDiscover,
                 playEpisode = {
+                    jetcasterAppState.playEpisode()
                 },
-                showEpisodeDetails = { jetcasterAppState.showEpisodeDetails(it.episode.uri) },
+                showEpisodeDetails = { jetcasterAppState.showEpisodeDetails(it.uri) },
                 modifier = Modifier
                     .padding(JetcasterAppDefaults.overScanMargin.podcast.intoPaddingValues())
                     .fillMaxSize(),

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/JetcasterAppState.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/JetcasterAppState.kt
@@ -70,10 +70,6 @@ class JetcasterAppState(
         navHostController.popBackStack()
         navigateToDiscover()
     }
-
-    fun navigateBack() {
-        navHostController.popBackStack()
-    }
 }
 
 @Composable

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/component/Button.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/component/Button.kt
@@ -16,8 +16,6 @@
 
 package com.example.jetcaster.tv.ui.component
 
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.Forward10
@@ -30,27 +28,27 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.ButtonScale
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.IconButton
-import androidx.tv.material3.Text
 import com.example.jetcaster.tv.R
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 internal fun PlayButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    scale: ButtonScale = ButtonDefaults.scale(),
 ) =
     ButtonWithIcon(
         icon = Icons.Outlined.PlayArrow,
         label = stringResource(R.string.label_play),
         onClick = onClick,
-        modifier = modifier
+        modifier = modifier,
+        scale = scale
     )
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -80,25 +78,6 @@ internal fun InfoButton(
         )
     }
 }
-
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-internal fun ButtonWithIcon(
-    icon: ImageVector,
-    label: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) =
-    Button(onClick = onClick, modifier = modifier) {
-        Icon(
-            icon,
-            contentDescription = null,
-            modifier = Modifier
-                .width(ButtonDefaults.IconSize)
-                .padding(end = ButtonDefaults.IconSpacing)
-        )
-        Text(text = label)
-    }
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
@@ -40,9 +40,9 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.StandardCardLayout
 import androidx.tv.material3.Text
 import coil.compose.AsyncImage
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.tv.R
 import com.example.jetcaster.tv.model.EpisodeList
 import com.example.jetcaster.tv.model.PodcastList
@@ -53,7 +53,7 @@ internal fun Catalog(
     podcastList: PodcastList,
     latestEpisodeList: EpisodeList,
     onPodcastSelected: (PodcastWithExtraInfo) -> Unit,
-    onEpisodeSelected: (EpisodeToPodcast) -> Unit,
+    onEpisodeSelected: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
     state: TvLazyListState = rememberTvLazyListState(),
     header: (@Composable () -> Unit)? = null,
@@ -109,7 +109,7 @@ private fun PodcastSection(
 @Composable
 private fun LatestEpisodeSection(
     episodeList: EpisodeList,
-    onEpisodeSelected: (EpisodeToPodcast) -> Unit,
+    onEpisodeSelected: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null
 ) {
@@ -118,8 +118,8 @@ private fun LatestEpisodeSection(
         title = title
     ) {
         EpisodeRow(
-            episodeList = episodeList,
-            onEpisodeSelected = onEpisodeSelected,
+            playerEpisodeList = episodeList,
+            onSelected = onEpisodeSelected,
             modifier = Modifier.focusRestorer()
         )
     }
@@ -191,28 +191,4 @@ internal fun PodcastCard(
         },
         modifier = modifier,
     )
-}
-
-@Composable
-private fun EpisodeRow(
-    episodeList: EpisodeList,
-    onEpisodeSelected: (EpisodeToPodcast) -> Unit,
-    modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(),
-    horizontalArrangement: Arrangement.Horizontal =
-        Arrangement.spacedBy(JetcasterAppDefaults.gap.episodeRow),
-) {
-    TvLazyRow(
-        contentPadding = contentPadding,
-        horizontalArrangement = horizontalArrangement,
-        modifier = modifier,
-    ) {
-        items(episodeList) {
-            EpisodeCard(
-                episode = it,
-                onClick = { onEpisodeSelected(it) },
-                cardWidth = JetcasterAppDefaults.cardWidth.small
-            )
-        }
-    }
 }

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/component/EpisodeRow.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/component/EpisodeRow.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetcaster.tv.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.tv.foundation.lazy.list.TvLazyRow
+import androidx.tv.foundation.lazy.list.itemsIndexed
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.tv.model.EpisodeList
+import com.example.jetcaster.tv.ui.theme.JetcasterAppDefaults
+
+@Composable
+internal fun EpisodeRow(
+    playerEpisodeList: EpisodeList,
+    onSelected: (PlayerEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal =
+        Arrangement.spacedBy(JetcasterAppDefaults.gap.item),
+    contentPadding: PaddingValues = PaddingValues(),
+    focusRequester: FocusRequester = remember { FocusRequester() }
+) {
+    TvLazyRow(
+        modifier = modifier,
+        contentPadding = contentPadding,
+        horizontalArrangement = horizontalArrangement,
+    ) {
+        itemsIndexed(playerEpisodeList) { index, item ->
+            val cardModifier = if (index == 0) {
+                Modifier.focusRequester(focusRequester)
+            } else {
+                Modifier
+            }
+            EpisodeCard(
+                playerEpisode = item,
+                onClick = { onSelected(item) },
+                modifier = cardModifier
+            )
+        }
+    }
+}

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/discover/DiscoverScreen.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/discover/DiscoverScreen.kt
@@ -37,9 +37,9 @@ import androidx.tv.material3.Tab
 import androidx.tv.material3.TabRow
 import androidx.tv.material3.Text
 import com.example.jetcaster.core.data.database.model.Category
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.database.model.Podcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.tv.model.CategoryList
 import com.example.jetcaster.tv.model.EpisodeList
 import com.example.jetcaster.tv.model.PodcastList
@@ -50,7 +50,7 @@ import com.example.jetcaster.tv.ui.theme.JetcasterAppDefaults
 @Composable
 fun DiscoverScreen(
     showPodcastDetails: (Podcast) -> Unit,
-    showEpisodeDetails: (EpisodeToPodcast) -> Unit,
+    playEpisode: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
     discoverScreenViewModel: DiscoverScreenViewModel = hiltViewModel()
 ) {
@@ -73,7 +73,10 @@ fun DiscoverScreen(
                 latestEpisodeList = s.latestEpisodeList,
                 onPodcastSelected = { showPodcastDetails(it.podcast) },
                 onCategorySelected = discoverScreenViewModel::selectCategory,
-                onEpisodeSelected = showEpisodeDetails,
+                onEpisodeSelected = {
+                    discoverScreenViewModel.play(it)
+                    playEpisode(it)
+                },
                 modifier = Modifier
                     .fillMaxSize()
                     .then(modifier)
@@ -90,7 +93,7 @@ private fun CatalogWithCategorySelection(
     selectedCategory: Category,
     latestEpisodeList: EpisodeList,
     onPodcastSelected: (PodcastWithExtraInfo) -> Unit,
-    onEpisodeSelected: (EpisodeToPodcast) -> Unit,
+    onEpisodeSelected: (PlayerEpisode) -> Unit,
     onCategorySelected: (Category) -> Unit,
     modifier: Modifier = Modifier,
     state: TvLazyListState = rememberTvLazyListState(),

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/discover/DiscoverScreenViewModel.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/discover/DiscoverScreenViewModel.kt
@@ -19,8 +19,11 @@ package com.example.jetcaster.tv.ui.discover
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jetcaster.core.data.database.model.Category
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.toPlayerEpisode
 import com.example.jetcaster.core.data.repository.CategoryStore
 import com.example.jetcaster.core.data.repository.PodcastsRepository
+import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.tv.model.CategoryList
 import com.example.jetcaster.tv.model.EpisodeList
 import com.example.jetcaster.tv.model.PodcastList
@@ -40,6 +43,7 @@ import kotlinx.coroutines.launch
 class DiscoverScreenViewModel @Inject constructor(
     private val podcastsRepository: PodcastsRepository,
     private val categoryStore: CategoryStore,
+    private val episodePlayer: EpisodePlayer,
 ) : ViewModel() {
 
     private val _selectedCategory = MutableStateFlow<Category?>(null)
@@ -80,8 +84,8 @@ class DiscoverScreenViewModel @Inject constructor(
         } else {
             flowOf(emptyList())
         }
-    }.map {
-        EpisodeList(it)
+    }.map { list ->
+        EpisodeList(list.map { it.toPlayerEpisode() })
     }
 
     val uiState = combine(
@@ -112,6 +116,10 @@ class DiscoverScreenViewModel @Inject constructor(
 
     fun selectCategory(category: Category) {
         _selectedCategory.value = category
+    }
+
+    fun play(playerEpisode: PlayerEpisode) {
+        episodePlayer.play(playerEpisode)
     }
 
     private fun refresh() {

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/episode/EpisodeScreen.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/episode/EpisodeScreen.kt
@@ -146,6 +146,7 @@ private fun EpisodeInfo(
     }
 }
 
+@OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun Controls(
     playEpisode: () -> Unit,
@@ -154,6 +155,7 @@ private fun Controls(
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(JetcasterAppDefaults.gap.item),
+        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
     ) {
         PlayButton(onClick = playEpisode)

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/library/LibraryScreen.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/library/LibraryScreen.kt
@@ -36,8 +36,8 @@ import androidx.tv.material3.Button
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.data.database.model.PodcastWithExtraInfo
+import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.tv.R
 import com.example.jetcaster.tv.model.EpisodeList
 import com.example.jetcaster.tv.model.PodcastList
@@ -50,7 +50,7 @@ fun LibraryScreen(
     modifier: Modifier = Modifier,
     navigateToDiscover: () -> Unit,
     showPodcastDetails: (PodcastWithExtraInfo) -> Unit,
-    showEpisodeDetails: (EpisodeToPodcast) -> Unit,
+    playEpisode: (PlayerEpisode) -> Unit,
     libraryScreenViewModel: LibraryScreenViewModel = hiltViewModel()
 ) {
     val uiState by libraryScreenViewModel.uiState.collectAsState()
@@ -64,7 +64,10 @@ fun LibraryScreen(
             podcastList = s.subscribedPodcastList,
             episodeList = s.latestEpisodeList,
             showPodcastDetails = showPodcastDetails,
-            showEpisodeDetails = showEpisodeDetails,
+            onEpisodeSelected = {
+                libraryScreenViewModel.playEpisode(it)
+                playEpisode(it)
+            },
             modifier = modifier,
         )
     }
@@ -76,7 +79,7 @@ private fun Library(
     podcastList: PodcastList,
     episodeList: EpisodeList,
     showPodcastDetails: (PodcastWithExtraInfo) -> Unit,
-    showEpisodeDetails: (EpisodeToPodcast) -> Unit,
+    onEpisodeSelected: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester = remember { FocusRequester() },
 ) {
@@ -88,7 +91,7 @@ private fun Library(
         podcastList = podcastList,
         latestEpisodeList = episodeList,
         onPodcastSelected = showPodcastDetails,
-        onEpisodeSelected = showEpisodeDetails,
+        onEpisodeSelected = onEpisodeSelected,
         modifier = modifier
             .focusRequester(focusRequester)
             .focusRestorer()

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/library/LibraryScreenViewModel.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/library/LibraryScreenViewModel.kt
@@ -18,9 +18,12 @@ package com.example.jetcaster.tv.ui.library
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.toPlayerEpisode
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
 import com.example.jetcaster.core.data.repository.PodcastsRepository
+import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.tv.model.EpisodeList
 import com.example.jetcaster.tv.model.PodcastList
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,6 +42,7 @@ class LibraryScreenViewModel @Inject constructor(
     private val podcastsRepository: PodcastsRepository,
     private val episodeStore: EpisodeStore,
     podcastStore: PodcastStore,
+    private val episodePlayer: EpisodePlayer,
 ) : ViewModel() {
 
     private val followingPodcastListFlow = podcastStore.followedPodcastsSortedByLastEpisode().map {
@@ -58,8 +62,8 @@ class LibraryScreenViewModel @Inject constructor(
             } else {
                 flowOf(emptyList())
             }
-        }.map {
-            EpisodeList(it)
+        }.map { list ->
+            EpisodeList(list.map { it.toPlayerEpisode() })
         }
 
     val uiState =
@@ -79,6 +83,10 @@ class LibraryScreenViewModel @Inject constructor(
         viewModelScope.launch {
             podcastsRepository.updatePodcasts(false)
         }
+    }
+
+    fun playEpisode(playerEpisode: PlayerEpisode) {
+        episodePlayer.play(playerEpisode)
     }
 }
 

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/player/PlayerScreen.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/player/PlayerScreen.kt
@@ -57,8 +57,6 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.tv.foundation.lazy.list.TvLazyRow
-import androidx.tv.foundation.lazy.list.itemsIndexed
 import androidx.tv.material3.Button
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
@@ -66,11 +64,11 @@ import androidx.tv.material3.Text
 import com.example.jetcaster.core.data.model.PlayerEpisode
 import com.example.jetcaster.core.player.EpisodePlayerState
 import com.example.jetcaster.tv.R
-import com.example.jetcaster.tv.model.PlayerEpisodeList
+import com.example.jetcaster.tv.model.EpisodeList
 import com.example.jetcaster.tv.ui.component.BackgroundContainer
 import com.example.jetcaster.tv.ui.component.EnqueueButton
-import com.example.jetcaster.tv.ui.component.EpisodeCard
 import com.example.jetcaster.tv.ui.component.EpisodeDetails
+import com.example.jetcaster.tv.ui.component.EpisodeRow
 import com.example.jetcaster.tv.ui.component.InfoButton
 import com.example.jetcaster.tv.ui.component.Loading
 import com.example.jetcaster.tv.ui.component.NextButton
@@ -142,7 +140,7 @@ private fun Player(
     if (currentEpisode != null) {
         EpisodePlayerWithBackground(
             playerEpisode = currentEpisode,
-            queue = PlayerEpisodeList(episodePlayerState.queue),
+            queue = EpisodeList(episodePlayerState.queue),
             isPlaying = episodePlayerState.isPlaying,
             timeElapsed = episodePlayerState.timeElapsed,
             play = play,
@@ -163,7 +161,7 @@ private fun Player(
 @Composable
 private fun EpisodePlayerWithBackground(
     playerEpisode: PlayerEpisode,
-    queue: PlayerEpisodeList,
+    queue: EpisodeList,
     isPlaying: Boolean,
     timeElapsed: Duration,
     play: () -> Unit,
@@ -416,40 +414,10 @@ private fun NoEpisodeInQueue(
     }
 }
 
-@Composable
-private fun PlayerQueue(
-    playerEpisodeList: PlayerEpisodeList,
-    onSelected: (PlayerEpisode) -> Unit,
-    modifier: Modifier = Modifier,
-    horizontalArrangement: Arrangement.Horizontal =
-        Arrangement.spacedBy(JetcasterAppDefaults.gap.item),
-    contentPadding: PaddingValues = PaddingValues(),
-    focusRequester: FocusRequester = remember { FocusRequester() }
-) {
-    TvLazyRow(
-        modifier = modifier,
-        contentPadding = contentPadding,
-        horizontalArrangement = horizontalArrangement,
-    ) {
-        itemsIndexed(playerEpisodeList) { index, item ->
-            val cardModifier = if (index == 0) {
-                Modifier.focusRequester(focusRequester)
-            } else {
-                Modifier
-            }
-            EpisodeCard(
-                playerEpisode = item,
-                onClick = { onSelected(item) },
-                modifier = cardModifier
-            )
-        }
-    }
-}
-
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PlayerQueueOverlay(
-    playerEpisodeList: PlayerEpisodeList,
+    playerEpisodeList: EpisodeList,
     onSelected: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
     horizontalArrangement: Arrangement.Horizontal =
@@ -481,7 +449,7 @@ private fun PlayerQueueOverlay(
         },
         contentAlignment = contentAlignment,
     ) {
-        PlayerQueue(
+        EpisodeRow(
             playerEpisodeList = playerEpisodeList,
             onSelected = onSelected,
             horizontalArrangement = horizontalArrangement,

--- a/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/podcast/PodcastScreenViewModel.kt
+++ b/Jetcaster/tv-app/src/main/java/com/example/jetcaster/tv/ui/podcast/PodcastScreenViewModel.kt
@@ -20,8 +20,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jetcaster.core.data.database.model.Podcast
+import com.example.jetcaster.core.data.model.PlayerEpisode
+import com.example.jetcaster.core.data.model.toPlayerEpisode
 import com.example.jetcaster.core.data.repository.EpisodeStore
 import com.example.jetcaster.core.data.repository.PodcastStore
+import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.tv.model.EpisodeList
 import com.example.jetcaster.tv.ui.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -40,6 +43,7 @@ class PodcastScreenViewModel @Inject constructor(
     handle: SavedStateHandle,
     private val podcastStore: PodcastStore,
     episodeStore: EpisodeStore,
+    private val episodePlayer: EpisodePlayer,
 ) : ViewModel() {
 
     private val podcastUri = handle.get<String>(Screen.Podcast.PARAMETER_NAME)
@@ -61,8 +65,8 @@ class PodcastScreenViewModel @Inject constructor(
         } else {
             flowOf(emptyList())
         }
-    }.map {
-        EpisodeList(it)
+    }.map { list ->
+        EpisodeList(list.map { it.toPlayerEpisode() })
     }
 
     private val subscribedPodcastListFlow = podcastStore.followedPodcastsSortedByLastEpisode()
@@ -98,6 +102,14 @@ class PodcastScreenViewModel @Inject constructor(
                 podcastStore.togglePodcastFollowed(podcast.uri)
             }
         }
+    }
+
+    fun play(playerEpisode: PlayerEpisode) {
+        episodePlayer.play(playerEpisode)
+    }
+
+    fun enqueue(playerEpisode: PlayerEpisode) {
+        episodePlayer.addToQueue(playerEpisode)
     }
 }
 


### PR DESCRIPTION
This pull request updates the change the screen transition when users clicks the episodes on the discovery, the library, and the podcast screen to navigate to the player screen.

This pull request also includes some code refactoring.