### PR TITLE
Fix for status bar icon colors

### DIFF
--- a/JetLagged/app/src/main/java/com/example/jetlagged/MainActivity.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/MainActivity.kt
@@ -16,8 +16,10 @@
 
 package com.example.jetlagged
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -28,7 +30,9 @@ class MainActivity : ComponentActivity() {
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
+        )
         super.onCreate(savedInstanceState)
         setContent {
             val windowSizeClass = calculateWindowSizeClass(this)


### PR DESCRIPTION
JetLagged only supports a light theme, which means the status bar icons should always use a light theme (meaning they have to be dark). I added the statusBarStyle to the enableEdgeToEdge call to force a light theme. The bottom nav also needs to be fixed but that's more involved because every screen needs to have enough padding to push the content into view when scrolled.