### PR TITLE
JetNews: Migrate from Navigation 2 to Navigation 3

### DIFF
--- a/JetNews/app/build.gradle.kts
+++ b/JetNews/app/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -117,7 +118,10 @@ dependencies {
     implementation(libs.androidx.lifecycle.livedata.ktx)
     implementation(libs.androidx.lifecycle.viewModelCompose)
     implementation(libs.androidx.lifecycle.runtime.compose)
-    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.window)
 
     androidTestImplementation(libs.junit)

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
@@ -42,7 +42,7 @@ import com.example.jetnews.ui.theme.JetnewsTheme
 @Composable
 fun AppDrawer(
     drawerState: DrawerState,
-    currentRoute: JetnewsRoute,
+    currentRoute: JetnewsRoute?,
     navigateToHome: () -> Unit,
     navigateToInterests: () -> Unit,
     closeDrawer: () -> Unit,

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
@@ -42,7 +42,7 @@ import com.example.jetnews.ui.theme.JetnewsTheme
 @Composable
 fun AppDrawer(
     drawerState: DrawerState,
-    currentRoute: String,
+    currentRoute: JetnewsRoute,
     navigateToHome: () -> Unit,
     navigateToInterests: () -> Unit,
     closeDrawer: () -> Unit,
@@ -58,7 +58,7 @@ fun AppDrawer(
         NavigationDrawerItem(
             label = { Text(stringResource(id = R.string.home_title)) },
             icon = { Icon(painterResource(R.drawable.ic_home), null) },
-            selected = currentRoute == JetnewsDestinations.HOME_ROUTE,
+            selected = currentRoute is Home,
             onClick = {
                 navigateToHome()
                 closeDrawer()
@@ -68,7 +68,7 @@ fun AppDrawer(
         NavigationDrawerItem(
             label = { Text(stringResource(id = R.string.interests_title)) },
             icon = { Icon(painterResource(R.drawable.ic_list_alt), null) },
-            selected = currentRoute == JetnewsDestinations.INTERESTS_ROUTE,
+            selected = currentRoute is Interests,
             onClick = {
                 navigateToInterests()
                 closeDrawer()
@@ -102,7 +102,7 @@ fun PreviewAppDrawer() {
     JetnewsTheme {
         AppDrawer(
             drawerState = rememberDrawerState(initialValue = DrawerValue.Open),
-            currentRoute = JetnewsDestinations.HOME_ROUTE,
+            currentRoute = Home(),
             navigateToHome = {},
             navigateToInterests = {},
             closeDrawer = { },

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsApp.kt
@@ -39,16 +39,17 @@ fun JetnewsApp(
 ) {
     JetnewsTheme {
         val backStack = remember { mutableStateListOf<JetnewsRoute>(startRoute) }
-        val currentRoute: JetnewsRoute = backStack.lastOrNull() ?: Home()
+        val currentRoute: JetnewsRoute? = backStack.lastOrNull()
 
         val navigateToHome: () -> Unit = {
             // Pop everything back to Home (the start destination)
             while (backStack.size > 1) backStack.removeLast()
         }
         val navigateToInterests: () -> Unit = {
-            // Pop to Home, then add Interests on top (single top behavior)
-            while (backStack.size > 1) backStack.removeLast()
-            backStack.add(Interests)
+            if (backStack.lastOrNull() != Interests) {
+                while (backStack.size > 1) backStack.removeLast()
+                backStack.add(Interests)
+            }
         }
 
         val coroutineScope = rememberCoroutineScope()

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavigation.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/JetnewsNavigation.kt
@@ -16,43 +16,17 @@
 
 package com.example.jetnews.ui
 
-import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.NavHostController
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
 
 /**
- * Destinations used in the [JetnewsApp].
+ * Route definitions used in [JetnewsApp].
  */
-object JetnewsDestinations {
-    const val HOME_ROUTE = "home"
-    const val INTERESTS_ROUTE = "interests"
-}
+@Serializable
+sealed interface JetnewsRoute : NavKey
 
-/**
- * Models the navigation actions in the app.
- */
-class JetnewsNavigationActions(navController: NavHostController) {
-    val navigateToHome: () -> Unit = {
-        navController.navigate(JetnewsDestinations.HOME_ROUTE) {
-            // Pop up to the start destination of the graph to
-            // avoid building up a large stack of destinations
-            // on the back stack as users select items
-            popUpTo(navController.graph.findStartDestination().id) {
-                saveState = true
-            }
-            // Avoid multiple copies of the same destination when
-            // reselecting the same item
-            launchSingleTop = true
-            // Restore state when reselecting a previously selected item
-            restoreState = true
-        }
-    }
-    val navigateToInterests: () -> Unit = {
-        navController.navigate(JetnewsDestinations.INTERESTS_ROUTE) {
-            popUpTo(navController.graph.findStartDestination().id) {
-                saveState = true
-            }
-            launchSingleTop = true
-            restoreState = true
-        }
-    }
-}
+@Serializable
+data class Home(val preSelectedPostId: String? = null) : JetnewsRoute
+
+@Serializable
+data object Interests : JetnewsRoute

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/MainActivity.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/MainActivity.kt
@@ -32,9 +32,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val appContainer = (application as JetnewsApplication).container
+
+        val postId = intent?.data?.getQueryParameter("postId")
+        val startRoute = Home(preSelectedPostId = postId)
+
         setContent {
             val widthSizeClass = calculateWindowSizeClass(this).widthSizeClass
-            JetnewsApp(appContainer, widthSizeClass)
+            JetnewsApp(appContainer, widthSizeClass, startRoute)
         }
     }
 }

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
@@ -31,11 +31,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.jetnews.R
-import com.example.jetnews.ui.JetnewsDestinations
+import com.example.jetnews.ui.Home
+import com.example.jetnews.ui.Interests
+import com.example.jetnews.ui.JetnewsRoute
 import com.example.jetnews.ui.theme.JetnewsTheme
 
 @Composable
-fun AppNavRail(currentRoute: String, navigateToHome: () -> Unit, navigateToInterests: () -> Unit, modifier: Modifier = Modifier) {
+fun AppNavRail(currentRoute: JetnewsRoute, navigateToHome: () -> Unit, navigateToInterests: () -> Unit, modifier: Modifier = Modifier) {
     NavigationRail(
         header = {
             Icon(
@@ -49,14 +51,14 @@ fun AppNavRail(currentRoute: String, navigateToHome: () -> Unit, navigateToInter
     ) {
         Spacer(Modifier.weight(1f))
         NavigationRailItem(
-            selected = currentRoute == JetnewsDestinations.HOME_ROUTE,
+            selected = currentRoute is Home,
             onClick = navigateToHome,
             icon = { Icon(painterResource(id = R.drawable.ic_home), stringResource(R.string.home_title)) },
             label = { Text(stringResource(R.string.home_title)) },
             alwaysShowLabel = false,
         )
         NavigationRailItem(
-            selected = currentRoute == JetnewsDestinations.INTERESTS_ROUTE,
+            selected = currentRoute is Interests,
             onClick = navigateToInterests,
             icon = { Icon(painterResource(id = R.drawable.ic_list_alt), stringResource(R.string.interests_title)) },
             label = { Text(stringResource(R.string.interests_title)) },
@@ -72,7 +74,7 @@ fun AppNavRail(currentRoute: String, navigateToHome: () -> Unit, navigateToInter
 fun PreviewAppNavRail() {
     JetnewsTheme {
         AppNavRail(
-            currentRoute = JetnewsDestinations.HOME_ROUTE,
+            currentRoute = Home(),
             navigateToHome = {},
             navigateToInterests = {},
         )

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
@@ -37,7 +37,7 @@ import com.example.jetnews.ui.JetnewsRoute
 import com.example.jetnews.ui.theme.JetnewsTheme
 
 @Composable
-fun AppNavRail(currentRoute: JetnewsRoute, navigateToHome: () -> Unit, navigateToInterests: () -> Unit, modifier: Modifier = Modifier) {
+fun AppNavRail(currentRoute: JetnewsRoute?, navigateToHome: () -> Unit, navigateToInterests: () -> Unit, modifier: Modifier = Modifier) {
     NavigationRail(
         header = {
             Icon(

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ androidx-lifecycle = "2.8.2"
 androidx-lifecycle-compose = "2.10.0"
 androidx-lifecycle-runtime-compose = "2.10.0"
 androidx-navigation = "2.9.6"
+androidx-navigation3 = "1.0.0"
+androidx-lifecycle-viewmodel-navigation3 = "2.10.0"
 androidx-palette = "1.0.0"
 androidx-test = "1.7.0"
 androidx-test-espresso = "3.7.0"
@@ -106,6 +108,9 @@ androidx-material-icons-core = { module = "androidx.compose.material:material-ic
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidx-navigation3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle-viewmodel-navigation3" }
 androidx-palette = { module = "androidx.palette:palette", version.ref = "androidx-palette" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }


### PR DESCRIPTION
## Summary
- Replaces `NavHost`/`NavController` with Nav3's `NavDisplay` and a developer-owned `SnapshotStateList` backstack
- Replaces string routes (`JetnewsDestinations`) with `@Serializable` `NavKey` types (`Home`, `Interests`) for type-safe navigation
- Deep link handling moved from `navDeepLink {}` DSL to manual intent parsing in `MainActivity`

## Changes
| File | What changed |
|------|-------------|
| `libs.versions.toml` | Added `navigation3-runtime`, `navigation3-ui`, `lifecycle-viewmodel-navigation3` |
| `build.gradle.kts` | Swapped Nav2 dep for Nav3 deps, added `kotlin.serialization` plugin |
| `JetnewsNavigation.kt` | Deleted `JetnewsDestinations`/`JetnewsNavigationActions`, added `sealed interface JetnewsRoute : NavKey` |
| `JetnewsNavGraph.kt` | `NavHost` → `NavDisplay` with `entryProvider` lambda and Nav3 decorators |
| `JetnewsApp.kt` | `rememberNavController()` → `mutableStateListOf<JetnewsRoute>()`, navigation via list ops |
| `AppDrawer.kt` | `currentRoute: String` → `currentRoute: JetnewsRoute`, `is` type checks |
| `AppNavRail.kt` | Same as AppDrawer |
| `MainActivity.kt` | Manual deep link parsing (`intent?.data?.getQueryParameter("postId")`) |

## Test plan
- [ ] `./gradlew :JetNews:app:assembleDebug` builds successfully
- [ ] App launches to Home screen
- [ ] Drawer navigation: Home ↔ Interests with correct selection state
- [ ] Expanded screen: NavRail shows correct selection state
- [ ] Deep link: `adb shell am start -a android.intent.action.VIEW -d "https://developer.android.com/jetnews/home?postId=post5"`
- [ ] System back button pops from Interests → Home correctly

Fixes #1632