### PR TITLE
[Jetcaster] Refactor to use fromHtml in AnnotatedString

### DIFF
--- a/Jetcaster/core/designsystem/src/main/java/com/example/jetcaster/designsystem/component/HtmlTextContainer.kt
+++ b/Jetcaster/core/designsystem/src/main/java/com/example/jetcaster/designsystem/component/HtmlTextContainer.kt
@@ -20,16 +20,11 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.core.text.HtmlCompat
+import androidx.compose.ui.text.fromHtml
 
 /**
  * A container for text that should be HTML formatted. This container will handle building the
  * annotated string from [text], and enable text selection if [text] has any selectable element.
- *
- * TODO: Remove/update once the project is using Compose 1.7 as that version provides improved
- * support for HTML formatting.
- * See: https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.7.0-alpha07
  */
 @Composable
 fun HtmlTextContainer(
@@ -37,10 +32,7 @@ fun HtmlTextContainer(
     content: @Composable (AnnotatedString) -> Unit
 ) {
     val annotatedString = remember(key1 = text) {
-        buildAnnotatedString {
-            val htmlCompat = HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_COMPACT)
-            append(htmlCompat)
-        }
+        AnnotatedString.fromHtml(htmlString = text)
     }
     SelectionContainer {
         content(annotatedString)


### PR DESCRIPTION
HTML formatting support from compose 1.7.0

![image](https://github.com/user-attachments/assets/a2cb3c89-bfc7-4ee6-884d-c46b82f1f4ff)