### PR TITLE
Fixed spacing for floating toolbar + back support

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -16,10 +16,10 @@
 
 package com.example.jetnews.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -32,9 +32,10 @@ import androidx.navigation.compose.rememberNavController
 import com.example.jetnews.data.AppContainer
 import com.example.jetnews.ui.components.AppNavRail
 import com.example.jetnews.ui.theme.JetnewsTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun JetnewsApp(
     appContainer: AppContainer,
@@ -54,6 +55,12 @@ fun JetnewsApp(
 
         val isExpandedScreen = widthSizeClass == WindowWidthSizeClass.Expanded
         val sizeAwareDrawerState = rememberSizeAwareDrawerState(isExpandedScreen)
+
+        BackHandler(sizeAwareDrawerState.isOpen) {
+            coroutineScope.launch {
+                sizeAwareDrawerState.close()
+            }
+        }
 
         ModalNavigationDrawer(
             drawerContent = {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -32,8 +32,6 @@ import androidx.navigation.compose.rememberNavController
 import com.example.jetnews.data.AppContainer
 import com.example.jetnews.ui.components.AppNavRail
 import com.example.jetnews.ui.theme.JetnewsTheme
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
@@ -21,7 +21,6 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.widget.Toast
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
@@ -32,11 +32,14 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -117,7 +120,6 @@ import kotlinx.coroutines.runBlocking
 /**
  * The home screen displaying the feed along with an article details.
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeFeedWithArticleDetailsScreen(
     uiState: HomeUiState,
@@ -160,7 +162,10 @@ fun HomeFeedWithArticleDetailsScreen(
                 onSearchInputChanged = onSearchInputChanged,
             )
             // Crossfade between different detail posts
-            Crossfade(targetState = hasPostsUiState.selectedPost) { detailPost ->
+            Crossfade(
+                targetState = hasPostsUiState.selectedPost,
+                label = "Detail Post Crossfade"
+            ) { detailPost ->
                 // Get the lazy list state for this detail view
                 val detailLazyListState by remember {
                     derivedStateOf {
@@ -170,28 +175,31 @@ fun HomeFeedWithArticleDetailsScreen(
 
                 // Key against the post id to avoid sharing any state between different posts
                 key(detailPost.id) {
-                    LazyColumn(
-                        state = detailLazyListState,
-                        contentPadding = contentPadding,
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .fillMaxSize()
-                            .notifyInput {
-                                onInteractWithDetail(detailPost.id)
-                            }
-                    ) {
-                        stickyHeader {
-                            val context = LocalContext.current
-                            PostTopBar(
-                                isFavorite = hasPostsUiState.favorites.contains(detailPost.id),
-                                onToggleFavorite = { onToggleFavorite(detailPost.id) },
-                                onSharePost = { sharePost(detailPost, context) },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .wrapContentWidth(Alignment.End)
-                            )
+                    Box {
+                        LazyColumn(
+                            state = detailLazyListState,
+                            contentPadding = contentPadding,
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp)
+                                .fillMaxSize()
+                                .notifyInput {
+                                    onInteractWithDetail(detailPost.id)
+                                }
+                        ) {
+                            postContentItems(detailPost)
                         }
-                        postContentItems(detailPost)
+
+                        // Floating toolbar
+                        val context = LocalContext.current
+                        PostTopBar(
+                            isFavorite = hasPostsUiState.favorites.contains(detailPost.id),
+                            onToggleFavorite = { onToggleFavorite(detailPost.id) },
+                            onSharePost = { sharePost(detailPost, context) },
+                            modifier = Modifier
+                                .windowInsetsPadding(WindowInsets.safeDrawing)
+                                .fillMaxWidth()
+                                .wrapContentWidth(Alignment.End)
+                        )
                     }
                 }
             }


### PR DESCRIPTION
The floating toolbar seen in expanded width windows was implemented as a sticky header. The problem with that is it allows the toolbar to go behind the status bar on scroll due to edge-to-edge. For a real sticky header, you'd probably want to implement inset handling into the header so that it sticks just below any insets. In this case, that would mean the toolbar never actually moves, so I pulled it out of sticky header and just put it as a sibling with the LazyColumn. By adding the safeDrawing insets, this keeps it positioned at the top right of the safeDrawing area.

I also added a BackHandler for the drawer, so that pressing back closes the drawer. I don't see any clean way to implement predictive back with a modal navigation drawer.