### PR TITLE
Replace deprecated icons and update ArticleScreen KDoc

### DIFF
--- a/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
@@ -22,8 +22,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ListAlt
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.ListAlt
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.Icon
@@ -70,7 +70,7 @@ fun AppDrawer(
         )
         NavigationDrawerItem(
             label = { Text(stringResource(id = R.string.interests_title)) },
-            icon = { Icon(Icons.Filled.ListAlt, null) },
+            icon = { Icon(Icons.AutoMirrored.Filled.ListAlt, null) },
             selected = currentRoute == JetnewsDestinations.INTERESTS_ROUTE,
             onClick = {
                 navigateToInterests()

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/article/ArticleScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -72,7 +72,7 @@ import kotlinx.coroutines.runBlocking
  * Stateless Article Screen that displays a single post adapting the UI to different screen sizes.
  *
  * @param post (state) item to display
- * @param showNavigationIcon (state) if the navigation icon should be shown
+ * @param isExpandedScreen (state) true if the window width is classified as expanded; hides navigation icon and bottom bar
  * @param onBack (event) request navigate back
  * @param isFavorite (state) is this item currently a favorite
  * @param onToggleFavorite (event) request that this post toggle it's favorite state
@@ -103,7 +103,7 @@ fun ArticleScreen(
                 if (!isExpandedScreen) {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.cd_navigate_up),
                             tint = MaterialTheme.colorScheme.primary,
                         )

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
@@ -20,8 +20,8 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ListAlt
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.ListAlt
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRail
@@ -61,7 +61,7 @@ fun AppNavRail(currentRoute: String, navigateToHome: () -> Unit, navigateToInter
         NavigationRailItem(
             selected = currentRoute == JetnewsDestinations.INTERESTS_ROUTE,
             onClick = navigateToInterests,
-            icon = { Icon(Icons.Filled.ListAlt, stringResource(R.string.interests_title)) },
+            icon = { Icon(Icons.AutoMirrored.Filled.ListAlt, stringResource(R.string.interests_title)) },
             label = { Text(stringResource(R.string.interests_title)) },
             alwaysShowLabel = false,
         )


### PR DESCRIPTION
This PR updates outdated documentation and replaces deprecated icon usage in accordance with the latest Material guidelines.

Changes:
- Replaced deprecated icon imports such as Icons.Filled.ArrowBack with Icons.AutoMirrored.Filled.ArrowBack.
- Updated KDoc for isExpandedScreen to more clearly reflect its role in determining layout behavior.

Closes #1572