### PR TITLE
Fix tab indicator clipping by removing matchContentSize in JetLaggedHeaderTabs

### DIFF
--- a/JetLagged/app/src/main/java/com/example/jetlagged/sleep/JetLaggedHeaderTabs.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/sleep/JetLaggedHeaderTabs.kt
@@ -53,7 +53,7 @@ fun JetLaggedHeaderTabs(onTabSelected: (SleepTab) -> Unit, selectedTab: SleepTab
         indicator = {
             Box(
                 Modifier
-                    .tabIndicatorOffset(selectedTab.ordinal, matchContentSize = true)
+                    .tabIndicatorOffset(selectedTab.ordinal)
                     .fillMaxSize()
                     .padding(horizontal = 2.dp)
                     .border(


### PR DESCRIPTION
## Description
This PR fixes issue #1703 where the tab selection indicator in the `JetLagged` sample was incorrectly sized and clipping the label text.

<img width="1344" height="2992" alt="Screenshot_20260829_053440" src="https://github.com/user-attachments/assets/491ff2b9-e999-4c37-ba32-a63d748d34d5" />


### Changes:
- Removed `matchContentSize = true` from `.tabIndicatorOffset()` in the indicator implementation. 
- By disabling content matching (returning to default behavior), the indicator box now fills the entire tab slot, providing enough space to comfortably encapsulate the label text without clipping.

### Verification:
- Verified via Compose Preview: The indicator now correctly encloses the entire label (e.g., "Day", "Week") without any clipping.
- Verified on Emulator: The selection box aligns perfectly with the tab's clickable area.

## Related Issues
Fixes #1703