### PR TITLE
[Jetcaster] Refactor home state and fix loading progress

### DIFF
--- a/Jetcaster/core/data/src/main/java/com/example/jetcaster/core/data/repository/PodcastsRepository.kt
+++ b/Jetcaster/core/data/src/main/java/com/example/jetcaster/core/data/repository/PodcastsRepository.kt
@@ -22,13 +22,13 @@ import com.example.jetcaster.core.data.database.dao.TransactionRunner
 import com.example.jetcaster.core.data.network.PodcastRssResponse
 import com.example.jetcaster.core.data.network.PodcastsFetcher
 import com.example.jetcaster.core.data.network.SampleFeeds
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /**
  * Data repository for Podcasts.

--- a/Jetcaster/core/data/src/main/java/com/example/jetcaster/core/data/repository/PodcastsRepository.kt
+++ b/Jetcaster/core/data/src/main/java/com/example/jetcaster/core/data/repository/PodcastsRepository.kt
@@ -22,13 +22,13 @@ import com.example.jetcaster.core.data.database.dao.TransactionRunner
 import com.example.jetcaster.core.data.network.PodcastRssResponse
 import com.example.jetcaster.core.data.network.PodcastsFetcher
 import com.example.jetcaster.core.data.network.SampleFeeds
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /**
  * Data repository for Podcasts.
@@ -49,8 +49,7 @@ class PodcastsRepository @Inject constructor(
         if (refreshingJob?.isActive == true) {
             refreshingJob?.join()
         } else if (force || podcastStore.isEmpty()) {
-
-            refreshingJob = scope.launch {
+            val job = scope.launch {
                 // Now fetch the podcasts, and add each to each store
                 podcastsFetcher(SampleFeeds)
                     .filter { it is PodcastRssResponse.Success }
@@ -72,6 +71,9 @@ class PodcastsRepository @Inject constructor(
                         }
                     }
             }
+            refreshingJob = job
+            // We need to wait here for the job to finish, otherwise the coroutine completes ~immediatelly
+            job.join()
         }
     }
 }

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -125,12 +125,12 @@ import com.example.jetcaster.util.fullWidthItem
 import com.example.jetcaster.util.isCompact
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.radialGradientScrim
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 
 data class HomeState(
     val windowSizeClass: WindowSizeClass,

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -50,10 +50,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBar
@@ -125,15 +125,16 @@ import com.example.jetcaster.util.fullWidthItem
 import com.example.jetcaster.util.isCompact
 import com.example.jetcaster.util.quantityStringResource
 import com.example.jetcaster.util.radialGradientScrim
-import java.time.Duration
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 data class HomeState(
     val windowSizeClass: WindowSizeClass,
+    val isLoading: Boolean,
     val featuredPodcasts: PersistentList<PodcastInfo>,
     val selectedHomeCategory: HomeCategory,
     val homeCategories: List<HomeCategory>,
@@ -180,10 +181,12 @@ fun calculateScaffoldDirective(
                 maxHorizontalPartitions = 1
                 verticalSpacerSize = 0.dp
             }
+
             WindowWidthSizeClass.MEDIUM -> {
                 maxHorizontalPartitions = 1
                 verticalSpacerSize = 0.dp
             }
+
             else -> {
                 maxHorizontalPartitions = 2
                 verticalSpacerSize = 24.dp
@@ -233,27 +236,17 @@ fun MainScreen(
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val homeScreenUiState by viewModel.state.collectAsStateWithLifecycle()
-    when (val uiState = homeScreenUiState) {
-        is HomeScreenUiState.Loading -> HomeScreenLoading()
-        is HomeScreenUiState.Error -> HomeScreenError(onRetry = viewModel::refresh)
-        is HomeScreenUiState.Ready -> {
-            HomeScreenReady(
-                uiState = uiState,
-                windowSizeClass = windowSizeClass,
-                navigateToPlayer = navigateToPlayer,
-                viewModel = viewModel,
-            )
-        }
-    }
-}
+    val uiState = homeScreenUiState
+    Box {
+        HomeScreenReady(
+            uiState = uiState,
+            windowSizeClass = windowSizeClass,
+            navigateToPlayer = navigateToPlayer,
+            viewModel = viewModel,
+        )
 
-@Composable
-private fun HomeScreenLoading(modifier: Modifier = Modifier) {
-    Surface(modifier.fillMaxSize()) {
-        Box {
-            CircularProgressIndicator(
-                modifier = Modifier.align(Alignment.Center)
-            )
+        if (uiState.errorMessage != null) {
+            HomeScreenError(onRetry = viewModel::refresh)
         }
     }
 }
@@ -288,7 +281,7 @@ fun HomeScreenErrorPreview() {
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 private fun HomeScreenReady(
-    uiState: HomeScreenUiState.Ready,
+    uiState: HomeScreenUiState,
     windowSizeClass: WindowSizeClass,
     navigateToPlayer: (EpisodeInfo) -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
@@ -302,6 +295,7 @@ private fun HomeScreenReady(
 
     val homeState = HomeState(
         windowSizeClass = windowSizeClass,
+        isLoading = uiState.isLoading,
         featuredPodcasts = uiState.featuredPodcasts,
         homeCategories = uiState.homeCategories,
         selectedHomeCategory = uiState.selectedHomeCategory,
@@ -448,10 +442,19 @@ private fun HomeScreen(
     ) {
         Scaffold(
             topBar = {
-                HomeAppBar(
-                    isExpanded = homeState.windowSizeClass.isCompact,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                Column {
+                    HomeAppBar(
+                        isExpanded = homeState.windowSizeClass.isCompact,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    if (homeState.isLoading) {
+                        LinearProgressIndicator(
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)
+                        )
+                    }
+                }
             },
             snackbarHost = {
                 SnackbarHost(hostState = snackbarHostState)
@@ -816,6 +819,7 @@ private fun PreviewHome() {
     JetcasterTheme {
         val homeState = HomeState(
             windowSizeClass = CompactWindowSizeClass,
+            isLoading = true,
             featuredPodcasts = PreviewPodcasts.toPersistentList(),
             homeCategories = HomeCategory.entries,
             selectedHomeCategory = HomeCategory.Discover,

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/HomeViewModel.kt
@@ -16,7 +16,6 @@
 
 package com.example.jetcaster.ui.home
 
-import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -36,6 +35,7 @@ import com.example.jetcaster.core.model.asPodcastToEpisodeInfo
 import com.example.jetcaster.core.player.EpisodePlayer
 import com.example.jetcaster.core.player.model.PlayerEpisode
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -47,7 +47,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -112,12 +111,6 @@ class HomeViewModel @Inject constructor(
                 podcastCategoryFilterResult,
                 libraryEpisodes ->
 
-                if (refreshing) {
-                    Log.d("Jetcaster", "refreshing: $refreshing, podcasts $podcasts")
-                    // TODO(mlykotom): this is equivalent of what we had before
-                    return@combine HomeScreenUiState(isLoading = true)
-                }
-
                 _selectedCategory.value = filterableCategories.selectedCategory
 
                 // Override selected home category to show 'DISCOVER' if there are no
@@ -126,7 +119,7 @@ class HomeViewModel @Inject constructor(
                     if (podcasts.isEmpty()) HomeCategory.Discover else homeCategory
 
                 HomeScreenUiState(
-                    isLoading = false,
+                    isLoading = refreshing,
                     homeCategories = homeCategories,
                     selectedHomeCategory = homeCategory,
                     featuredPodcasts = podcasts.map { it.asExternalModel() }.toPersistentList(),
@@ -144,7 +137,6 @@ class HomeViewModel @Inject constructor(
             }.collect {
                 _state.value = it
             }
-
         }
 
         refresh(force = false)
@@ -161,7 +153,6 @@ class HomeViewModel @Inject constructor(
             refreshing.value = false
         }
     }
-
 
     fun onCategorySelected(category: CategoryInfo) {
         _selectedCategory.value = category


### PR DESCRIPTION
[Merge after #1498]

- This PR merges the home UI state into one data class to be able to show loading state and content state at the same time.
- It also fixes the progress to wait for the loading to finish.
- Instead of circular progress, I switched to linear progress at the top of the content, which can indicate the work while showing content

**After**

https://github.com/user-attachments/assets/ec3e9220-addc-4b96-9b6a-477294b6cf85




**Before**

https://github.com/user-attachments/assets/c795afc3-01f6-407b-b0b6-505da33652ec

