### PR TITLE
[Jetcaster] Use one HomeScreen call inside SupportingPaneScaffold

### DIFF
--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -324,6 +324,12 @@ private fun HomeScreenReady(
         SupportingPaneScaffold(
             value = navigator.scaffoldValue,
             directive = navigator.scaffoldDirective,
+            mainPane = {
+                HomeScreen(
+                    homeState = homeState,
+                    modifier = Modifier.fillMaxSize()
+                )
+            },
             supportingPane = {
                 val podcastUri = navigator.currentDestination?.content
                 if (!podcastUri.isNullOrEmpty()) {
@@ -344,12 +350,6 @@ private fun HomeScreenReady(
                         showBackButton = navigator.isMainPaneHidden(),
                     )
                 }
-            },
-            mainPane = {
-                HomeScreen(
-                    homeState = homeState,
-                    modifier = Modifier.fillMaxSize()
-                )
             },
             modifier = Modifier.fillMaxSize()
         )

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -321,17 +321,12 @@ private fun HomeScreenReady(
     )
 
     Surface {
-        val podcastUri = navigator.currentDestination?.content
-        if (podcastUri.isNullOrEmpty()) {
-            HomeScreen(
-                homeState = homeState,
-                modifier = Modifier.fillMaxSize()
-            )
-        } else {
-            SupportingPaneScaffold(
-                value = navigator.scaffoldValue,
-                directive = navigator.scaffoldDirective,
-                supportingPane = {
+        SupportingPaneScaffold(
+            value = navigator.scaffoldValue,
+            directive = navigator.scaffoldDirective,
+            supportingPane = {
+                val podcastUri = navigator.currentDestination?.content
+                if (!podcastUri.isNullOrEmpty()) {
                     val podcastDetailsViewModel =
                         hiltViewModel<PodcastDetailsViewModel, PodcastDetailsViewModel.Factory>(
                             key = podcastUri
@@ -348,16 +343,16 @@ private fun HomeScreenReady(
                         },
                         showBackButton = navigator.isMainPaneHidden(),
                     )
-                },
-                mainPane = {
-                    HomeScreen(
-                        homeState = homeState,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                },
-                modifier = Modifier.fillMaxSize()
-            )
-        }
+                }
+            },
+            mainPane = {
+                HomeScreen(
+                    homeState = homeState,
+                    modifier = Modifier.fillMaxSize()
+                )
+            },
+            modifier = Modifier.fillMaxSize()
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #1508 by only calling `HomeScreen` in a single source code location, in the main pane of `SupportingPaneScaffold`.