### PR TITLE
Specify surfaceTint in TV ColorScheme (remove TODO)

### DIFF
--- a/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/theme/Color.kt
+++ b/Jetcaster/tv/src/main/java/com/example/jetcaster/tv/ui/theme/Color.kt
@@ -81,6 +81,7 @@ val colorSchemeForDarkMode = darkColorScheme(
     primaryContainer = primaryContainerDark,
     onPrimaryContainer = onPrimaryContainerDark,
     secondary = secondaryDark,
+    surfaceTint = primaryDark,
     onSecondary = onSecondaryDark,
     secondaryContainer = secondaryContainerDark,
     onSecondaryContainer = onSecondaryContainerDark,
@@ -106,7 +107,6 @@ val colorSchemeForDarkMode = darkColorScheme(
     onErrorContainer = onErrorContainerDark,
 )
 
-// Todo: specify surfaceTint
 val colorSchemeForLightMode = lightColorScheme(
     primary = primaryLight,
     onPrimary = onPrimaryLight,
@@ -125,6 +125,7 @@ val colorSchemeForLightMode = lightColorScheme(
     background = backgroundLight,
     onBackground = onBackgroundLight,
     surface = surfaceLight,
+    surfaceTint = primaryLight,
     onSurface = onSurfaceLight,
     surfaceVariant = surfaceVariantLight,
     onSurfaceVariant = onSurfaceVariantLight,


### PR DESCRIPTION
### Overview
This PR sets the `surfaceTint` color in the TV `ColorScheme` (light mode) using `primaryLight`, which follows Material3 guidance for surface elevation tint. This allows us to remove the TODO comment.

### What Changed
- Added `surfaceTint = primaryLight` in the TV lightColorScheme
- Also added surfaceTint to dark mode to keep symmetry
- Removed the TODO comment

### Why
Material3 expects surfaceTint to be specified for elevation tinting. Using the primary color is a standard default in Material guidelines.