### PR TITLE
[Wear]Add preview to latestEpisodes and refactoring

### DIFF
--- a/Jetcaster/core/domain-testing/src/main/java/com/example/jetcaster/core/domain/testing/PreviewData.kt
+++ b/Jetcaster/core/domain-testing/src/main/java/com/example/jetcaster/core/domain/testing/PreviewData.kt
@@ -20,6 +20,7 @@ import com.example.jetcaster.core.model.CategoryInfo
 import com.example.jetcaster.core.model.EpisodeInfo
 import com.example.jetcaster.core.model.PodcastInfo
 import com.example.jetcaster.core.model.PodcastToEpisodeInfo
+import com.example.jetcaster.core.player.model.PlayerEpisode
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
@@ -55,6 +56,13 @@ val PreviewEpisodes = listOf(
             2020, 6, 2, 9,
             27, 0, 0, ZoneOffset.of("-0800")
         )
+    )
+)
+
+val PreviewPlayerEpisodes = listOf(
+    PlayerEpisode(
+        PreviewPodcasts[0],
+        PreviewEpisodes[0]
     )
 )
 

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/WearApp.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/WearApp.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
@@ -127,7 +126,6 @@ fun WearApp() {
                     route = LatestEpisodes.navRoute,
                 ) {
                     LatestEpisodesScreen(
-                        playlistName = stringResource(id = R.string.latest_episodes),
                         onPlayButtonClick = {
                             navController.navigateToPlayer()
                         },

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/components/MediaContent.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/components/MediaContent.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetcaster.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material.ChipDefaults
+import com.example.jetcaster.R
+import com.example.jetcaster.core.player.model.PlayerEpisode
+import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.images.coil.CoilPaintable
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@Composable
+fun MediaContent(
+    episode: PlayerEpisode,
+    episodeArtworkPlaceholder: Painter?,
+    onItemClick: (PlayerEpisode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val mediaTitle = episode.title
+    val duration = episode.duration
+
+    val secondaryLabel = when {
+        duration != null -> {
+            // If we have the duration, we combine the date/duration via a
+            // formatted string
+            stringResource(
+                R.string.episode_date_duration,
+                MediumDateFormatter.format(episode.published),
+                duration.toMinutes().toInt()
+            )
+        }
+        // Otherwise we just use the date
+        else -> MediumDateFormatter.format(episode.published)
+    }
+
+    Chip(
+        label = mediaTitle,
+        onClick = { onItemClick(episode) },
+        secondaryLabel = secondaryLabel,
+        icon = CoilPaintable(episode.podcastImageUrl, episodeArtworkPlaceholder),
+        largeIcon = true,
+        colors = ChipDefaults.secondaryChipColors(),
+        modifier = modifier
+    )
+}
+
+public val MediumDateFormatter: DateTimeFormatter by lazy {
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+}

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/episode/EpisodeScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/episode/EpisodeScreen.kt
@@ -35,12 +35,15 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.LocalContentColor
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.example.jetcaster.R
 import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.player.model.PlayerEpisode
 import com.example.jetcaster.core.player.model.toPlayerEpisode
+import com.example.jetcaster.designsystem.component.HtmlTextContainer
+import com.example.jetcaster.ui.components.MediumDateFormatter
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
@@ -54,8 +57,6 @@ import com.google.android.horologist.compose.material.Button
 import com.google.android.horologist.compose.material.ListHeaderDefaults
 import com.google.android.horologist.compose.material.ResponsiveListHeader
 import com.google.android.horologist.media.ui.screens.entity.EntityScreen
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 
 @Composable
 fun EpisodeScreen(
@@ -69,10 +70,10 @@ fun EpisodeScreen(
     EpisodeScreen(
         uiState = uiState,
         onPlayButtonClick = onPlayButtonClick,
-        modifier = modifier,
         onPlayEpisode = episodeViewModel::onPlayEpisode,
         onAddToQueue = episodeViewModel::addToQueue,
         onDismiss = onDismiss,
+        modifier = modifier,
     )
 }
 
@@ -80,10 +81,10 @@ fun EpisodeScreen(
 fun EpisodeScreen(
     uiState: EpisodeScreenState,
     onPlayButtonClick: () -> Unit,
-    modifier: Modifier = Modifier,
     onPlayEpisode: (PlayerEpisode) -> Unit,
     onAddToQueue: (PlayerEpisode) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val columnState = rememberResponsiveColumnState(
         contentPadding = padding(
@@ -276,14 +277,14 @@ private fun ScalingLazyListScope.episodeInfoContent(episode: EpisodeToPodcast) {
     if (summary != null) {
         val summaryInParagraphs = summary.split("\n+".toRegex()).orEmpty()
         items(summaryInParagraphs) {
-            Text(
-                text = it,
-                modifier = Modifier.listTextPadding()
-            )
+            HtmlTextContainer(text = summary) {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.body2,
+                    color = LocalContentColor.current,
+                    modifier = Modifier.listTextPadding()
+                )
+            }
         }
     }
-}
-
-private val MediumDateFormatter by lazy {
-    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/player/PlaybackSpeedScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/player/PlaybackSpeedScreen.kt
@@ -16,16 +16,13 @@
 
 package com.example.jetcaster.ui.player
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.material.ContentAlpha
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.InlineSlider
@@ -38,13 +35,11 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.listTextPadding
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
-import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.ResponsiveListHeader
 
 /**
  * Playback Speed Screen with an [InlineSlider].
  */
-@OptIn(ExperimentalWearFoundationApi::class)
 @Composable
 public fun PlaybackSpeedScreen(
     modifier: Modifier = Modifier,

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/player/PlaybackSpeedViewModel.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/player/PlaybackSpeedViewModel.kt
@@ -16,8 +16,6 @@
 
 package com.example.jetcaster.ui.player
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jetcaster.core.player.EpisodePlayer
@@ -55,9 +53,5 @@ public open class PlaybackSpeedViewModel @Inject constructor(
 
     public fun decreaseSpeed() {
         episodePlayer.decreaseSpeed()
-    }
-
-    private fun notSupported() {
-        Log.i(TAG, "Effect not supported")
     }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -24,17 +24,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Text
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import com.example.jetcaster.R
+import com.example.jetcaster.core.domain.testing.PreviewPodcastEpisodes
 import com.example.jetcaster.core.model.PodcastInfo
 import com.example.jetcaster.core.player.model.PlayerEpisode
+import com.example.jetcaster.ui.components.MediaContent
+import com.example.jetcaster.ui.preview.WearPreviewEpisodes
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
@@ -47,7 +52,6 @@ import com.google.android.horologist.compose.material.ListHeaderDefaults
 import com.google.android.horologist.compose.material.ResponsiveListHeader
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 import com.google.android.horologist.images.base.util.rememberVectorPainter
-import com.google.android.horologist.images.coil.CoilPaintable
 import com.google.android.horologist.media.ui.screens.entity.EntityScreen
 
 @Composable fun PodcastDetailsScreen(
@@ -175,26 +179,6 @@ fun ButtonsContent(
     )
 }
 
-@Composable
-fun MediaContent(
-    episode: PlayerEpisode,
-    episodeArtworkPlaceholder: Painter?,
-    onEpisodeItemClick: (PlayerEpisode) -> Unit
-) {
-    val mediaTitle = episode.title
-
-    val secondaryLabel = episode.author
-
-    Chip(
-        label = mediaTitle,
-        onClick = { onEpisodeItemClick(episode) },
-        secondaryLabel = secondaryLabel,
-        icon = CoilPaintable(episode.podcastImageUrl, episodeArtworkPlaceholder),
-        largeIcon = true,
-        colors = ChipDefaults.secondaryChipColors(),
-    )
-}
-
 @ExperimentalHorologistApi
 sealed class PodcastDetailsScreenState {
 
@@ -206,4 +190,39 @@ sealed class PodcastDetailsScreenState {
     ) : PodcastDetailsScreenState()
 
     data object Empty : PodcastDetailsScreenState()
+}
+
+@WearPreviewDevices
+@WearPreviewFontScales
+@Composable
+fun PodcastDetailsScreenLoadedPreview(
+    @PreviewParameter(WearPreviewEpisodes::class)
+    episode: PlayerEpisode
+) {
+    PodcastDetailsScreen(
+        uiState = PodcastDetailsScreenState.Loaded(
+            episodeList = listOf(episode),
+            podcast = PreviewPodcastEpisodes.first().podcast
+        ),
+        onPlayButtonClick = { },
+        onEpisodeItemClick = {},
+        onPlayEpisode = {},
+        onDismiss = {}
+    )
+}
+
+@WearPreviewDevices
+@WearPreviewFontScales
+@Composable
+fun PodcastDetailsScreenLoadingPreview(
+    @PreviewParameter(WearPreviewEpisodes::class)
+    episode: PlayerEpisode
+) {
+    PodcastDetailsScreen(
+        uiState = PodcastDetailsScreenState.Loading,
+        onPlayButtonClick = { },
+        onEpisodeItemClick = {},
+        onPlayEpisode = {},
+        onDismiss = {}
+    )
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcasts/PodcastsScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcasts/PodcastsScreen.kt
@@ -33,7 +33,7 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import com.example.jetcaster.R
 import com.example.jetcaster.core.model.PodcastInfo
-import com.example.jetcaster.podcasts.WearPreviewPodcasts
+import com.example.jetcaster.ui.preview.WearPreviewPodcasts
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/preview/WearPreviewEpisodes.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/preview/WearPreviewEpisodes.kt
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package com.example.jetcaster.ui.queue
+package com.example.jetcaster.ui.preview
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import com.example.jetcaster.core.domain.testing.PreviewEpisodes
+import com.example.jetcaster.core.domain.testing.PreviewPlayerEpisodes
 import com.example.jetcaster.core.player.model.PlayerEpisode
 
-public class WearPreviewQueue : PreviewParameterProvider<PlayerEpisode> {
+public class WearPreviewEpisodes : PreviewParameterProvider<PlayerEpisode> {
     public override val values: Sequence<PlayerEpisode>
-        get() = PreviewEpisodes.map {
-            PlayerEpisode(
-                uri = it.uri,
-                author = it.author,
-                title = it.title,
-                published = it.published
-            )
-        }.asSequence()
+        get() = PreviewPlayerEpisodes.asSequence()
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/preview/WearPreviewPodcasts.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/preview/WearPreviewPodcasts.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.jetcaster.podcasts
+package com.example.jetcaster.ui.preview
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.example.jetcaster.core.domain.testing.PreviewPodcasts
 import com.example.jetcaster.core.model.PodcastInfo

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/queue/QueueScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/queue/QueueScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -41,8 +40,9 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import com.example.jetcaster.R
-import com.example.jetcaster.core.data.database.model.EpisodeToPodcast
 import com.example.jetcaster.core.player.model.PlayerEpisode
+import com.example.jetcaster.ui.components.MediaContent
+import com.example.jetcaster.ui.preview.WearPreviewEpisodes
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
@@ -52,19 +52,15 @@ import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.AlertDialog
 import com.google.android.horologist.compose.material.Button
-import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.ListHeaderDefaults
 import com.google.android.horologist.compose.material.ResponsiveListHeader
 import com.google.android.horologist.images.base.util.rememberVectorPainter
-import com.google.android.horologist.images.coil.CoilPaintable
 import com.google.android.horologist.media.ui.screens.entity.DefaultEntityScreenHeader
 import com.google.android.horologist.media.ui.screens.entity.EntityScreen
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 
 @Composable fun QueueScreen(
     onPlayButtonClick: () -> Unit,
-    onEpisodeItemClick: (EpisodeToPodcast) -> Unit,
+    onEpisodeItemClick: (PlayerEpisode) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     queueViewModel: QueueViewModel = hiltViewModel()
@@ -88,7 +84,7 @@ fun QueueScreen(
     onPlayButtonClick: () -> Unit,
     onPlayEpisodes: (List<PlayerEpisode>) -> Unit,
     modifier: Modifier = Modifier,
-    onEpisodeItemClick: (EpisodeToPodcast) -> Unit,
+    onEpisodeItemClick: (PlayerEpisode) -> Unit,
     onDeleteQueueEpisodes: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -124,7 +120,7 @@ fun QueueScreenLoaded(
     onPlayButtonClick: () -> Unit,
     onPlayEpisodes: (List<PlayerEpisode>) -> Unit,
     onDeleteQueueEpisodes: () -> Unit,
-    onEpisodeItemClick: (EpisodeToPodcast) -> Unit,
+    onEpisodeItemClick: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier
 ) {
     EntityScreen(
@@ -153,7 +149,7 @@ fun QueueScreenLoaded(
                         image = Icons.Default.MusicNote,
                         tintColor = Color.Blue,
                     ),
-                    onEpisodeItemClick
+                    onItemClick = onEpisodeItemClick
                 )
             }
         }
@@ -199,7 +195,8 @@ fun QueueScreenEmpty(
         showDialog = true,
         onDismiss = onDismiss,
         title = stringResource(R.string.display_nothing_in_queue),
-        message = stringResource(R.string.no_episodes_from_queue)
+        message = stringResource(R.string.no_episodes_from_queue),
+        modifier = modifier
     )
 }
 
@@ -244,49 +241,13 @@ fun ButtonsContent(
     }
 }
 
-@Composable
-fun MediaContent(
-    episode: PlayerEpisode,
-    episodeArtworkPlaceholder: Painter?,
-    onEpisodeItemClick: (EpisodeToPodcast) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val mediaTitle = episode.title
-    val duration = episode.duration
-
-    val secondaryLabel = when {
-        duration != null -> {
-            // If we have the duration, we combine the date/duration via a
-            // formatted string
-            stringResource(
-                R.string.episode_date_duration,
-                MediumDateFormatter.format(episode.published),
-                duration.toMinutes().toInt()
-            )
-        }
-        // Otherwise we just use the date
-        else -> MediumDateFormatter.format(episode.published)
-    }
-
-    Chip(
-        modifier = modifier,
-        label = mediaTitle,
-        onClick = { onEpisodeItemClick },
-        secondaryLabel = secondaryLabel,
-        icon = CoilPaintable(episode.podcastImageUrl, episodeArtworkPlaceholder),
-        largeIcon = true,
-        colors = ChipDefaults.secondaryChipColors(),
-    )
-}
-
-private val MediumDateFormatter by lazy {
-    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
-}
-
 @WearPreviewDevices
 @WearPreviewFontScales
 @Composable
-fun QueueScreenLoadedPreview(@PreviewParameter(WearPreviewQueue::class) episode: PlayerEpisode,) {
+fun QueueScreenLoadedPreview(
+    @PreviewParameter(WearPreviewEpisodes::class)
+    episode: PlayerEpisode
+) {
     val columnState = rememberResponsiveColumnState(
         contentPadding = padding(
             first = ScalingLazyColumnDefaults.ItemType.Text,


### PR DESCRIPTION
- Uses #1377
- Add previews for latestEpisode screen
- Refactor `MediaContent` for Queue and Podcasts (need a separate PR to see if it can be expanded for LatestEpisodes since it has additional play methods)
- Moves the latestEpisodes screen title to the Composable
- Add more data preview to create PlayerEpisode