### PR TITLE
[DO NOT MERGE] Sharing a repro scenario for a leak related to Recomposer.snapshotInvalidations

### DIFF
--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -112,6 +112,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.googlefonts)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+    debugImplementation("com.squareup.leakcanary:leakcanary-android:3.0-alpha-7")
+
 
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.core)
@@ -121,4 +123,5 @@ dependencies {
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation("com.squareup.leakcanary:leakcanary-android-instrumentation:3.0-alpha-7")
 }

--- a/Jetchat/app/src/androidTest/java/com/example/compose/jetchat/RecomposerLeakTest.kt
+++ b/Jetchat/app/src/androidTest/java/com/example/compose/jetchat/RecomposerLeakTest.kt
@@ -1,0 +1,75 @@
+package com.example.compose.jetchat
+
+import android.app.Activity
+import android.app.Application
+import android.app.Application.ActivityLifecycleCallbacks
+import android.os.Bundle
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import leakcanary.LeakAssertions
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+
+class RecomposerLeakTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<NavActivity>()
+
+  @Test
+  fun app_launches() {
+    ActivityScenario.launch(LeakingActivity::class.java)
+
+    val latchWaitingForNextActivityDestroy = createLatchWaitingForNextActivityDestroy()
+
+    composeTestRule
+      .onNodeWithText("Finish")
+      .performClick()
+
+    latchWaitingForNextActivityDestroy.await()
+
+    // Uncommenting "composeTestRule.waitForIdle()" fixes the leak and makes the test pass, as this
+    // has the side effect of clearing Recomposer.snapshotInvalidations.
+
+    // composeTestRule.waitForIdle()
+
+    // This check fails, LeakingActivity has been finished and destroyed, but it cannot be
+    // garbage collected because its held through the lambda passed to ComposeView.setContent()
+    // which itself is held by Recomposer.snapshotInvalidations.
+    LeakAssertions.assertNoLeaks()
+  }
+
+  private fun createLatchWaitingForNextActivityDestroy(): CountDownLatch {
+    val latch = CountDownLatch(1)
+
+    val applicationContext =
+      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+    applicationContext.registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
+      override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?
+      ) = Unit
+
+      override fun onActivityStarted(activity: Activity) = Unit
+
+      override fun onActivityResumed(activity: Activity) = Unit
+
+      override fun onActivityPaused(activity: Activity) = Unit
+
+      override fun onActivityStopped(activity: Activity) = Unit
+
+      override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle
+      ) = Unit
+
+      override fun onActivityDestroyed(activity: Activity) {
+        latch.countDown()
+      }
+    })
+    return latch
+  }
+}

--- a/Jetchat/app/src/main/AndroidManifest.xml
+++ b/Jetchat/app/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -33,6 +32,11 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".LeakingActivity"
+            android:exported="true">
         </activity>
 
     </application>

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/LeakingActivity.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/LeakingActivity.kt
@@ -1,0 +1,33 @@
+package com.example.compose.jetchat
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.ui.platform.ComposeView
+
+class LeakingActivity : AppCompatActivity() {
+
+  private lateinit var composeView: ComposeView
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    composeView = ComposeView(this)
+    resetContent()
+    setContentView(composeView)
+  }
+
+  private fun resetContent() {
+    composeView.setContent {
+      Button(onClick = {
+        // The lambda passed to ComposeView.setContent() is added to Recomposer.snapshotInvalidations
+        // This wouldn't be a problem when the Recomposer is per activity. However, in test,
+        // there is a single shared Recomposer across all activities.
+        resetContent()
+        finish()
+      }) {
+        Text("Finish")
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm opening this just as a demo, I'll close the PR immediately after, this isn't meant to be merged.

The core of the issue is that large object graphs can be retained by `Recomposer.snapshotInvalidations` until the next recomposition. When an activity gets destroyed, there's no more recomposition there, so `Recomposer.snapshotInvalidations` isn't cleared until something else needs recomposing. This is a problem in Compose tests where the Recomposer is a shared instance and a singleton.

This issue has been impacting our UI tests more and more as we migrated to Compose, it's been 2 years now, and we've had to progressively disable leak detection in more and more tests as this kept firing and making tests fail. I only finally figured it out.

While there seems to be a workaround (composeTestRule.waitForIdle()), ideally we wouldn't need to do this.

I'll check in with folks if this is worth filing.