### PR TITLE
[Jetchat] fix: white padding in profile screen in dark mode

### DIFF
--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
@@ -89,13 +89,13 @@ fun ProfileScreen(
         modifier = Modifier
             .fillMaxSize()
             .nestedScroll(nestedScrollInteropConnection)
-            .systemBarsPadding()
     ) {
         Surface {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(scrollState),
+                    .verticalScroll(scrollState)
+                    .padding(16.dp),
             ) {
                 ProfileHeader(
                     scrollState,


### PR DESCRIPTION
There's a white padding in profile screen when in dark mode.

[Before]
![White padding (before)](https://github.com/user-attachments/assets/e87c3271-3264-48ad-a0e4-1f97e4c35039)

[After]
![Padding (after)](https://github.com/user-attachments/assets/ecd032c0-87a9-4ded-b55d-c2df030124d6)
