### PR TITLE
[Jetcaster]: Change alpha of prev/next buttons.

### DIFF
--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
@@ -109,8 +109,8 @@ import com.example.jetcaster.util.verticalGradientScrim
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
 import com.google.accompanist.adaptive.VerticalTwoPaneStrategy
-import kotlinx.coroutines.launch
 import java.time.Duration
+import kotlinx.coroutines.launch
 
 /**
  * Stateful version of the Podcast player

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
@@ -108,8 +109,8 @@ import com.example.jetcaster.util.verticalGradientScrim
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
 import com.google.accompanist.adaptive.VerticalTwoPaneStrategy
-import java.time.Duration
 import kotlinx.coroutines.launch
+import java.time.Duration
 
 /**
  * Stateful version of the Podcast player
@@ -712,6 +713,9 @@ private fun PlayerSlider(
     }
 }
 
+private fun Modifier.invisibleWhen(predicate: () -> Boolean): Modifier =
+    Modifier.alpha(if (predicate()) 0f else 1f) then this
+
 @Composable
 private fun PlayerButtons(
     hasNext: Boolean,
@@ -754,6 +758,7 @@ private fun PlayerButtons(
             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurfaceVariant),
             modifier = sideButtonsModifier
                 .clickable(enabled = isPlaying, onClick = onPrevious)
+                .alpha(if (isPlaying) 1f else 0.25f)
         )
         Image(
             imageVector = Icons.Filled.Replay10,
@@ -807,6 +812,7 @@ private fun PlayerButtons(
             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurfaceVariant),
             modifier = sideButtonsModifier
                 .clickable(enabled = hasNext, onClick = onNext)
+                .alpha(if (hasNext) 1f else 0.25f)
         )
     }
 }

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
@@ -713,9 +713,6 @@ private fun PlayerSlider(
     }
 }
 
-private fun Modifier.invisibleWhen(predicate: () -> Boolean): Modifier =
-    Modifier.alpha(if (predicate()) 0f else 1f) then this
-
 @Composable
 private fun PlayerButtons(
     hasNext: Boolean,


### PR DESCRIPTION
Change alpha of previous and next buttons in the player to help indicate if those actions are possible based on the state of the player (i.e. previous only possible while playing and next only possible when queue isn't empty).

Disabled:
<img src="https://github.com/android/compose-samples/assets/463186/81bf2fcb-c8af-4db3-bf79-421c79b2393f" width=300 />


Enabled:
<img src="https://github.com/android/compose-samples/assets/463186/f6cfebbf-e54e-41bf-9813-302536a1cb5e" width=300 />