### PR TITLE
Added window insets to the the main screen

### DIFF
--- a/JetLagged/app/src/main/java/com/example/jetlagged/JetLaggedScreen.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/JetLaggedScreen.kt
@@ -22,10 +22,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowColumn
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -67,9 +72,13 @@ fun JetLaggedScreen(
 
         val uiState =
             viewModel.uiState.collectAsStateWithLifecycle()
-
+        val insets = WindowInsets.safeDrawing.only(
+            WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal
+        )
         FlowRow(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(insets),
             horizontalArrangement = Arrangement.Center,
             verticalArrangement = Arrangement.Center,
             maxItemsInEachRow = 3


### PR DESCRIPTION
Since the headder and the body (FlowRow) are sibling elements, we have to explicitly exclude the top inset, which we get by combining the bottom and the sides (horizontal). Tested with all the developer options notch settings and with both gesture nav and 3 button nav.

I did not override the navigationBarStyle since the default actually seems to work well. With three button nav, it has a partially transparent light background that helps the buttons stand out when content is behind them. With gesture nav, the bar stands out enough on its own.

This fixes #1450.