### PR TITLE
Fix issue: tapping text input outside placeholder don't bring it to focus

### DIFF
--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
@@ -440,7 +440,7 @@ private fun UserInputText(
                         keyboardType,
                         focusState,
                         onMessageSent,
-                        Modifier.semantics {
+                        Modifier.fillMaxWidth().semantics {
                             contentDescription = a11ylabel
                             keyboardShownProperty = keyboardShown
                         }


### PR DESCRIPTION
Before
[tap on text input (before).webm](https://github.com/user-attachments/assets/6336821b-0abe-4090-ab06-a7dd8a756102)

After
[tap on text input (after).webm](https://github.com/user-attachments/assets/c70cebd5-b737-4e03-9925-bed61f14a3b9)
