### PR TITLE
Experimenting with safe versions of Shared element modifiers.

### DIFF
--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/JetsnackApp.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/JetsnackApp.kt
@@ -55,6 +55,8 @@ import com.example.jetsnack.ui.snackdetail.SnackDetail
 import com.example.jetsnack.ui.snackdetail.nonSpatialExpressiveSpring
 import com.example.jetsnack.ui.snackdetail.spatialExpressiveSpring
 import com.example.jetsnack.ui.theme.JetsnackTheme
+import com.example.jetsnack.ui.utils.safeAnimateEnterExit
+import com.example.jetsnack.ui.utils.safeRenderInSharedTransitionScopeOverlay
 
 @Preview
 @Composable
@@ -62,9 +64,9 @@ fun JetsnackApp() {
     JetsnackTheme {
         val jetsnackNavController = rememberJetsnackNavController()
         SharedTransitionLayout {
-            CompositionLocalProvider(
+            /*CompositionLocalProvider(
                 LocalSharedTransitionScope provides this
-            ) {
+            ) {*/
                 NavHost(
                     navController = jetsnackNavController.navController,
                     startDestination = MainDestinations.HOME_ROUTE
@@ -97,7 +99,7 @@ fun JetsnackApp() {
                         )
                     }
                 }
-            }
+           /* }*/
         }
     }
 }
