### PR TITLE
[JetLagged] Fix HeartRateCard Preview Render

### DIFF
--- a/JetLagged/app/src/main/java/com/example/jetlagged/ui/theme/Theme.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/ui/theme/Theme.kt
@@ -50,7 +50,7 @@ data class JetLaggedExtraColors(
     val sleep: Color = Color.Unspecified,
     val wellness: Color = Color.Unspecified,
     val heart: Color = Color.Unspecified,
-    val heartWave: List<Color> = listOf(Color.Unspecified),
+    val heartWave: List<Color> = listOf(Color.Unspecified, Color.Unspecified),
     val heartWaveBackground: Color = Color.Unspecified,
     val sleepChartPrimary: Color = Color.Unspecified,
     val sleepChartSecondary: Color = Color.Unspecified,


### PR DESCRIPTION
There is a preview error in the HeartRateCard Composable in JetLagged, which was caused by the JetLaggedExtraColors.heartWave default value list having a size of 1.

![image](https://github.com/user-attachments/assets/74e4d776-26a4-4147-b499-5b2e03e086d8)
