### PR TITLE
Migrate Jetchat to new TextField

### DIFF
--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -111,6 +111,9 @@ dependencies {
     implementation(libs.androidx.compose.ui.viewbinding)
     implementation(libs.androidx.compose.ui.googlefonts)
 
+    implementation(libs.coil.kt.compose)
+    implementation(libs.coil.kt.gif)
+
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 
     androidTestImplementation(libs.junit)

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/ConversationUiState.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/ConversationUiState.kt
@@ -38,6 +38,6 @@ data class Message(
     val author: String,
     val content: String,
     val timestamp: String,
-    val image: Int? = null,
-    val authorImage: Int = if (author == "me") R.drawable.ali else R.drawable.someone_else,
+    val image: Any? = null,
+    val authorImage: Int = if (author == "me") R.drawable.ali else R.drawable.someone_else
 )

--- a/Jetchat/app/src/main/res/values/strings.xml
+++ b/Jetchat/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="not_available">Functionality currently not available</string>
     <string name="not_available_subtitle">Grab a beverage and check back later!</string>
     <string name="attached_image">Attached image</string>
+    <string name="remove_image">Remove image</string>
     <string name="search">Search</string>
     <string name="info">Information</string>
     <string name="more_options">More options</string>

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ androidx-wear-compose = "1.4.1"
 androidx-window = "1.3.0"
 androidxHiltNavigationCompose = "1.2.0"
 androix-test-uiautomator = "2.3.0"
-coil = "2.7.0"
+coil = "3.1.0"
 # @keep
 compileSdk = "35"
 coroutines = "1.10.1"
@@ -123,7 +123,8 @@ androidx-wear-compose-navigation = { module = "androidx.wear.compose:compose-nav
 androidx-wear-compose-ui-tooling = { module = "androidx.wear.compose:compose-ui-tooling", version.ref = "androidx-wear-compose" }
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 androidx-window-core = { module = "androidx.window:window-core", version.ref = "androidx-window" }
-coil-kt-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+coil-kt-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-kt-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 core-jdk-desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "jdkDesugar" }
 dagger-hiltandroidplugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 googlemaps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "maps-compose" }


### PR DESCRIPTION
This commit also integrates `contentReceiver`, dropping DragAndDrop modifier. 

`contentReceiver` already supports drag and drop, it additionally supports importing gifs and other rich content from keyboard or clipboard.

We also change how media is attached to each message. If there is no text content in the message, than the chat bubble is not rendered, only image bubble is shown.

Added coil-compose and coil-gif dependencies to show the images in the easiest way possible. 