### PR TITLE
Moved withContext() call up to surround all IO being performed. 

### DIFF
--- a/Jetcaster/core/data/src/main/java/com/example/jetcaster/core/data/network/PodcastFetcher.kt
+++ b/Jetcaster/core/data/src/main/java/com/example/jetcaster/core/data/network/PodcastFetcher.kt
@@ -86,20 +86,20 @@ class PodcastsFetcher @Inject constructor(
     }
 
     private suspend fun fetchPodcast(url: String): PodcastRssResponse {
-        val request = Request.Builder()
-            .url(url)
-            .cacheControl(cacheControl)
-            .build()
-
-        val response = okHttpClient.newCall(request).execute()
-
-        // If the network request wasn't successful, throw an exception
-        if (!response.isSuccessful) throw HttpException(response)
-
-        // Otherwise we can parse the response using a Rome SyndFeedInput, then map it
-        // to a Podcast instance. We run this on the IO dispatcher since the parser is reading
-        // from a stream.
         return withContext(ioDispatcher) {
+            val request = Request.Builder()
+                .url(url)
+                .cacheControl(cacheControl)
+                .build()
+
+            val response = okHttpClient.newCall(request).execute()
+
+            // If the network request wasn't successful, throw an exception
+            if (!response.isSuccessful) throw HttpException(response)
+
+            // Otherwise we can parse the response using a Rome SyndFeedInput, then map it
+            // to a Podcast instance. We run this on the IO dispatcher since the parser is reading
+            // from a stream.
             response.body!!.use { body ->
                 syndFeedInput.build(body.charStream()).toPodcastResponse(url)
             }


### PR DESCRIPTION
Fixes part of #1461 

JetCaster showed a blank screen when run. The podcast fetching was running on the main dispatcher. Moved the withContext() up to ensure all IO was being performed on the IO dispatcher.