### PR TITLE
Remove building release on PRs

### DIFF
--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -76,7 +76,7 @@ jobs:
           target: google_apis
           arch: x86
           disable-animations: true
-          script: ./gradlew connectedCheck --stacktrace
+          script: ./gradlew connectedAndroidDebugTest --stacktrace
           working-directory: ${{ env.SAMPLE_PATH }}
 
       - name: Upload test reports

--- a/.github/workflows/Crane.yaml
+++ b/.github/workflows/Crane.yaml
@@ -76,7 +76,7 @@ jobs:
           target: google_apis
           arch: x86
           disable-animations: true
-          script: ./gradlew connectedAndroidDebugTest --stacktrace
+          script: ./gradlew app:connectedDebugAndroidTest --stacktrace
           working-directory: ${{ env.SAMPLE_PATH }}
 
       - name: Upload test reports

--- a/.github/workflows/build-sample.yml
+++ b/.github/workflows/build-sample.yml
@@ -69,10 +69,6 @@ jobs:
         working-directory: ${{ inputs.path }}
         run: ./gradlew assembleDebug --stacktrace
 
-      - name: Build release
-        working-directory: ${{ inputs.path }}
-        run: ./gradlew assembleRelease --stacktrace
-
       - name: Run local tests
         working-directory: ${{ inputs.path }}
         run: ./gradlew testDebug --stacktrace

--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")

--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+            
         }
 
         getByName("release") {

--- a/Crane/app/build.gradle.kts
+++ b/Crane/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")
@@ -58,18 +58,19 @@ android {
 
     buildTypes {
         getByName("debug") {
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro")
         }
 
         create("benchmark") {
             initWith(getByName("release"))
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             matchingFallbacks.add("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-benchmark-rules.pro")

--- a/JetLagged/app/build.gradle.kts
+++ b/JetLagged/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")

--- a/JetLagged/app/build.gradle.kts
+++ b/JetLagged/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")
@@ -48,19 +48,19 @@ android {
 
     buildTypes {
         getByName("debug") {
-
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro")
         }
 
         create("benchmark") {
             initWith(getByName("release"))
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             matchingFallbacks.add("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-benchmark-rules.pro")

--- a/JetLagged/app/build.gradle.kts
+++ b/JetLagged/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+
         }
 
         getByName("release") {

--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")

--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")
@@ -48,12 +48,12 @@ android {
 
     buildTypes {
         getByName("debug") {
-
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro")
         }

--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+
         }
 
         getByName("release") {

--- a/Jetcaster/mobile/build.gradle.kts
+++ b/Jetcaster/mobile/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             // get from env variables
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")

--- a/Jetcaster/mobile/build.gradle.kts
+++ b/Jetcaster/mobile/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             // get from env variables
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
@@ -51,12 +51,12 @@ android {
 
     buildTypes {
         getByName("debug") {
-
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/Jetcaster/mobile/build.gradle.kts
+++ b/Jetcaster/mobile/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+
         }
 
         getByName("release") {

--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")

--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")
@@ -49,12 +49,12 @@ android {
 
     buildTypes {
         getByName("debug") {
-            
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro")
         }

--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+
         }
 
         getByName("release") {

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")
@@ -48,19 +48,19 @@ android {
 
     buildTypes {
         getByName("debug") {
-
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro")
         }
 
         create("benchmark") {
             initWith(getByName("release"))
-           // signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             matchingFallbacks.add("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-benchmark-rules.pro")

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")

--- a/Jetsnack/app/build.gradle.kts
+++ b/Jetsnack/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+
         }
 
         getByName("release") {

--- a/Owl/app/build.gradle.kts
+++ b/Owl/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")

--- a/Owl/app/build.gradle.kts
+++ b/Owl/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
             keyAlias = if (hasKeyInfo) "androiddebugkey" else System.getenv("compose_key_alias")
@@ -48,12 +48,12 @@ android {
 
     buildTypes {
         getByName("debug") {
-
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro")
         }

--- a/Owl/app/build.gradle.kts
+++ b/Owl/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+
         }
 
         getByName("release") {

--- a/Reply/app/build.gradle.kts
+++ b/Reply/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("release") {
+        create("release") {
             // get from env variables
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")

--- a/Reply/app/build.gradle.kts
+++ b/Reply/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 
     buildTypes {
         getByName("debug") {
-            signingConfig = null
+
         }
 
         getByName("release") {

--- a/Reply/app/build.gradle.kts
+++ b/Reply/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         val userKeystore = File(System.getProperty("user.home"), ".android/debug.keystore")
         val localKeystore = rootProject.file("debug_2.keystore")
         val hasKeyInfo = userKeystore.exists()
-        named("debug") {
+        named("release") {
             // get from env variables
             storeFile = if (hasKeyInfo) userKeystore else localKeystore
             storePassword = if (hasKeyInfo) "android" else System.getenv("compose_store_password")
@@ -49,12 +49,12 @@ android {
 
     buildTypes {
         getByName("debug") {
-
+            signingConfig = null
         }
 
         getByName("release") {
             isMinifyEnabled = true
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro")
         }


### PR DESCRIPTION
When building from a fork pull request, the secrets are not shared. This PR removes the need to build a release since it wasn't used, named the signing config it to be a release. 