@@ -110,24 +112,24 @@ fun MainContainer(
     val jetsnackScaffoldState = rememberJetsnackScaffoldState()
     val nestedNavController = rememberJetsnackNavController()
     val navBackStackEntry by nestedNavController.navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
+    val currentRoute = navBackStackEntry?.destination?.route/*
     val sharedTransitionScope = LocalSharedTransitionScope.current
         ?: throw IllegalStateException("No SharedElementScope found")
     val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
-        ?: throw IllegalStateException("No SharedElementScope found")
+        ?: throw IllegalStateException("No SharedElementScope found")*/
     JetsnackScaffold(
-        bottomBar = {
-            with(animatedVisibilityScope) {
-                with(sharedTransitionScope) {
+        bottomBar = {/*
+            with(animatedVisibilityScope) {*//*
+                with(sharedTransitionScope) {*/
                     JetsnackBottomBar(
                         tabs = HomeSections.entries.toTypedArray(),
                         currentRoute = currentRoute ?: HomeSections.FEED.route,
                         navigateToRoute = nestedNavController::navigateToBottomBarRoute,
                         modifier = Modifier
-                            .renderInSharedTransitionScopeOverlay(
+                            .safeRenderInSharedTransitionScopeOverlay(
                                 zIndexInOverlay = 1f,
                             )
-                            .animateEnterExit(
+                            .safeAnimateEnterExit(
                                 enter = fadeIn(nonSpatialExpressiveSpring()) + slideInVertically(
                                     spatialExpressiveSpring()
                                 ) {
@@ -140,8 +142,8 @@ fun MainContainer(
                                 }
                             )
                     )
-                }
-            }
+               /* }
+            }*/
         },
         modifier = modifier,
         snackbarHost = {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Snacks.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Snacks.kt
@@ -88,7 +88,9 @@ import com.example.jetsnack.ui.SnackSharedElementType
 import com.example.jetsnack.ui.snackdetail.nonSpatialExpressiveSpring
 import com.example.jetsnack.ui.snackdetail.snackDetailBoundsTransform
 import com.example.jetsnack.ui.theme.JetsnackTheme
+import com.example.jetsnack.ui.utils.ShapeBasedClip
 import com.example.jetsnack.ui.utils.mirroringIcon
+import com.example.jetsnack.ui.utils.safeSharedBounds
 
 private val HighlightCardWidth = 170.dp
 private val HighlightCardPadding = 16.dp
@@ -216,12 +218,12 @@ fun SnackItem(
         )
 
     ) {
-        val sharedTransitionScope = LocalSharedTransitionScope.current
+       /* val sharedTransitionScope = LocalSharedTransitionScope.current
             ?: throw IllegalStateException("No sharedTransitionScope found")
         val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
             ?: throw IllegalStateException("No animatedVisibilityScope found")
 
-        with(sharedTransitionScope) {
+        with(sharedTransitionScope) {*/
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
@@ -236,15 +238,12 @@ fun SnackItem(
                     contentDescription = null,
                     modifier = Modifier
                         .size(120.dp)
-                        .sharedBounds(
-                            rememberSharedContentState(
-                                key = SnackSharedElementKey(
-                                    snackId = snack.id,
-                                    origin = snackCollectionId.toString(),
-                                    type = SnackSharedElementType.Image
-                                )
+                        .safeSharedBounds(
+                            key = SnackSharedElementKey(
+                                snackId = snack.id,
+                                origin = snackCollectionId.toString(),
+                                type = SnackSharedElementType.Image
                             ),
-                            animatedVisibilityScope = animatedVisibilityScope,
                             boundsTransform = snackDetailBoundsTransform
                         )
                 )
@@ -255,15 +254,12 @@ fun SnackItem(
                     modifier = Modifier
                         .padding(top = 8.dp)
                         .wrapContentWidth()
-                        .sharedBounds(
-                            rememberSharedContentState(
-                                key = SnackSharedElementKey(
-                                    snackId = snack.id,
-                                    origin = snackCollectionId.toString(),
-                                    type = SnackSharedElementType.Title
-                                )
+                        .safeSharedBounds(
+                            key = SnackSharedElementKey(
+                                snackId = snack.id,
+                                origin = snackCollectionId.toString(),
+                                type = SnackSharedElementType.Title
                             ),
-                            animatedVisibilityScope = animatedVisibilityScope,
                             enter = fadeIn(nonSpatialExpressiveSpring()),
                             exit = fadeOut(nonSpatialExpressiveSpring()),
                             resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds(),
@@ -272,7 +268,6 @@ fun SnackItem(
                 )
             }
         }
-    }
 }
 
 @Composable
@@ -285,174 +280,160 @@ private fun HighlightSnackItem(
     scrollProvider: () -> Float,
     modifier: Modifier = Modifier
 ) {
-    val sharedTransitionScope = LocalSharedTransitionScope.current
-        ?: throw IllegalStateException("No Scope found")
-    val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
-        ?: throw IllegalStateException("No Scope found")
-    with(sharedTransitionScope) {
-        val roundedCornerAnimation by animatedVisibilityScope.transition
-            .animateDp(label = "rounded corner") { enterExit: EnterExitState ->
-                when (enterExit) {
-                    EnterExitState.PreEnter -> 0.dp
-                    EnterExitState.Visible -> 20.dp
-                    EnterExitState.PostExit -> 20.dp
-                }
+    /* val sharedTransitionScope = LocalSharedTransitionScope.current
+         ?: throw IllegalStateException("No Scope found")
+     val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
+         ?: throw IllegalStateException("No Scope found")*/
+    /* with(sharedTransitionScope) {*/
+    /* todo figure out how to tie into transition scope if its null
+    val roundedCornerAnimation by animatedVisibilityScope.transition
+        .animateDp(label = "rounded corner") { enterExit: EnterExitState ->
+            when (enterExit) {
+                EnterExitState.PreEnter -> 0.dp
+                EnterExitState.Visible -> 20.dp
+                EnterExitState.PostExit -> 20.dp
             }
-        JetsnackCard(
-            elevation = 0.dp,
-            shape = RoundedCornerShape(roundedCornerAnimation),
-            modifier = modifier
-                .padding(bottom = 16.dp)
-                .sharedBounds(
-                    sharedContentState = rememberSharedContentState(
-                        key = SnackSharedElementKey(
-                            snackId = snack.id,
-                            origin = snackCollectionId.toString(),
-                            type = SnackSharedElementType.Bounds
-                        )
-                    ),
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    boundsTransform = snackDetailBoundsTransform,
-                    clipInOverlayDuringTransition = OverlayClip(
-                        RoundedCornerShape(
-                            roundedCornerAnimation
-                        )
-                    ),
-                    enter = fadeIn(),
-                    exit = fadeOut()
-                )
-                .size(
-                    width = HighlightCardWidth,
-                    height = 250.dp
-                )
-                .border(
-                    1.dp,
-                    JetsnackTheme.colors.uiBorder.copy(alpha = 0.12f),
-                    RoundedCornerShape(roundedCornerAnimation)
-                )
+        }*/
+    JetsnackCard(
+        elevation = 0.dp,
+        shape = RoundedCornerShape(20.dp),
+        modifier = modifier
+            .padding(bottom = 16.dp)
+            .safeSharedBounds(
+                key = SnackSharedElementKey(
+                    snackId = snack.id,
+                    origin = snackCollectionId.toString(),
+                    type = SnackSharedElementType.Bounds
+                ),
+                boundsTransform = snackDetailBoundsTransform,
+                clipInOverlayDuringTransition = ShapeBasedClip(
+                    RoundedCornerShape(
+                        20.dp
+                    )
+                ),
+                enter = fadeIn(),
+                exit = fadeOut()
+            )
+            .size(
+                width = HighlightCardWidth,
+                height = 250.dp
+            )
+            .border(
+                1.dp,
+                JetsnackTheme.colors.uiBorder.copy(alpha = 0.12f),
+                RoundedCornerShape(20.dp)
+            )
+
+    ) {
+        Column(
+            modifier = Modifier
+                .clickable(onClick = {
+                    onSnackClick(
+                        snack.id,
+                        snackCollectionId.toString()
+                    )
+                })
+                .fillMaxSize()
 
         ) {
-            Column(
+            Box(
                 modifier = Modifier
-                    .clickable(onClick = {
-                        onSnackClick(
-                            snack.id,
-                            snackCollectionId.toString()
-                        )
-                    })
-                    .fillMaxSize()
-
+                    .height(160.dp)
+                    .fillMaxWidth()
             ) {
                 Box(
                     modifier = Modifier
-                        .height(160.dp)
+                        .safeSharedBounds(
+                            key = SnackSharedElementKey(
+                                snackId = snack.id,
+                                origin = snackCollectionId.toString(),
+                                type = SnackSharedElementType.Background
+                            ),
+                            boundsTransform = snackDetailBoundsTransform,
+                            enter = fadeIn(nonSpatialExpressiveSpring()),
+                            exit = fadeOut(nonSpatialExpressiveSpring()),
+                            resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds()
+                        )
+                        .height(100.dp)
                         .fillMaxWidth()
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .sharedBounds(
-                                rememberSharedContentState(
-                                    key = SnackSharedElementKey(
-                                        snackId = snack.id,
-                                        origin = snackCollectionId.toString(),
-                                        type = SnackSharedElementType.Background
-                                    )
-                                ),
-                                animatedVisibilityScope = animatedVisibilityScope,
-                                boundsTransform = snackDetailBoundsTransform,
-                                enter = fadeIn(nonSpatialExpressiveSpring()),
-                                exit = fadeOut(nonSpatialExpressiveSpring()),
-                                resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds()
-                            )
-                            .height(100.dp)
-                            .fillMaxWidth()
-                            .offsetGradientBackground(
-                                colors = gradient,
-                                width = {
-                                    // The Cards show a gradient which spans 6 cards and
-                                    // scrolls with parallax.
-                                    6 * cardWidthWithPaddingPx
-                                },
-                                offset = {
-                                    val left = index * cardWidthWithPaddingPx
-                                    val gradientOffset = left - (scrollProvider() / 3f)
-                                    gradientOffset
-                                }
-                            )
-                    )
-
-                    SnackImage(
-                        imageRes = snack.imageRes,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .sharedBounds(
-                                rememberSharedContentState(
-                                    key = SnackSharedElementKey(
-                                        snackId = snack.id,
-                                        origin = snackCollectionId.toString(),
-                                        type = SnackSharedElementType.Image
-                                    )
-                                ),
-                                animatedVisibilityScope = animatedVisibilityScope,
-                                exit = fadeOut(nonSpatialExpressiveSpring()),
-                                enter = fadeIn(nonSpatialExpressiveSpring()),
-                                boundsTransform = snackDetailBoundsTransform
-                            )
-                            .align(Alignment.BottomCenter)
-                            .size(120.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = snack.name,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.h6,
-                    color = JetsnackTheme.colors.textSecondary,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .sharedBounds(
-                            rememberSharedContentState(
-                                key = SnackSharedElementKey(
-                                    snackId = snack.id,
-                                    origin = snackCollectionId.toString(),
-                                    type = SnackSharedElementType.Title
-                                )
-                            ),
-                            animatedVisibilityScope = animatedVisibilityScope,
-                            enter = fadeIn(nonSpatialExpressiveSpring()),
-                            exit = fadeOut(nonSpatialExpressiveSpring()),
-                            boundsTransform = snackDetailBoundsTransform,
-                            resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds()
+                        .offsetGradientBackground(
+                            colors = gradient,
+                            width = {
+                                // The Cards show a gradient which spans 6 cards and
+                                // scrolls with parallax.
+                                6 * cardWidthWithPaddingPx
+                            },
+                            offset = {
+                                val left = index * cardWidthWithPaddingPx
+                                val gradientOffset = left - (scrollProvider() / 3f)
+                                gradientOffset
+                            }
                         )
-                        .wrapContentWidth()
                 )
-                Spacer(modifier = Modifier.height(4.dp))
 
-                Text(
-                    text = snack.tagline,
-                    style = MaterialTheme.typography.body1,
-                    color = JetsnackTheme.colors.textHelp,
+                SnackImage(
+                    imageRes = snack.imageRes,
+                    contentDescription = null,
                     modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .sharedBounds(
-                            rememberSharedContentState(
-                                key = SnackSharedElementKey(
-                                    snackId = snack.id,
-                                    origin = snackCollectionId.toString(),
-                                    type = SnackSharedElementType.Tagline
-                                )
+                        .safeSharedBounds(
+                            key = SnackSharedElementKey(
+                                snackId = snack.id,
+                                origin = snackCollectionId.toString(),
+                                type = SnackSharedElementType.Image
                             ),
-                            animatedVisibilityScope = animatedVisibilityScope,
-                            enter = fadeIn(nonSpatialExpressiveSpring()),
                             exit = fadeOut(nonSpatialExpressiveSpring()),
-                            boundsTransform = snackDetailBoundsTransform,
-                            resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds()
+                            enter = fadeIn(nonSpatialExpressiveSpring()),
+                            boundsTransform = snackDetailBoundsTransform
                         )
-                        .wrapContentWidth()
+                        .align(Alignment.BottomCenter)
+                        .size(120.dp)
                 )
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = snack.name,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.h6,
+                color = JetsnackTheme.colors.textSecondary,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .safeSharedBounds(
+                        key = SnackSharedElementKey(
+                            snackId = snack.id,
+                            origin = snackCollectionId.toString(),
+                            type = SnackSharedElementType.Title
+                        ),
+                        enter = fadeIn(nonSpatialExpressiveSpring()),
+                        exit = fadeOut(nonSpatialExpressiveSpring()),
+                        boundsTransform = snackDetailBoundsTransform,
+                        resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds()
+                    )
+                    .wrapContentWidth()
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = snack.tagline,
+                style = MaterialTheme.typography.body1,
+                color = JetsnackTheme.colors.textHelp,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .safeSharedBounds(
+
+                        key = SnackSharedElementKey(
+                            snackId = snack.id,
+                            origin = snackCollectionId.toString(),
+                            type = SnackSharedElementType.Tagline
+                        ),
+                        enter = fadeIn(nonSpatialExpressiveSpring()),
+                        exit = fadeOut(nonSpatialExpressiveSpring()),
+                        boundsTransform = snackDetailBoundsTransform,
+                        resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds()
+                    )
+                    .wrapContentWidth()
+            )
         }
     }
 }
@@ -498,7 +479,7 @@ fun SnackImage(
 @Composable
 fun SnackCardPreview() {
     val snack = snacks.first()
-    JetsnackPreviewWrapper {
+    JetsnackTheme {
         HighlightSnackItem(
             snackCollectionId = 1,
             snack = snack,

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/DestinationBar.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/DestinationBar.kt
@@ -52,20 +52,22 @@ import com.example.jetsnack.ui.components.JetsnackPreviewWrapper
 import com.example.jetsnack.ui.snackdetail.spatialExpressiveSpring
 import com.example.jetsnack.ui.theme.AlphaNearOpaque
 import com.example.jetsnack.ui.theme.JetsnackTheme
+import com.example.jetsnack.ui.utils.safeAnimateEnterExit
+import com.example.jetsnack.ui.utils.safeRenderInSharedTransitionScopeOverlay
 import java.lang.IllegalStateException
 
 @Composable
 fun DestinationBar(modifier: Modifier = Modifier) {
-    val sharedElementScope =
+   /* val sharedElementScope =
         LocalSharedTransitionScope.current ?: throw IllegalStateException("No shared element scope")
     val navAnimatedScope =
-        LocalNavAnimatedVisibilityScope.current ?: throw IllegalStateException("No nav scope")
-    with(sharedElementScope) {
-        with(navAnimatedScope) {
+        LocalNavAnimatedVisibilityScope.current ?: throw IllegalStateException("No nav scope")*/
+ /*   with(sharedElementScope) {
+        with(navAnimatedScope) {*/
             Column(
                 modifier = modifier
-                    .renderInSharedTransitionScopeOverlay()
-                    .animateEnterExit(
+                    .safeRenderInSharedTransitionScopeOverlay()
+                    .safeAnimateEnterExit(
                         enter = slideInVertically(spatialExpressiveSpring()) { -it },
                         exit = slideOutVertically(spatialExpressiveSpring()) { -it }
                     )
@@ -102,8 +104,8 @@ fun DestinationBar(modifier: Modifier = Modifier) {
                 }
                 JetsnackDivider()
             }
-        }
-    }
+      /*  }
+    }*/
 }
 
 @Preview("default")

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/utils/SafeSharedElement.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/utils/SafeSharedElement.kt
@@ -1,0 +1,196 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
+package com.example.jetsnack.ui.utils
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.SharedTransitionScope.OverlayClip
+import androidx.compose.animation.SharedTransitionScope.PlaceHolderSize
+import androidx.compose.animation.SharedTransitionScope.PlaceHolderSize.Companion.contentSize
+import androidx.compose.animation.SharedTransitionScope.ResizeMode
+import androidx.compose.animation.SharedTransitionScope.ResizeMode.Companion.ScaleToBounds
+import androidx.compose.animation.SharedTransitionScope.SharedContentState
+import androidx.compose.animation.core.Spring.StiffnessMediumLow
+import androidx.compose.animation.core.VisibilityThreshold
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import com.example.jetsnack.ui.LocalNavAnimatedVisibilityScope
+import com.example.jetsnack.ui.LocalSharedTransitionScope
+
+
+private val DefaultSpring = spring(
+    stiffness = StiffnessMediumLow,
+    visibilityThreshold = Rect.VisibilityThreshold
+)
+
+private val DefaultBoundsTransform = BoundsTransform { _, _ -> DefaultSpring }
+
+private val ParentClip: OverlayClip =
+    object : OverlayClip {
+        override fun getClipPath(
+            state: SharedContentState,
+            bounds: Rect,
+            layoutDirection: LayoutDirection,
+            density: Density
+        ): Path? {
+            return state.parentSharedContentState?.clipPathInOverlay
+        }
+    }
+
+class ShapeBasedClip(
+    val clipShape: Shape
+) : OverlayClip {
+    private val path = Path()
+
+    override fun getClipPath(
+        state: SharedContentState,
+        bounds: Rect,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Path {
+        path.reset()
+        path.addOutline(
+            clipShape.createOutline(
+                bounds.size,
+                layoutDirection,
+                density
+            )
+        )
+        path.translate(bounds.topLeft)
+        return path
+    }
+}
+/**
+ * This modifier performs a NoOp when sharedTransitionScope or AnimatedVisibilityScope is null.
+ * And by default pulls the scopes from the Composition Locals [LocalSharedTransitionScope] and [LocalNavAnimatedVisibilityScope].
+ * Otherwise, it just calls [Modifier.sharedElement] with the provided parameters.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.safeSharedElement(
+    sharedTransitionScope: SharedTransitionScope? = LocalSharedTransitionScope.current,
+    key: Any,
+    // todo figure out how to allow this with null scope:
+    //  rememberSharedContentState requires a SharedTransitionScope
+    //state: SharedContentState,
+    animatedVisibilityScope: AnimatedVisibilityScope? = LocalNavAnimatedVisibilityScope.current,
+    boundsTransform: BoundsTransform = DefaultBoundsTransform,
+    placeHolderSize: PlaceHolderSize = contentSize,
+    renderInOverlayDuringTransition: Boolean = true,
+    zIndexInOverlay: Float = 0f,
+    clipInOverlayDuringTransition: OverlayClip = ParentClip
+): Modifier {
+    if (sharedTransitionScope == null
+        || animatedVisibilityScope == null
+    ) return this
+    with(sharedTransitionScope) {
+        return this@safeSharedElement then
+                Modifier.sharedElement(
+                    rememberSharedContentState(key = key),
+                    animatedVisibilityScope,
+                    boundsTransform,
+                    placeHolderSize,
+                    renderInOverlayDuringTransition,
+                    zIndexInOverlay,
+                    clipInOverlayDuringTransition
+                )
+    }
+}
+
+/**
+ * This modifier performs a NoOp when sharedTransitionScope or AnimatedVisibilityScope is null.
+ * And by default pulls the scopes from the Composition Locals [LocalSharedTransitionScope] and [LocalNavAnimatedVisibilityScope].
+ * Otherwise, it just calls [Modifier.sharedBounds] with the provided parameters.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.safeSharedBounds(
+    key: Any,
+    // todo figure out how to allow this with null scope:
+    //  rememberSharedContentState requires a SharedTransitionScope
+    //sharedContentState: SharedContentState,
+    sharedTransitionScope: SharedTransitionScope? = LocalSharedTransitionScope.current,
+    animatedVisibilityScope: AnimatedVisibilityScope? = LocalNavAnimatedVisibilityScope.current,
+    enter: EnterTransition = fadeIn(),
+    exit: ExitTransition = fadeOut(),
+    boundsTransform: BoundsTransform = DefaultBoundsTransform,
+    resizeMode: ResizeMode = ScaleToBounds(ContentScale.FillWidth, Center),
+    placeHolderSize: PlaceHolderSize = contentSize,
+    renderInOverlayDuringTransition: Boolean = true,
+    zIndexInOverlay: Float = 0f,
+    clipInOverlayDuringTransition: OverlayClip = ParentClip
+): Modifier {
+    if (sharedTransitionScope == null
+        || animatedVisibilityScope == null
+    ) return this
+    with(sharedTransitionScope) {
+        return this@safeSharedBounds then
+                Modifier.sharedBounds(
+                    rememberSharedContentState(key = key),
+                    animatedVisibilityScope,
+                    enter,
+                    exit,
+                    boundsTransform,
+                    resizeMode,
+                    placeHolderSize,
+                    renderInOverlayDuringTransition,
+                    zIndexInOverlay,
+                    clipInOverlayDuringTransition
+                )
+    }
+}
+@Composable
+fun Modifier.safeSkipToLookaheadSize(
+    sharedTransitionScope: SharedTransitionScope? = LocalSharedTransitionScope.current
+) : Modifier {
+    if (sharedTransitionScope == null) return this@safeSkipToLookaheadSize
+    with (sharedTransitionScope){
+        return this@safeSkipToLookaheadSize then Modifier.skipToLookaheadSize()
+    }
+}
+
+@Composable
+fun Modifier.safeAnimateEnterExit(enter: EnterTransition,
+                                  exit: ExitTransition,
+                                  label: String = "animateEnterExit") : Modifier {
+    val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current ?: return this@safeAnimateEnterExit
+    with (animatedVisibilityScope){
+        return this@safeAnimateEnterExit then Modifier.animateEnterExit(enter, exit, label)
+    }
+}
+private val DefaultClipInOverlayDuringTransition: (LayoutDirection, Density) -> Path? =
+    { _, _ -> null }
+
+@Composable
+fun Modifier.safeRenderInSharedTransitionScopeOverlay(
+    /* todo figure out how to safely provide the LocalTransitionScope here.
+    renderInOverlay: () -> Boolean = { LocalSharedTransitionScope.current?.isTransitionActive ?: false },*/
+    zIndexInOverlay: Float = 0f,
+    clipInOverlayDuringTransition: (LayoutDirection, Density) -> Path? =
+        DefaultClipInOverlayDuringTransition
+) : Modifier {
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+        ?: return this@safeRenderInSharedTransitionScopeOverlay
+    val renderInOverlay = { sharedTransitionScope.isTransitionActive }
+    with (sharedTransitionScope){
+        return this@safeRenderInSharedTransitionScopeOverlay then
+                Modifier.renderInSharedTransitionScopeOverlay(renderInOverlay,
+                    zIndexInOverlay,
+                    clipInOverlayDuringTransition)
+    }
+}


### PR DESCRIPTION
Sometimes your composables may be created from places that don't have a AnimatedContentScope or SharedTransitionScope - for instance if you are opening up your app from a notifcation. Instead of throwing an IllegalArgumentException in these cases, it'd be best if the shared element modifiers, just didn't do anything if the scopes are not present. 
This pull request creates new modifiers that wrap the shared element APIs, to skip their operation if the scopes are null. Modifiers such as: `Modifier.safeSharedElement()`, `Modifier.safeSharedBounds()`, `Modifier.safeSkipToLookaheadSize()`, `Modifier.safeRenderInSharedTransitionScope()`.

Please note: This is in no way a complete solution at present, this is an experiment and subject to change. Please do leave feedback if you'd like to see changes to shared element APIs based on this use case. 