### PR TITLE
[Jetcaster] Update gradle typesafe import

### DIFF
--- a/Jetcaster/glancewidget/build.gradle.kts
+++ b/Jetcaster/glancewidget/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
-    implementation(project(":core:designsystem"))
+    implementation(projects.core.designsystem)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/Jetcaster/mobile/build.gradle.kts
+++ b/Jetcaster/mobile/build.gradle.kts
@@ -135,7 +135,7 @@ dependencies {
     implementation(projects.core.data)
     implementation(projects.core.designsystem)
     implementation(projects.core.domain)
-    implementation(project(":glancewidget"))
+    implementation(projects.glancewidget)
     implementation(projects.core.domainTesting)
 
     coreLibraryDesugaring(libs.core.jdk.desugaring)


### PR DESCRIPTION
reference to #1487

Afflicted modules have been updated with the new gradle typesafe import API