### PR TITLE
[Jetcaster] Fix layout inconsistency in the discovery screen and the library screen

### DIFF
--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/JetcasterApp.kt
@@ -153,9 +153,7 @@ private fun Route(jetcasterAppState: JetcasterAppState) {
                     playEpisode = {
                         jetcasterAppState.playEpisode()
                     },
-                    modifier = Modifier
-                        .padding(JetcasterAppDefaults.overScanMargin.default.intoPaddingValues())
-                        .fillMaxSize()
+                    modifier = Modifier.fillMaxSize()
                 )
             }
         }
@@ -170,9 +168,7 @@ private fun Route(jetcasterAppState: JetcasterAppState) {
                     playEpisode = {
                         jetcasterAppState.playEpisode()
                     },
-                    modifier = Modifier
-                        .padding(JetcasterAppDefaults.overScanMargin.default.intoPaddingValues())
-                        .fillMaxSize()
+                    modifier = Modifier.fillMaxSize()
                 )
             }
         }

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/Catalog.kt
@@ -147,7 +147,7 @@ private fun PodcastRow(
     podcastList: PodcastList,
     onPodcastSelected: (PodcastInfo) -> Unit,
     modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(),
+    contentPadding: PaddingValues = JetcasterAppDefaults.padding.podcastRowContentPadding,
     horizontalArrangement: Arrangement.Horizontal =
         Arrangement.spacedBy(JetcasterAppDefaults.gap.podcastRow),
 ) {

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/EpisodeRow.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/component/EpisodeRow.kt
@@ -43,7 +43,7 @@ internal fun EpisodeRow(
     modifier: Modifier = Modifier,
     horizontalArrangement: Arrangement.Horizontal =
         Arrangement.spacedBy(JetcasterAppDefaults.gap.item),
-    contentPadding: PaddingValues = PaddingValues(),
+    contentPadding: PaddingValues = JetcasterAppDefaults.padding.episodeRowContentPadding,
     focusRequester: FocusRequester = remember { FocusRequester() },
     lazyListState: TvLazyListState = remember(playerEpisodeList) { TvLazyListState() }
 ) {

--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/theme/Space.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/theme/Space.kt
@@ -32,7 +32,7 @@ internal data object JetcasterAppDefaults {
 
 internal data class OverScanMarginSettings(
     val default: OverScanMargin = OverScanMargin(),
-    val catalog: OverScanMargin = OverScanMargin(start = 0.dp, end = 0.dp),
+    val catalog: OverScanMargin = OverScanMargin(end = 0.dp),
     val episode: OverScanMargin = OverScanMargin(start = 80.dp, end = 80.dp),
     val drawer: OverScanMargin = OverScanMargin(start = 0.dp, end = 0.dp),
     val podcast: OverScanMargin = OverScanMargin(
@@ -74,7 +74,9 @@ internal data class ThumbnailSize(
 
 internal data class PaddingSettings(
     val tab: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
-    val sectionTitle: PaddingValues = PaddingValues(bottom = 16.dp)
+    val sectionTitle: PaddingValues = PaddingValues(bottom = 16.dp),
+    val podcastRowContentPadding: PaddingValues = PaddingValues(horizontal = 5.dp),
+    val episodeRowContentPadding: PaddingValues = PaddingValues(horizontal = 5.dp),
 )
 
 internal data class GapSettings(


### PR DESCRIPTION
This pull request fixes layout inconsistency in the following screens of the TV app:

- The discovery screen
- The library screen
