### PR TITLE
[FIXED] Update links in README for project resources to avoid 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ the most up to date resources.
 
 | Project                                          | Removed    | Commit                                                              |
 | ------------------------------------------------ | -----------|-------------------------------------------------------------------- |
-| [Crane](../../../tree/v2024.05.00/Crane)         | 2024-08-02 | [ee8e272](../../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
-| [Owl](../../../tree/v2024.05.00/Owl)             | 2024-08-02 | [ee8e272](../../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
-| [Jetsurvey](../../../tree/v2024.05.00/Jetsurvey) | 2024-08-02 | [ee8e272](../../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
-| [Rally](../../../tree/v2024.05.00/Rally)         | 2024-08-02 | [ee8e272](../../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
+| [Crane](../../tree/v2024.05.00/Crane)         | 2024-08-02 | [ee8e272](../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
+| [Owl](../../tree/v2024.05.00/Owl)             | 2024-08-02 | [ee8e272](../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
+| [Jetsurvey](../../tree/v2024.05.00/Jetsurvey) | 2024-08-02 | [ee8e272](../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
+| [Rally](../../tree/v2024.05.00/Rally)         | 2024-08-02 | [ee8e272](../../commit/ee8e27289f4bc36304ee9f04397f49c35f402a65) |
 
 ## License
 ```


### PR DESCRIPTION
Right now, all the links resolves to 404 due to extra `../` removing project name from the path.

* Before: `https://github.com/android/commit/ee8e27289f4bc36304ee9f04397f49c35f402a65`
* After: `https://github.com/android/compose-samples/commit/ee8e27289f4bc36304ee9f04397f49c35f402a65`
* Before: `https://github.com/android/tree/v2024.05.00/Jetsurvey`
* After: `https://github.com/android/compose-samples/tree/v2024.05.00/Jetsurvey`