### PR TITLE
Fix previews for JetLaggedScreen and HeartRateCard

### DIFF
--- a/JetLagged/app/src/main/java/com/example/jetlagged/JetLaggedScreen.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/JetLaggedScreen.kt
@@ -49,7 +49,6 @@ import com.example.jetlagged.ui.theme.JetLaggedTheme
 import com.example.jetlagged.ui.util.MultiDevicePreview
 
 @OptIn(ExperimentalLayoutApi::class)
-@MultiDevicePreview
 @Composable
 fun JetLaggedScreen(
     modifier: Modifier = Modifier,
@@ -124,5 +123,13 @@ fun JetLaggedScreen(
                 }
             }
         }
+    }
+}
+
+@MultiDevicePreview
+@Composable
+private fun JetLaggedScreenPreview() {
+    JetLaggedTheme {
+        JetLaggedScreen()
     }
 }

--- a/JetLagged/app/src/main/java/com/example/jetlagged/heartrate/HeartRateCard.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/heartrate/HeartRateCard.kt
@@ -38,7 +38,6 @@ import com.example.jetlagged.ui.theme.JetLaggedTheme
 import com.example.jetlagged.ui.theme.SmallHeadingStyle
 import com.example.jetlagged.ui.theme.TitleStyle
 
-@Preview
 @Composable
 fun HeartRateCard(
     modifier: Modifier = Modifier,
@@ -75,5 +74,13 @@ fun HeartRateCard(
             }
             HeartRateGraph(heartRateData.listData)
         }
+    }
+}
+
+@Preview
+@Composable
+private fun HeartRateCardPreview() {
+    JetLaggedTheme {
+        HeartRateCard()
     }
 }


### PR DESCRIPTION
The HeartRateGraph needs the theme. This fixes the previews to make sure the JetLaggedTheme theme is used.