### PR TITLE
[Jetcaster] fix d-pad focus issues of TV app

### DIFF
--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
@@ -41,7 +41,7 @@ import com.example.jetcaster.tv.ui.discover.DiscoverScreen
 import com.example.jetcaster.tv.ui.episode.EpisodeScreen
 import com.example.jetcaster.tv.ui.library.LibraryScreen
 import com.example.jetcaster.tv.ui.player.PlayerScreen
-import com.example.jetcaster.tv.ui.podcast.PodcastScreen
+import com.example.jetcaster.tv.ui.podcast.PodcastDetailsScreen
 import com.example.jetcaster.tv.ui.profile.ProfileScreen
 import com.example.jetcaster.tv.ui.search.SearchScreen
 import com.example.jetcaster.tv.ui.settings.SettingsScreen
@@ -162,7 +162,7 @@ private fun Route(jetcasterAppState: JetcasterAppState) {
         }
 
         composable(Screen.Podcast.route) {
-            PodcastScreen(
+            PodcastDetailsScreen(
                 backToHomeScreen = jetcasterAppState::navigateToDiscover,
                 playEpisode = {
                     jetcasterAppState.playEpisode()

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
@@ -28,7 +28,14 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.VideoLibrary
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusTarget
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.tv.material3.DrawerValue
@@ -52,13 +59,16 @@ fun JetcasterApp(jetcasterAppState: JetcasterAppState = rememberJetcasterAppStat
     Route(jetcasterAppState = jetcasterAppState)
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun WithGlobalNavigation(
     jetcasterAppState: JetcasterAppState,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    val currentScreen by jetcasterAppState.currentScreenState
+    val (discover, library) = remember { FocusRequester.createRefs() }
+    val currentRoute
+        by jetcasterAppState.currentRouteFlow.collectAsStateWithLifecycle(initialValue = null)
 
     NavigationDrawer(
         drawerContent = {
@@ -66,9 +76,19 @@ private fun WithGlobalNavigation(
             Column(
                 modifier = Modifier
                     .padding(JetcasterAppDefaults.overScanMargin.drawer.intoPaddingValues())
+                    .focusTarget()
+                    .focusProperties {
+                        enter = {
+                            when (currentRoute) {
+                                Screen.Discover.route -> discover
+                                Screen.Library.route -> library
+                                else -> FocusRequester.Default
+                            }
+                        }
+                    }
             ) {
                 NavigationDrawerItem(
-                    selected = isClosed && currentScreen.index == Screen.Profile.index,
+                    selected = isClosed && currentRoute == Screen.Profile.route,
                     onClick = jetcasterAppState::navigateToProfile,
                     leadingContent = { Icon(Icons.Default.Person, contentDescription = null) },
                 ) {
@@ -79,29 +99,36 @@ private fun WithGlobalNavigation(
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 NavigationDrawerItem(
-                    selected = isClosed && currentScreen.index == Screen.Search.index,
+                    selected = isClosed && currentRoute == Screen.Search.route,
                     onClick = jetcasterAppState::navigateToSearch,
                     leadingContent = { Icon(Icons.Default.Search, contentDescription = null) }
                 ) {
                     Text(text = "Search")
                 }
                 NavigationDrawerItem(
-                    selected = isClosed && currentScreen.index == Screen.Discover.index,
+                    selected = isClosed && currentRoute == Screen.Discover.route,
                     onClick = jetcasterAppState::navigateToDiscover,
                     leadingContent = { Icon(Icons.Default.Home, contentDescription = null) },
+                    modifier = Modifier.focusRequester(discover)
                 ) {
                     Text(text = "Discover")
                 }
                 NavigationDrawerItem(
-                    selected = isClosed && currentScreen.index == Screen.Library.index,
+                    selected = isClosed && currentRoute == Screen.Library.route,
                     onClick = jetcasterAppState::navigateToLibrary,
-                    leadingContent = { Icon(Icons.Default.VideoLibrary, contentDescription = null) }
+                    leadingContent = {
+                        Icon(
+                            Icons.Default.VideoLibrary,
+                            contentDescription = null
+                        )
+                    },
+                    modifier = Modifier.focusRequester(library)
                 ) {
                     Text(text = "Library")
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 NavigationDrawerItem(
-                    selected = isClosed && currentScreen.index == Screen.Settings.index,
+                    selected = isClosed && currentRoute == Screen.Settings.route,
                     onClick = jetcasterAppState::navigateToSettings,
                     leadingContent = { Icon(Icons.Default.Settings, contentDescription = null) }
                 ) {
@@ -110,7 +137,7 @@ private fun WithGlobalNavigation(
             }
         },
         content = content,
-        modifier = modifier
+        modifier = modifier,
     )
 }
 

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterAppState.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterAppState.kt
@@ -18,20 +18,21 @@ package com.example.jetcaster.tv.ui
 
 import android.net.Uri
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.example.jetcaster.core.player.model.PlayerEpisode
+import kotlinx.coroutines.flow.map
 
 class JetcasterAppState(
     val navHostController: NavHostController
 ) {
 
-    private var _currentScreenState = mutableStateOf<Screen>(Screen.Discover)
-    val currentScreenState = _currentScreenState
+    val currentRouteFlow = navHostController.currentBackStackEntryFlow.map {
+        it.destination.route
+    }
+
     private fun navigate(screen: Screen) {
-        _currentScreenState.value = screen
         navHostController.navigate(screen.route)
     }
 
@@ -91,60 +92,49 @@ fun rememberJetcasterAppState(
 
 sealed interface Screen {
     val route: String
-    val index: Int
 
     data object Discover : Screen {
         override val route = "/discover"
-        override val index = 0
     }
 
     data object Library : Screen {
-        override val route = "library"
-        override val index = 1
+        override val route = "/library"
     }
 
     data object Search : Screen {
-        override val route = "search"
-        override val index = 2
+        override val route = "/search"
     }
 
     data object Profile : Screen {
-        override val route = "profile"
-        override val index = 3
+        override val route = "/profile"
     }
 
     data object Settings : Screen {
         override val route: String = "settings"
-        override val index = 4
     }
 
     data class Podcast(private val podcastUri: String) : Screen {
         override val route = "$ROOT/$podcastUri"
-        override val index = Companion.index
 
         companion object : Screen {
-            private const val ROOT = "podcast"
+            private const val ROOT = "/podcast"
             const val PARAMETER_NAME = "podcastUri"
             override val route = "$ROOT/{$PARAMETER_NAME}"
-            override val index = 5
         }
     }
 
     data class Episode(private val episodeUri: String) : Screen {
 
         override val route: String = "$ROOT/$episodeUri"
-        override val index = Companion.index
 
         companion object : Screen {
-            private const val ROOT = "episode"
+            private const val ROOT = "/episode"
             const val PARAMETER_NAME = "episodeUri"
             override val route = "$ROOT/{$PARAMETER_NAME}"
-            override val index = 6
         }
     }
 
     data object Player : Screen {
         override val route = "player"
-        override val index = 7
     }
 }

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
@@ -22,15 +22,21 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.tv.foundation.lazy.list.TvLazyColumn
 import androidx.tv.foundation.lazy.list.TvLazyListState
 import androidx.tv.foundation.lazy.list.TvLazyRow
-import androidx.tv.foundation.lazy.list.items
+import androidx.tv.foundation.lazy.list.itemsIndexed
 import androidx.tv.foundation.lazy.list.rememberTvLazyListState
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
@@ -79,7 +85,6 @@ internal fun Catalog(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PodcastSection(
     podcastList: PodcastList,
@@ -94,12 +99,10 @@ private fun PodcastSection(
         PodcastRow(
             podcastList = podcastList,
             onPodcastSelected = onPodcastSelected,
-            modifier = Modifier.focusRestorer()
         )
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun LatestEpisodeSection(
     episodeList: EpisodeList,
@@ -114,7 +117,6 @@ private fun LatestEpisodeSection(
         EpisodeRow(
             playerEpisodeList = episodeList,
             onSelected = onEpisodeSelected,
-            modifier = Modifier.focusRestorer()
         )
     }
 }
@@ -139,6 +141,7 @@ private fun Section(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PodcastRow(
     podcastList: PodcastList,
@@ -148,16 +151,40 @@ private fun PodcastRow(
     horizontalArrangement: Arrangement.Horizontal =
         Arrangement.spacedBy(JetcasterAppDefaults.gap.podcastRow),
 ) {
+    val (focusRequester, firstItem) = remember { FocusRequester.createRefs() }
+    var previousPodcastListHash by remember { mutableIntStateOf(podcastList.hashCode()) }
+    val isSamePodcastList = previousPodcastListHash == podcastList.hashCode()
+
     TvLazyRow(
         contentPadding = contentPadding,
         horizontalArrangement = horizontalArrangement,
-        modifier = modifier,
+        modifier = modifier
+            .focusRequester(focusRequester)
+            .focusProperties {
+                exit = {
+                    previousPodcastListHash = podcastList.hashCode()
+                    focusRequester.saveFocusedChild()
+                    FocusRequester.Default
+                }
+                enter = {
+                    if (isSamePodcastList && focusRequester.restoreFocusedChild()) {
+                        FocusRequester.Cancel
+                    } else {
+                        firstItem
+                    }
+                }
+            },
     ) {
-        items(podcastList) {
+        itemsIndexed(podcastList){index, podcastInfo ->
+            val cardModifier = if(index == 0) {
+                Modifier.focusRequester(firstItem)
+            }else{
+                Modifier
+            }
             PodcastCard(
-                podcastInfo = it,
-                onClick = { onPodcastSelected(it) },
-                modifier = Modifier.width(JetcasterAppDefaults.cardWidth.medium)
+                podcastInfo = podcastInfo,
+                onClick = { onPodcastSelected(podcastInfo) },
+                modifier = cardModifier.width(JetcasterAppDefaults.cardWidth.medium)
             )
         }
     }

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
@@ -175,10 +175,10 @@ private fun PodcastRow(
                 }
             },
     ) {
-        itemsIndexed(podcastList){index, podcastInfo ->
-            val cardModifier = if(index == 0) {
+        itemsIndexed(podcastList) { index, podcastInfo ->
+            val cardModifier = if (index == 0) {
                 Modifier.focusRequester(firstItem)
-            }else{
+            } else {
                 Modifier
             }
             PodcastCard(

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/podcast/PodcastDetailsScreen.kt
@@ -74,14 +74,14 @@ import com.example.jetcaster.tv.ui.component.TwoColumn
 import com.example.jetcaster.tv.ui.theme.JetcasterAppDefaults
 
 @Composable
-fun PodcastScreen(
+fun PodcastDetailsScreen(
     backToHomeScreen: () -> Unit,
     playEpisode: (PlayerEpisode) -> Unit,
     showEpisodeDetails: (PlayerEpisode) -> Unit,
     modifier: Modifier = Modifier,
-    podcastScreenViewModel: PodcastScreenViewModel = hiltViewModel(),
+    podcastDetailsScreenViewModel: PodcastDetailsScreenViewModel = hiltViewModel(),
 ) {
-    val uiState by podcastScreenViewModel.uiStateFlow.collectAsState()
+    val uiState by podcastDetailsScreenViewModel.uiStateFlow.collectAsState()
     when (val s = uiState) {
         PodcastScreenUiState.Loading -> Loading(modifier = modifier)
         PodcastScreenUiState.Error -> ErrorState(backToHome = backToHomeScreen, modifier = modifier)
@@ -89,13 +89,13 @@ fun PodcastScreen(
             podcastInfo = s.podcastInfo,
             episodeList = s.episodeList,
             isSubscribed = s.isSubscribed,
-            subscribe = podcastScreenViewModel::subscribe,
-            unsubscribe = podcastScreenViewModel::unsubscribe,
+            subscribe = podcastDetailsScreenViewModel::subscribe,
+            unsubscribe = podcastDetailsScreenViewModel::unsubscribe,
             playEpisode = {
-                podcastScreenViewModel.play(it)
+                podcastDetailsScreenViewModel.play(it)
                 playEpisode(it)
             },
-            enqueue = podcastScreenViewModel::enqueue,
+            enqueue = podcastDetailsScreenViewModel::enqueue,
             showEpisodeDetails = showEpisodeDetails,
         )
     }

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/podcast/PodcastDetailsScreenViewModel.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/podcast/PodcastDetailsScreenViewModel.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
-class PodcastScreenViewModel @Inject constructor(
+class PodcastDetailsScreenViewModel @Inject constructor(
     handle: SavedStateHandle,
     private val podcastStore: PodcastStore,
     episodeStore: EpisodeStore,


### PR DESCRIPTION
This pull request fixes the following focus issues:

- The item for the current screen does not got focused when users move the d-pad focus to the NavigationDrawer
- The app crashes when users are moving d-pad focus to the podcast list from the tab item if the podcast list for the previous category is longer than current category's one
- D-pad focus moves to the different component according to the selected episode in the queue on the player screen 