### PR TITLE
Fix drawer animation logic

### DIFF
--- a/JetLagged/app/src/main/java/com/example/jetlagged/JetLaggedDrawer.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/JetLaggedDrawer.kt
@@ -158,18 +158,16 @@ fun HomeScreenDrawer(windowSizeClass: WindowSizeClass) {
                             } else {
                                 0f
                             }
-                            // checking if the difference between the target and actual is + or -
-                            val targetDifference = (actualTargetX - targetOffsetX)
                             val canReachTargetWithDecay =
                                 (
                                     targetOffsetX > actualTargetX &&
                                         velocity > 0f &&
-                                        targetDifference > 0f
+                                        actualTargetX > 0f
                                     ) ||
                                     (
                                         targetOffsetX < actualTargetX &&
                                             velocity < 0 &&
-                                            targetDifference < 0f
+                                            actualTargetX == 0f
                                         )
                             if (canReachTargetWithDecay) {
                                 translationX.animateDecay(


### PR DESCRIPTION
The drawer animation logic had a bug where it would not properly animate the drawer to the correct position.

This commit fixes the issue by adjusting the conditions that determine whether the drawer can reach the target position with decay. Specifically, it checks if `actualTargetX > 0f` instead of `targetDifference > 0f` and `actualTargetX == 0f` instead of `targetDifference < 0f`.