### PR TITLE
[Jetcaster] Add tests for podcast category filter limit

### DIFF
--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/domain/PodcastCategoryFilterUseCaseTest.kt
@@ -113,6 +113,24 @@ class PodcastCategoryFilterUseCaseTest {
             result.episodes
         )
     }
+
+    @Test
+    fun whenCategoryInfoNotNull_verifyLimitFlow() = runTest {
+        val resultFlow = useCase(testCategory.asExternalModel())
+
+        categoriesStore.setEpisodesFromPodcast(
+            testCategory.id,
+            List(8) { testEpisodeToPodcast }.flatten()
+        )
+        categoriesStore.setPodcastsInCategory(
+            testCategory.id,
+            List(4) { testPodcasts }.flatten()
+        )
+
+        val result = resultFlow.first()
+        assertEquals(20, result.episodes.size)
+        assertEquals(10, result.topPodcasts.size)
+    }
 }
 
 val testPodcasts = listOf(

--- a/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/repository/TestCategoryStore.kt
+++ b/Jetcaster/core/src/test/kotlin/com/example/jetcaster/core/data/repository/TestCategoryStore.kt
@@ -42,14 +42,14 @@ class TestCategoryStore : CategoryStore {
         categoryId: Long,
         limit: Int
     ): Flow<List<PodcastWithExtraInfo>> = podcastsInCategoryFlow.map {
-        it[categoryId] ?: emptyList()
+        it[categoryId]?.take(limit) ?: emptyList()
     }
 
     override fun episodesFromPodcastsInCategory(
         categoryId: Long,
         limit: Int
     ): Flow<List<EpisodeToPodcast>> = episodesFromPodcasts.map {
-        it[categoryId] ?: emptyList()
+        it[categoryId]?.take(limit) ?: emptyList()
     }
 
     override suspend fun addCategory(category: Category): Long = -1


### PR DESCRIPTION
Although this test case may become unnecessary once the `limit` parameters in each method of the `CategoryStore` are explicitly specified, I added it because it seems that there was no test code to verify the limits currently used in the `PodcastCategoryFilterUseCase`.