### PR TITLE
Added predictive back support to Jetchat drawer

### DIFF
--- a/Jetchat/app/src/main/AndroidManifest.xml
+++ b/Jetchat/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
 
     <application
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/NavActivity.kt
@@ -17,7 +17,6 @@
 package com.example.compose.jetchat
 
 import android.os.Bundle
-import androidx.activity.compose.BackHandler
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -71,15 +70,7 @@ class NavActivity : AppCompatActivity() {
                         }
                     }
 
-                    // Intercepts back navigation when the drawer is open
                     val scope = rememberCoroutineScope()
-                    if (drawerState.isOpen) {
-                        BackHandler {
-                            scope.launch {
-                                drawerState.close()
-                            }
-                        }
-                    }
 
                     JetchatDrawer(
                         drawerState = drawerState,

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatDrawer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatDrawer.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -61,7 +60,7 @@ fun JetchatDrawerContent(
 ) {
     // Use windowInsetsTopHeight() to add a spacer which pushes the drawer content
     // below the status bar (y-axis)
-    Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+    Column {
         Spacer(Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
         DrawerHeader()
         DividerItem()

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatScaffold.kt
@@ -18,14 +18,13 @@ package com.example.compose.jetchat.components
 
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue.Closed
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import com.example.compose.jetchat.theme.JetchatTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun JetchatDrawer(
     drawerState: DrawerState = rememberDrawerState(initialValue = Closed),
@@ -37,7 +36,11 @@ fun JetchatDrawer(
         ModalNavigationDrawer(
             drawerState = drawerState,
             drawerContent = {
-                ModalDrawerSheet {
+                ModalDrawerSheet(
+                    drawerState = drawerState,
+                    drawerContainerColor = MaterialTheme.colorScheme.background,
+                    drawerContentColor = MaterialTheme.colorScheme.onBackground,
+                ) {
                     JetchatDrawerContent(
                         onProfileClicked = onProfileClicked,
                         onChatClicked = onChatClicked

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -10,8 +10,6 @@ androidx-appcompat = "1.7.0"
 androidx-benchmark = "1.2.4"
 androidx-benchmark-junit4 = "1.2.4"
 androidx-compose-bom = "2024.09.00"
-androidx-compose-latest = "1.7.0-beta07"
-androidx-compose-material3-adaptive = "1.0.0-beta04"
 androidx-constraintlayout = "1.1.0-alpha13"
 androidx-core-splashscreen = "1.0.1"
 androidx-corektx = "1.13.1"
@@ -72,20 +70,20 @@ androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-benchmark-macrobenchmark = { module = "androidx.benchmark:benchmark-macro", version.ref = "androidx-benchmark" }
 androidx-benchmark-macrobenchmark-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark-junit4" }
-androidx-compose-animation = { module = "androidx.compose.animation:animation", version.ref = "androidx-compose-latest" }
+androidx-compose-animation = { module = "androidx.compose.animation:animation" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation",  version.ref = "androidx-compose-latest"}
-androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" ,version.ref = "androidx-compose-latest"}
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
 androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
-androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidx-compose-material3-adaptive" }
-androidx-compose-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "androidx-compose-material3-adaptive" }
-androidx-compose-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "androidx-compose-material3-adaptive" }
+androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive" }
+androidx-compose-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout" }
+androidx-compose-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation" }
 androidx-compose-material3-adaptive-navigationSuite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite" }
 androidx-compose-materialWindow = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
-androidx-compose-ui = { module = "androidx.compose.ui:ui" , version.ref = "androidx-compose-latest"}
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-googlefonts = { module = "androidx.compose.ui:ui-text-google-fonts" }
 androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test" }

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidx-benchmark = "1.2.4"
 androidx-benchmark-junit4 = "1.2.4"
 androidx-compose-bom = "2024.06.00"
 androidx-compose-latest = "1.7.0-beta07"
-androidx-compose-material3 = "1.3.0-beta05"
+androidx-compose-material3 = "1.3.0-rc01"
 androidx-compose-material3-adaptive = "1.0.0-beta04"
 androidx-constraintlayout = "1.1.0-alpha13"
 androidx-core-splashscreen = "1.0.1"
@@ -78,7 +78,7 @@ androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = 
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation",  version.ref = "androidx-compose-latest"}
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" ,version.ref = "androidx-compose-latest"}
 androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended" }
-androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3" }
 androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidx-compose-material3-adaptive" }
 androidx-compose-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "androidx-compose-material3-adaptive" }
 androidx-compose-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "androidx-compose-material3-adaptive" }

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -9,9 +9,8 @@ androidx-activity-compose = "1.9.0"
 androidx-appcompat = "1.7.0"
 androidx-benchmark = "1.2.4"
 androidx-benchmark-junit4 = "1.2.4"
-androidx-compose-bom = "2024.06.00"
+androidx-compose-bom = "2024.09.00"
 androidx-compose-latest = "1.7.0-beta07"
-androidx-compose-material3 = "1.3.0-rc01"
 androidx-compose-material3-adaptive = "1.0.0-beta04"
 androidx-constraintlayout = "1.1.0-alpha13"
 androidx-core-splashscreen = "1.0.1"
@@ -78,11 +77,11 @@ androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = 
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation",  version.ref = "androidx-compose-latest"}
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" ,version.ref = "androidx-compose-latest"}
 androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended" }
-androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidx-compose-material3-adaptive" }
 androidx-compose-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "androidx-compose-material3-adaptive" }
 androidx-compose-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "androidx-compose-material3-adaptive" }
-androidx-compose-material3-adaptive-navigationSuite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "androidx-compose-material3" }
+androidx-compose-material3-adaptive-navigationSuite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite" }
 androidx-compose-materialWindow = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }


### PR DESCRIPTION
In M3 1.3, the drawerState can be passed to the ModalDrawerSheet to get predictive back animations without the need for a PredictiveBackHandler to be manually defined. I also moved the color settings to the correct place (ModalDrawerSheet) to make sure the drawer portions covered by insets would be colored correctly.