### PR TITLE
[GH Workflow]: Use inputs.module variable for uploading artifacts.

### DIFF
--- a/.github/workflows/build-sample.yml
+++ b/.github/workflows/build-sample.yml
@@ -77,11 +77,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-outputs
-          path: ${{ inputs.path }}/app/build/outputs
+          path: ${{ inputs.path }}/${{ inputs.module }}/build/outputs
 
       - name: Upload build reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: build-reports
-          path: ${{ inputs.path }}/app/build/reports
+          path: ${{ inputs.path }}/${{ inputs.module }}/build/reports


### PR DESCRIPTION
Looks like there was a regression introduced - Jetcaster artifacts were not uplaoded on successful builds. See: https://github.com/android/compose-samples/actions/runs/8926918741

Workflow run with this change: https://github.com/android/compose-samples/actions/runs/8927043650
