### PR TITLE
docs(README): call out JDK 17 requirement for AGP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ You can clone this repository or import the
 project from Android Studio following the steps
 [here](https://developer.android.com/jetpack/compose/setup#sample).
 
+> **Java / JDK**  
+> Building with recent Android Gradle Plugin versions requires **JDK 17**.  
+> Android Studio (Flamingo and newer) bundles JDK 17 by default.  
+> See: https://developer.android.com/studio/releases/gradle-plugin#jdk-17
+
+
 🧬 Samples
 ------------
 


### PR DESCRIPTION
New contributors often hit “AGP requires Java 17” when building samples.
This adds a short note under Requirements with a link to the official AGP docs.