### PR TITLE
Fix dependency updates

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
 kotlinx-serialization-json = "1.7.3"
-kotlinx_immutable = "1.9.0"
+kotlinx_immutable = "0.3.8"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -153,7 +153,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -42,8 +42,8 @@ horologist = "0.6.19"
 jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
-kotlinx_immutable = "0.3.8"
-kotlinx-serialization-json = "1.6.3"
+kotlinx-serialization-json = "1.7.3"
+kotlinx_immutable = "1.9.0"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -154,7 +154,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
 kotlinx-serialization-json = "1.7.3"
-kotlinx_immutable = "1.9.0"
+kotlinx_immutable = "0.3.8"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -153,7 +153,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -42,8 +42,8 @@ horologist = "0.6.19"
 jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
-kotlinx_immutable = "0.3.8"
-kotlinx-serialization-json = "1.6.3"
+kotlinx-serialization-json = "1.7.3"
+kotlinx_immutable = "1.9.0"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -154,7 +154,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
 kotlinx-serialization-json = "1.7.3"
-kotlinx_immutable = "1.9.0"
+kotlinx_immutable = "0.3.8"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -153,7 +153,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -42,8 +42,8 @@ horologist = "0.6.19"
 jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
-kotlinx_immutable = "0.3.8"
-kotlinx-serialization-json = "1.6.3"
+kotlinx-serialization-json = "1.7.3"
+kotlinx_immutable = "1.9.0"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -154,7 +154,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
 kotlinx-serialization-json = "1.7.3"
-kotlinx_immutable = "1.9.0"
+kotlinx_immutable = "0.3.8"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -153,7 +153,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -42,8 +42,8 @@ horologist = "0.6.19"
 jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
-kotlinx_immutable = "0.3.8"
-kotlinx-serialization-json = "1.6.3"
+kotlinx-serialization-json = "1.7.3"
+kotlinx_immutable = "1.9.0"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -154,7 +154,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
 kotlinx-serialization-json = "1.7.3"
-kotlinx_immutable = "1.9.0"
+kotlinx_immutable = "0.3.8"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -153,7 +153,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -42,8 +42,8 @@ horologist = "0.6.19"
 jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
-kotlinx_immutable = "0.3.8"
-kotlinx-serialization-json = "1.6.3"
+kotlinx-serialization-json = "1.7.3"
+kotlinx_immutable = "1.9.0"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -154,7 +154,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
 kotlinx-serialization-json = "1.7.3"
-kotlinx_immutable = "1.9.0"
+kotlinx_immutable = "0.3.8"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -153,7 +153,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -42,8 +42,8 @@ horologist = "0.6.19"
 jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
-kotlinx_immutable = "0.3.8"
-kotlinx-serialization-json = "1.6.3"
+kotlinx-serialization-json = "1.7.3"
+kotlinx_immutable = "1.9.0"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -154,7 +154,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }

--- a/scripts/libs.versions.toml
+++ b/scripts/libs.versions.toml
@@ -43,7 +43,7 @@ jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
 kotlinx-serialization-json = "1.7.3"
-kotlinx_immutable = "1.9.0"
+kotlinx_immutable = "0.3.8"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -153,7 +153,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/scripts/libs.versions.toml
+++ b/scripts/libs.versions.toml
@@ -42,8 +42,8 @@ horologist = "0.6.19"
 jdkDesugar = "1.2.2"
 junit = "4.13.2"
 kotlin = "2.0.20"
-kotlinx_immutable = "0.3.8"
-kotlinx-serialization-json = "1.6.3"
+kotlinx-serialization-json = "1.7.3"
+kotlinx_immutable = "1.9.0"
 ksp = "2.0.20-1.0.24"
 maps-compose = "3.1.1"
 # @keep
@@ -154,7 +154,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx_immutable" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx_immutable" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }

--- a/scripts/updateDeps.sh
+++ b/scripts/updateDeps.sh
@@ -16,7 +16,7 @@
 
 ########################################################################
 #
-# Updates dependencies using JetNews as the source of truth (then copies JetNews's 
+# Updates dependencies using Reply as the source of truth (then copies Reply's 
 # output into each sample)
 #
 # Example: To run build over all projects run:
@@ -26,7 +26,7 @@
 
 set -xe
 
-./JetNews/gradlew -p ./JetNews versionCatalogUpdate 
+./Reply/gradlew -p ./Reply versionCatalogUpdate 
 
-cp JetNews/gradle/libs.versions.toml scripts/libs.versions.toml
+cp Reply/gradle/libs.versions.toml scripts/libs.versions.toml
 ./scripts/duplicate_version_config.sh


### PR DESCRIPTION
Fixed #1478 by using the correct version variable for `kotlinx-coroutines-test`

Also changed the master project used for version updates from `JetNews` to `Reply`. 

Why? `JetNews` doesn't use the `kotlinx-serialization` plugin so this was automatically removed when running `versionCatalogUpdate` gradle task. This meant that `Reply` would fail to build because it depends on this plugin.  
