### PR TITLE
[Jetcaster] Fix crash bug on TV app

### DIFF
--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
@@ -16,6 +16,7 @@
 
 package com.example.jetcaster.tv.ui
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -32,9 +33,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.focusTarget
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -61,14 +61,14 @@ fun JetcasterApp(jetcasterAppState: JetcasterAppState = rememberJetcasterAppStat
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-private fun WithGlobalNavigation(
+private fun GlobalNavigationContainer(
     jetcasterAppState: JetcasterAppState,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
     val (discover, library) = remember { FocusRequester.createRefs() }
     val currentRoute
-        by jetcasterAppState.currentRouteFlow.collectAsStateWithLifecycle(initialValue = null)
+            by jetcasterAppState.currentRouteFlow.collectAsStateWithLifecycle(initialValue = null)
 
     NavigationDrawer(
         drawerContent = {
@@ -76,16 +76,16 @@ private fun WithGlobalNavigation(
             Column(
                 modifier = Modifier
                     .padding(JetcasterAppDefaults.overScanMargin.drawer.intoPaddingValues())
-                    .focusTarget()
-                    .focusProperties {
-                        enter = {
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
                             when (currentRoute) {
                                 Screen.Discover.route -> discover
                                 Screen.Library.route -> library
                                 else -> FocusRequester.Default
-                            }
+                            }.requestFocus()
                         }
                     }
+                    .focusable()
             ) {
                 NavigationDrawerItem(
                     selected = isClosed && currentRoute == Screen.Profile.route,
@@ -145,7 +145,7 @@ private fun WithGlobalNavigation(
 private fun Route(jetcasterAppState: JetcasterAppState) {
     NavHost(navController = jetcasterAppState.navHostController, Screen.Discover.route) {
         composable(Screen.Discover.route) {
-            WithGlobalNavigation(jetcasterAppState = jetcasterAppState) {
+            GlobalNavigationContainer(jetcasterAppState = jetcasterAppState) {
                 DiscoverScreen(
                     showPodcastDetails = {
                         jetcasterAppState.showPodcastDetails(it.uri)
@@ -161,7 +161,7 @@ private fun Route(jetcasterAppState: JetcasterAppState) {
         }
 
         composable(Screen.Library.route) {
-            WithGlobalNavigation(jetcasterAppState = jetcasterAppState) {
+            GlobalNavigationContainer(jetcasterAppState = jetcasterAppState) {
                 LibraryScreen(
                     navigateToDiscover = jetcasterAppState::navigateToDiscover,
                     showPodcastDetails = {

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
@@ -68,7 +68,7 @@ private fun GlobalNavigationContainer(
 ) {
     val (discover, library) = remember { FocusRequester.createRefs() }
     val currentRoute
-            by jetcasterAppState.currentRouteFlow.collectAsStateWithLifecycle(initialValue = null)
+        by jetcasterAppState.currentRouteFlow.collectAsStateWithLifecycle(initialValue = null)
 
     NavigationDrawer(
         drawerContent = {

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/player/PlayerScreen.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/player/PlayerScreen.kt
@@ -77,9 +77,9 @@ import com.example.jetcaster.tv.ui.component.RewindButton
 import com.example.jetcaster.tv.ui.component.Seekbar
 import com.example.jetcaster.tv.ui.component.SkipButton
 import com.example.jetcaster.tv.ui.theme.JetcasterAppDefaults
+import java.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.time.Duration
 
 @Composable
 fun PlayerScreen(

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/player/PlayerScreen.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/player/PlayerScreen.kt
@@ -17,6 +17,7 @@
 package com.example.jetcaster.tv.ui.player
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,10 +40,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.BlendMode
@@ -76,9 +77,9 @@ import com.example.jetcaster.tv.ui.component.RewindButton
 import com.example.jetcaster.tv.ui.component.Seekbar
 import com.example.jetcaster.tv.ui.component.SkipButton
 import com.example.jetcaster.tv.ui.theme.JetcasterAppDefaults
-import java.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.time.Duration
 
 @Composable
 fun PlayerScreen(
@@ -205,7 +206,6 @@ private fun EpisodePlayerWithBackground(
             contentPadding = JetcasterAppDefaults.overScanMargin.player.copy(top = 0.dp)
                 .intoPaddingValues(),
             offset = DpOffset(0.dp, 136.dp),
-            previousComponent = episodePlayer
         )
     }
 }
@@ -288,6 +288,7 @@ private fun EpisodeControl(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PlayerControl(
     isPlaying: Boolean,
@@ -302,17 +303,27 @@ private fun PlayerControl(
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
+    val playPauseButton = remember { FocusRequester() }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(JetcasterAppDefaults.gap.item),
         modifier = modifier,
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(
                 JetcasterAppDefaults.gap.default,
                 Alignment.CenterHorizontally
             ),
             verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .onFocusChanged {
+                    if (it.isFocused) {
+                        playPauseButton.requestFocus()
+                    }
+                }
+                .focusable(),
         ) {
             PreviousButton(
                 onClick = previous,
@@ -333,7 +344,7 @@ private fun PlayerControl(
                 },
                 modifier = Modifier
                     .size(JetcasterAppDefaults.iconButtonSize.large.intoDpSize())
-                    .focusRequester(focusRequester)
+                    .focusRequester(playPauseButton)
             )
             SkipButton(
                 onClick = skip,
@@ -421,6 +432,7 @@ private fun NoEpisodeInQueue(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PlayerQueueOverlay(
     playerEpisodeList: EpisodeList,
@@ -437,7 +449,6 @@ private fun PlayerQueueOverlay(
         drawRect(brush, blendMode = BlendMode.Multiply)
     },
     offset: DpOffset = DpOffset.Zero,
-    previousComponent: FocusRequester = FocusRequester.Default,
 ) {
     var hasFocus by remember { mutableStateOf(false) }
     val actualOffset = if (hasFocus) {
@@ -463,11 +474,6 @@ private fun PlayerQueueOverlay(
             modifier = Modifier
                 .offset(actualOffset.x, actualOffset.y)
                 .onFocusChanged { hasFocus = it.hasFocus }
-                .focusProperties {
-                    previous = previousComponent
-                    next = previous
-                    up = previous
-                },
         )
     }
 }


### PR DESCRIPTION
This PR fixes a crash bug happening on TV app: the `EpisodeRow` in the discovery screen can crash the app when users are moving d-pad focus when no visible item in the `EpisodeRow`. 