### PR TITLE
Fix bottom padding for HTML text in Wear module

### DIFF
--- a/Jetcaster/core/designsystem/src/main/java/com/example/jetcaster/designsystem/component/HtmlTextContainer.kt
+++ b/Jetcaster/core/designsystem/src/main/java/com/example/jetcaster/designsystem/component/HtmlTextContainer.kt
@@ -22,16 +22,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
 
+import androidx.compose.ui.Modifier
+
 /**
  * A container for text that should be HTML formatted. This container will handle building the
  * annotated string from [text], and enable text selection if [text] has any selectable element.
  */
 @Composable
-fun HtmlTextContainer(text: String, content: @Composable (AnnotatedString) -> Unit) {
+fun HtmlTextContainer(
+    text: String,
+    modifier: Modifier = Modifier,
+    content: @Composable (AnnotatedString) -> Unit
+) {
     val annotatedString = remember(key1 = text) {
         AnnotatedString.fromHtml(htmlString = text)
     }
-    SelectionContainer {
+    SelectionContainer(modifier = modifier) {
         content(annotatedString)
     }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/episode/EpisodeScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/episode/EpisodeScreen.kt
@@ -51,6 +51,7 @@ import androidx.wear.compose.material3.PlaceholderState
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.TextDefaults
 import androidx.wear.compose.material3.lazy.TransformationSpec
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
@@ -298,7 +299,13 @@ private fun TransformingLazyColumnScope.episodeInfoContent(episode: PlayerEpisod
     if (summary != null) {
         val summaryInParagraphs = summary.split("\n+".toRegex()).orEmpty()
         items(summaryInParagraphs) {
-            HtmlTextContainer(text = summary) {
+            HtmlTextContainer(
+                text = summary,
+                modifier = Modifier.minimumVerticalContentPadding(
+                    TextDefaults.minimumTopListContentPadding,
+                    TextDefaults.minimumBottomListContentPadding
+                )
+            ) {
                 Text(
                     text = it,
                     style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
Fix bottom padding for HTML text in Wear module, required changing the HTMLTextContainer which is used also on phone sample.