### PR TITLE
Switch GH runners to run on ubuntu-latest

### DIFF
--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/JetLagged.yaml
+++ b/.github/workflows/JetLagged.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/JetNews.yaml
+++ b/.github/workflows/JetNews.yaml
@@ -25,7 +25,7 @@ jobs:
 
   androidTest:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/Jetchat.yaml
+++ b/.github/workflows/Jetchat.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/Owl.yaml
+++ b/.github/workflows/Owl.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/Reply.yaml
+++ b/.github/workflows/Reply.yaml
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
`macOS-latest` resulted in emulators failing to run since the `macOS-latest` runner was updated to `mac14-arm64`.

Failed action with `macOS-latest`: https://github.com/android/compose-samples/actions/runs/8835086121
Confirming that this change fixes emulator runs: https://github.com/android/compose-samples/actions/runs/8837607669


...changing emulator arch to [arm64](https://github.com/android/compose-samples/blob/main/.github/workflows/Reply.yaml#L62) is perhaps another way to fix this.

Note: I had to use `macos-12` for Crane to fix emulator-related failures (see https://github.com/android/compose-samples/actions/runs/8837918596/job/24270240695)