### PR TITLE
Migrate Jetcaster to AGP 9.0

### DIFF
--- a/Jetcaster/build.gradle.kts
+++ b/Jetcaster/build.gradle.kts
@@ -19,7 +19,6 @@ plugins {
     alias(libs.plugins.version.catalog.update)
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false

--- a/Jetcaster/core/data-testing/build.gradle.kts
+++ b/Jetcaster/core/data-testing/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/Jetcaster/core/data/build.gradle.kts
+++ b/Jetcaster/core/data/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/Jetcaster/core/designsystem/build.gradle.kts
+++ b/Jetcaster/core/designsystem/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose)
 }
 

--- a/Jetcaster/core/domain-testing/build.gradle.kts
+++ b/Jetcaster/core/domain-testing/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/Jetcaster/core/domain/build.gradle.kts
+++ b/Jetcaster/core/domain/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }

--- a/Jetcaster/glancewidget/build.gradle.kts
+++ b/Jetcaster/glancewidget/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose)
 }
 

--- a/Jetcaster/gradle.properties
+++ b/Jetcaster/gradle.properties
@@ -37,3 +37,6 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Suppress error regarding kotlin.sourceSets with built-in Kotlin in AGP 9.0
+android.disallowKotlinSourceSets=false

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 [versions]
 accompanist = "0.37.3"
 android-material3 = "1.13.0-alpha13"
-androidGradlePlugin = "8.10.1"
+androidGradlePlugin = "9.0.0"
 androidx-activity-compose = "1.10.1"
 androidx-appcompat = "1.7.1"
 androidx-compose-bom = "2025.09.00"
@@ -35,7 +35,7 @@ compileSdk = "36"
 coroutines = "1.10.2"
 google-maps = "19.2.0"
 gradle-versions = "0.52.0"
-hilt = "2.56.2"
+hilt = "2.59"
 hiltExt = "1.2.0"
 horologist = "0.7.15"
 jdkDesugar = "2.1.5"
@@ -51,9 +51,9 @@ minSdk = "23"
 okhttp = "4.12.0"
 play-services-wearable = "19.0.0"
 robolectric = "4.14.1"
-roborazzi = "1.45.1"
+roborazzi = "1.58.0"
 rome = "2.1.0"
-room = "2.7.1"
+room = "2.8.4"
 secrets = "2.0.1"
 spotless = "7.0.4"
 # @keep
@@ -177,7 +177,6 @@ compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 gradle-versions = { id = "com.github.ben-manes.versions", version.ref = "gradle-versions" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/Jetcaster/gradle/wrapper/gradle-wrapper.properties
+++ b/Jetcaster/gradle/wrapper/gradle-wrapper.properties
@@ -14,6 +14,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Jetcaster/mobile/build.gradle.kts
+++ b/Jetcaster/mobile/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.compose)

--- a/Jetcaster/tv/build.gradle.kts
+++ b/Jetcaster/tv/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.compose)

--- a/Jetcaster/wear/build.gradle
+++ b/Jetcaster/wear/build.gradle
@@ -15,7 +15,6 @@
  */
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias libs.plugins.roborazzi
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
@@ -23,7 +22,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     namespace "com.example.jetcaster"
 
@@ -55,10 +54,14 @@ android {
         }
     }
     
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.majorVersion
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+            freeCompilerArgs.addAll(
+                "-opt-in=kotlin.RequiresOptIn",
+                "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
+            )
+        }
     }
     buildFeatures {
         compose true
@@ -86,14 +89,6 @@ dependencies {
     implementation composeBom
     implementation libs.androidx.activity.compose
     implementation libs.androidx.core.splashscreen
-
-    // Compose for Wear OS Dependencies
-    // NOTE: DO NOT INCLUDE a dependency on androidx.compose.material:material.
-    // androidx.wear.compose:compose-material is designed as a replacement not an addition to
-    // androidx.compose.material:material. If there are features from that you feel are missing from
-    // androidx.wear.compose:compose-material please raise a bug to let us know:
-    // https://issuetracker.google.com/issues/new?component=1077552&template=1598429&pli=1
-    implementation libs.androidx.wear.compose.material
 
     // For using the phone Typography
     implementation libs.androidx.compose.material3


### PR DESCRIPTION
GiAS prepared this by relying on AKB tools.