### PR TITLE
Use new SurfaceView.setBlurRegions API - Android 37

### DIFF
--- a/Jetchat/app/build.gradle.kts
+++ b/Jetchat/app/build.gradle.kts
@@ -115,6 +115,10 @@ dependencies {
     implementation(libs.androidx.compose.ui.viewbinding)
     implementation(libs.androidx.compose.ui.googlefonts)
 
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.exoplayer.hls)
+    implementation(libs.androidx.media3.ui.compose)
+
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 
     androidTestImplementation(libs.junit)

--- a/Jetchat/app/src/main/AndroidManifest.xml
+++ b/Jetchat/app/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
@@ -31,9 +31,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
@@ -202,6 +205,16 @@ fun ConversationContent(
                 onMessageSent = { content ->
                     uiState.addMessage(
                         Message(authorMe, content, timeNow),
+                    )
+                },
+                onVideoMessageSent = { videoUri, content ->
+                    uiState.addMessage(
+                        Message(
+                            author = authorMe,
+                            content = content,
+                            timestamp = timeNow,
+                            videoUri = videoUri,
+                        ),
                     )
                 },
                 resetScroll = {
@@ -501,6 +514,24 @@ fun ChatItemBubble(message: Message, isUserMe: Boolean, authorClicked: (String) 
                     contentScale = ContentScale.Fit,
                     modifier = Modifier.size(160.dp),
                     contentDescription = stringResource(id = R.string.attached_image),
+                )
+            }
+        }
+
+        message.videoUri?.let { videoUri ->
+            Spacer(modifier = Modifier.height(4.dp))
+            Surface(
+                color = backgroundBubbleColor,
+                shape = ChatBubbleShape,
+            ) {
+                VideoPlayer(
+                    videoUri = videoUri,
+                    autoPlay = false,
+                    shape = ChatBubbleShape,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .clip(ChatBubbleShape),
                 )
             }
         }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
@@ -492,19 +492,24 @@ fun ChatItemBubble(message: Message, isUserMe: Boolean, authorClicked: (String) 
     }
 
     Column {
-        Surface(
-            color = backgroundBubbleColor,
-            shape = ChatBubbleShape,
-        ) {
-            ClickableMessage(
-                message = message,
-                isUserMe = isUserMe,
-                authorClicked = authorClicked,
-            )
+        val hasText = message.content.isNotBlank() || (message.image == null && message.videoUri == null)
+        if (hasText) {
+            Surface(
+                color = backgroundBubbleColor,
+                shape = ChatBubbleShape,
+            ) {
+                ClickableMessage(
+                    message = message,
+                    isUserMe = isUserMe,
+                    authorClicked = authorClicked,
+                )
+            }
         }
 
         message.image?.let {
-            Spacer(modifier = Modifier.height(4.dp))
+            if (hasText) {
+                Spacer(modifier = Modifier.height(4.dp))
+            }
             Surface(
                 color = backgroundBubbleColor,
                 shape = ChatBubbleShape,
@@ -519,7 +524,9 @@ fun ChatItemBubble(message: Message, isUserMe: Boolean, authorClicked: (String) 
         }
 
         message.videoUri?.let { videoUri ->
-            Spacer(modifier = Modifier.height(4.dp))
+            if (hasText || message.image != null) {
+                Spacer(modifier = Modifier.height(4.dp))
+            }
             Surface(
                 color = backgroundBubbleColor,
                 shape = ChatBubbleShape,

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
@@ -19,6 +19,10 @@
 package com.example.compose.jetchat.conversation
 
 import android.content.ClipDescription
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -31,12 +35,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
@@ -69,6 +71,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -167,65 +170,83 @@ fun ConversationContent(
         }
     }
 
-    Scaffold(
-        topBar = {
-            ChannelNameBar(
-                channelName = uiState.channelName,
-                channelMembers = uiState.channelMembers,
-                onNavIconPressed = onNavIconPressed,
-                scrollBehavior = scrollBehavior,
-            )
-        },
-        // Exclude ime and navigation bar padding so this can be added by the UserInput composable
-        contentWindowInsets = ScaffoldDefaults
-            .contentWindowInsets
-            .exclude(WindowInsets.navigationBars)
-            .exclude(WindowInsets.ime),
-        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-    ) { paddingValues ->
-        Column(
-            Modifier.fillMaxSize().padding(paddingValues)
-                .background(color = background)
-                .border(width = 2.dp, color = borderStroke)
-                .dragAndDropTarget(shouldStartDragAndDrop = { event ->
-                    event
-                        .mimeTypes()
-                        .contains(
-                            ClipDescription.MIMETYPE_TEXT_PLAIN,
+    var activeVideoUri by rememberSaveable { mutableStateOf<String?>(null) }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Scaffold(
+            topBar = {
+                ChannelNameBar(
+                    channelName = uiState.channelName,
+                    channelMembers = uiState.channelMembers,
+                    onNavIconPressed = onNavIconPressed,
+                    scrollBehavior = scrollBehavior,
+                )
+            },
+            // Exclude ime and navigation bar padding so this can be added by the UserInput composable
+            contentWindowInsets = ScaffoldDefaults
+                .contentWindowInsets
+                .exclude(WindowInsets.navigationBars)
+                .exclude(WindowInsets.ime),
+            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        ) { paddingValues ->
+            Column(
+                Modifier.fillMaxSize().padding(paddingValues)
+                    .background(color = background)
+                    .border(width = 2.dp, color = borderStroke)
+                    .dragAndDropTarget(shouldStartDragAndDrop = { event ->
+                        event
+                            .mimeTypes()
+                            .contains(
+                                ClipDescription.MIMETYPE_TEXT_PLAIN,
+                            )
+                    }, target = dragAndDropCallback),
+            ) {
+                Messages(
+                    messages = uiState.messages,
+                    navigateToProfile = navigateToProfile,
+                    modifier = Modifier.weight(1f),
+                    scrollState = scrollState,
+                    onVideoClick = { videoUri -> activeVideoUri = videoUri },
+                )
+                UserInput(
+                    onMessageSent = { content ->
+                        uiState.addMessage(
+                            Message(authorMe, content, timeNow),
                         )
-                }, target = dragAndDropCallback),
+                    },
+                    onVideoMessageSent = { videoUri, content ->
+                        uiState.addMessage(
+                            Message(
+                                author = authorMe,
+                                content = content,
+                                timestamp = timeNow,
+                                videoUri = videoUri,
+                            ),
+                        )
+                    },
+                    resetScroll = {
+                        scope.launch {
+                            scrollState.scrollToItem(0)
+                        }
+                    },
+                    // let this element handle the padding so that the elevation is shown behind the
+                    // navigation bar
+                    modifier = Modifier.navigationBarsPadding().imePadding(),
+                )
+            }
+        }
+
+        AnimatedVisibility(
+            visible = activeVideoUri != null,
+            enter = fadeIn(animationSpec = tween(200)),
+            exit = fadeOut(animationSpec = tween(200)),
         ) {
-            Messages(
-                messages = uiState.messages,
-                navigateToProfile = navigateToProfile,
-                modifier = Modifier.weight(1f),
-                scrollState = scrollState,
-            )
-            UserInput(
-                onMessageSent = { content ->
-                    uiState.addMessage(
-                        Message(authorMe, content, timeNow),
-                    )
-                },
-                onVideoMessageSent = { videoUri, content ->
-                    uiState.addMessage(
-                        Message(
-                            author = authorMe,
-                            content = content,
-                            timestamp = timeNow,
-                            videoUri = videoUri,
-                        ),
-                    )
-                },
-                resetScroll = {
-                    scope.launch {
-                        scrollState.scrollToItem(0)
-                    }
-                },
-                // let this element handle the padding so that the elevation is shown behind the
-                // navigation bar
-                modifier = Modifier.navigationBarsPadding().imePadding(),
-            )
+            activeVideoUri?.let { uri ->
+                FullScreenVideoPlayer(
+                    videoUri = uri,
+                    onDismiss = { activeVideoUri = null },
+                )
+            }
         }
     }
 }
@@ -290,7 +311,13 @@ fun ChannelNameBar(
 const val ConversationTestTag = "ConversationTestTag"
 
 @Composable
-fun Messages(messages: List<Message>, navigateToProfile: (String) -> Unit, scrollState: LazyListState, modifier: Modifier = Modifier) {
+fun Messages(
+    messages: List<Message>,
+    navigateToProfile: (String) -> Unit,
+    scrollState: LazyListState,
+    modifier: Modifier = Modifier,
+    onVideoClick: (String) -> Unit = {},
+) {
     val scope = rememberCoroutineScope()
     Box(modifier = modifier) {
 
@@ -327,6 +354,7 @@ fun Messages(messages: List<Message>, navigateToProfile: (String) -> Unit, scrol
                         isUserMe = content.author == authorMe,
                         isFirstMessageByAuthor = isFirstMessageByAuthor,
                         isLastMessageByAuthor = isLastMessageByAuthor,
+                        onVideoClick = onVideoClick,
                     )
                 }
             }
@@ -366,6 +394,7 @@ fun Message(
     isUserMe: Boolean,
     isFirstMessageByAuthor: Boolean,
     isLastMessageByAuthor: Boolean,
+    onVideoClick: (String) -> Unit = {},
 ) {
     val borderColor = if (isUserMe) {
         MaterialTheme.colorScheme.primary
@@ -400,6 +429,7 @@ fun Message(
             isFirstMessageByAuthor = isFirstMessageByAuthor,
             isLastMessageByAuthor = isLastMessageByAuthor,
             authorClicked = onAuthorClick,
+            onVideoClick = onVideoClick,
             modifier = Modifier
                 .padding(end = 16.dp)
                 .weight(1f),
@@ -415,12 +445,18 @@ fun AuthorAndTextMessage(
     isLastMessageByAuthor: Boolean,
     authorClicked: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onVideoClick: (String) -> Unit = {},
 ) {
     Column(modifier = modifier) {
         if (isLastMessageByAuthor) {
             AuthorNameTimestamp(msg)
         }
-        ChatItemBubble(msg, isUserMe, authorClicked = authorClicked)
+        ChatItemBubble(
+            message = msg,
+            isUserMe = isUserMe,
+            authorClicked = authorClicked,
+            onVideoClick = onVideoClick,
+        )
         if (isFirstMessageByAuthor) {
             // Last bubble before next author
             Spacer(modifier = Modifier.height(8.dp))
@@ -483,7 +519,7 @@ private fun RowScope.DayHeaderLine() {
 }
 
 @Composable
-fun ChatItemBubble(message: Message, isUserMe: Boolean, authorClicked: (String) -> Unit) {
+fun ChatItemBubble(message: Message, isUserMe: Boolean, authorClicked: (String) -> Unit, onVideoClick: (String) -> Unit = {}) {
 
     val backgroundBubbleColor = if (isUserMe) {
         MaterialTheme.colorScheme.primary
@@ -531,9 +567,9 @@ fun ChatItemBubble(message: Message, isUserMe: Boolean, authorClicked: (String) 
                 color = backgroundBubbleColor,
                 shape = ChatBubbleShape,
             ) {
-                VideoPlayer(
+                VideoThumbnail(
                     videoUri = videoUri,
-                    autoPlay = false,
+                    onClick = { onVideoClick(videoUri) },
                     shape = ChatBubbleShape,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/ConversationUiState.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/ConversationUiState.kt
@@ -36,4 +36,5 @@ data class Message(
     val timestamp: String,
     val image: Int? = null,
     val authorImage: Int = if (author == "me") R.drawable.ali else R.drawable.someone_else,
+    val videoUri: String? = null,
 )

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
@@ -37,15 +37,18 @@ import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.spatial.RelativeLayoutBounds
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
+import java.util.WeakHashMap
 
 /**
  * Data specification for a blur region placed over a SurfaceView.
  */
 data class BlurRegionSpec(
     val id: String,
-    val boundsInSurface: RectF,
-    val cornerRadiusPx: Float,
+    val boundsInSurface: RectF = RectF(),
+    val boundsInWindow: IntRect = IntRect.Zero,
+    val cornerRadiusPx: Float = 0f,
     val blurRadiusPx: Float = 50f,
     val alpha: Float = 1.0f,
 )
@@ -55,6 +58,7 @@ data class BlurRegionSpec(
  */
 object SurfaceViewBlurHelper {
     private const val TAG = "SurfaceViewBlurHelper"
+    private val lastAppliedRegions = WeakHashMap<SurfaceView, List<BlurRegionSpec>>()
 
     /**
      * Applies a collection of blur regions to the given SurfaceView.
@@ -79,13 +83,19 @@ object SurfaceViewBlurHelper {
 
     @RequiresApi(37)
     private fun applyBlurRegionsInternal(surfaceView: SurfaceView, regions: Collection<BlurRegionSpec>) {
-        if (regions.isEmpty()) {
+        val regionList = if (regions.isEmpty()) emptyList() else regions.toList()
+        if (lastAppliedRegions[surfaceView] == regionList) {
+            return
+        }
+        lastAppliedRegions[surfaceView] = regionList
+
+        if (regionList.isEmpty()) {
             surfaceView.setBlurRegions(emptyList())
             return
         }
 
-        val blurRegions = ArrayList<BlurRegion>(regions.size)
-        for (spec in regions) {
+        val blurRegions = ArrayList<BlurRegion>(regionList.size)
+        for (spec in regionList) {
             if (spec.boundsInSurface.width() <= 0f || spec.boundsInSurface.height() <= 0f) continue
             val roundedRectRegion = RoundedRectBlurRegion().apply {
                 bounds = spec.boundsInSurface
@@ -107,7 +117,7 @@ object SurfaceViewBlurHelper {
 @Composable
 fun Modifier.registerBlurRegion(
     id: String,
-    surfaceCoordinates: LayoutCoordinates?,
+    surfaceCoordinates: LayoutCoordinates? = null,
     cornerRadius: Dp,
     blurRadius: Dp = 20.dp,
     alpha: Float = 1.0f,
@@ -127,35 +137,36 @@ fun Modifier.registerBlurRegion(
         }
     }
 
-    var lastRect by remember(id) { mutableStateOf<RectF?>(null) }
+    var lastBounds by remember(id) { mutableStateOf<IntRect?>(null) }
 
-    return this.onLayoutRectChanged(throttleMillis = 16, debounceMillis = 0) { bounds: RelativeLayoutBounds ->
-        if (surfaceCoordinates != null && surfaceCoordinates.isAttached) {
-            val surfacePosInWindow = surfaceCoordinates.positionInWindow()
-            val surfaceW = surfaceCoordinates.size.width.toFloat()
-            val surfaceH = surfaceCoordinates.size.height.toFloat()
-
-            val boxInWindow = bounds.boundsInWindow
-            val left = (boxInWindow.left - surfacePosInWindow.x).coerceIn(0f, surfaceW)
-            val top = (boxInWindow.top - surfacePosInWindow.y).coerceIn(0f, surfaceH)
-            val right = (boxInWindow.right - surfacePosInWindow.x).coerceIn(0f, surfaceW)
-            val bottom = (boxInWindow.bottom - surfacePosInWindow.y).coerceIn(0f, surfaceH)
-
-            if (right > left && bottom > top) {
-                val prev = lastRect
-                if (prev == null || prev.left != left || prev.top != top || prev.right != right || prev.bottom != bottom) {
-                    val newRect = RectF(left, top, right, bottom)
-                    lastRect = newRect
-                    currentOnUpdateRegion(
-                        BlurRegionSpec(
-                            id = id,
-                            boundsInSurface = newRect,
-                            cornerRadiusPx = cornerRadiusPx,
-                            blurRadiusPx = blurRadiusPx,
-                            alpha = alpha,
-                        ),
-                    )
+    return this.onLayoutRectChanged(throttleMillis = 0, debounceMillis = 0) { bounds: RelativeLayoutBounds ->
+        val boxInWindow = bounds.boundsInWindow
+        if (boxInWindow.width > 0 && boxInWindow.height > 0) {
+            val prev = lastBounds
+            if (prev == null || prev != boxInWindow) {
+                lastBounds = boxInWindow
+                val boundsInSurface = if (surfaceCoordinates != null && surfaceCoordinates.isAttached) {
+                    val surfacePos = surfaceCoordinates.positionInWindow()
+                    val surfaceW = surfaceCoordinates.size.width.toFloat()
+                    val surfaceH = surfaceCoordinates.size.height.toFloat()
+                    val left = (boxInWindow.left.toFloat() - surfacePos.x).coerceIn(0f, surfaceW)
+                    val top = (boxInWindow.top.toFloat() - surfacePos.y).coerceIn(0f, surfaceH)
+                    val right = (boxInWindow.right.toFloat() - surfacePos.x).coerceIn(0f, surfaceW)
+                    val bottom = (boxInWindow.bottom.toFloat() - surfacePos.y).coerceIn(0f, surfaceH)
+                    RectF(left, top, right, bottom)
+                } else {
+                    RectF()
                 }
+                currentOnUpdateRegion(
+                    BlurRegionSpec(
+                        id = id,
+                        boundsInSurface = boundsInSurface,
+                        boundsInWindow = boxInWindow,
+                        cornerRadiusPx = cornerRadiusPx,
+                        blurRadiusPx = blurRadiusPx,
+                        alpha = alpha,
+                    ),
+                )
             }
         }
     }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
@@ -25,6 +25,11 @@ import android.view.SurfaceView
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onLayoutRectChanged
@@ -52,9 +57,9 @@ object SurfaceViewBlurHelper {
     private const val TAG = "SurfaceViewBlurHelper"
 
     /**
-     * Applies a list of blur regions to the given SurfaceView.
+     * Applies a collection of blur regions to the given SurfaceView.
      */
-    fun applyBlurRegions(surfaceView: SurfaceView?, regions: List<BlurRegionSpec>) {
+    fun applyBlurRegions(surfaceView: SurfaceView?, regions: Collection<BlurRegionSpec>) {
         if (surfaceView == null) return
         try {
             if (Build.VERSION.SDK_INT >= 37) {
@@ -73,7 +78,7 @@ object SurfaceViewBlurHelper {
     }
 
     @RequiresApi(37)
-    private fun applyBlurRegionsInternal(surfaceView: SurfaceView, regions: List<BlurRegionSpec>) {
+    private fun applyBlurRegionsInternal(surfaceView: SurfaceView, regions: Collection<BlurRegionSpec>) {
         if (regions.isEmpty()) {
             surfaceView.setBlurRegions(emptyList())
             return
@@ -110,16 +115,21 @@ fun Modifier.registerBlurRegion(
     onRemoveRegion: (String) -> Unit,
 ): Modifier {
     val density = LocalDensity.current
-    val cornerRadiusPx = with(density) { cornerRadius.toPx() }
-    val blurRadiusPx = with(density) { blurRadius.toPx() }
+    val cornerRadiusPx = remember(density, cornerRadius) { with(density) { cornerRadius.toPx() } }
+    val blurRadiusPx = remember(density, blurRadius) { with(density) { blurRadius.toPx() } }
+
+    val currentOnUpdateRegion by rememberUpdatedState(onUpdateRegion)
+    val currentOnRemoveRegion by rememberUpdatedState(onRemoveRegion)
 
     DisposableEffect(id) {
         onDispose {
-            onRemoveRegion(id)
+            currentOnRemoveRegion(id)
         }
     }
 
-    return this.onLayoutRectChanged(throttleMillis = 0, debounceMillis = 0) { bounds: RelativeLayoutBounds ->
+    var lastRect by remember(id) { mutableStateOf<RectF?>(null) }
+
+    return this.onLayoutRectChanged(throttleMillis = 16, debounceMillis = 0) { bounds: RelativeLayoutBounds ->
         if (surfaceCoordinates != null && surfaceCoordinates.isAttached) {
             val surfacePosInWindow = surfaceCoordinates.positionInWindow()
             val surfaceW = surfaceCoordinates.size.width.toFloat()
@@ -132,15 +142,20 @@ fun Modifier.registerBlurRegion(
             val bottom = (boxInWindow.bottom - surfacePosInWindow.y).coerceIn(0f, surfaceH)
 
             if (right > left && bottom > top) {
-                onUpdateRegion(
-                    BlurRegionSpec(
-                        id = id,
-                        boundsInSurface = RectF(left, top, right, bottom),
-                        cornerRadiusPx = cornerRadiusPx,
-                        blurRadiusPx = blurRadiusPx,
-                        alpha = alpha,
-                    ),
-                )
+                val prev = lastRect
+                if (prev == null || prev.left != left || prev.top != top || prev.right != right || prev.bottom != bottom) {
+                    val newRect = RectF(left, top, right, bottom)
+                    lastRect = newRect
+                    currentOnUpdateRegion(
+                        BlurRegionSpec(
+                            id = id,
+                            boundsInSurface = newRect,
+                            cornerRadiusPx = cornerRadiusPx,
+                            blurRadiusPx = blurRadiusPx,
+                            alpha = alpha,
+                        ),
+                    )
+                }
             }
         }
     }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.jetchat.conversation
+
+import android.graphics.RectF
+import android.os.Build
+import android.util.Log
+import android.view.BlurRegion
+import android.view.RoundedRectBlurRegion
+import android.view.SurfaceView
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onLayoutRectChanged
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.spatial.RelativeLayoutBounds
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Data specification for a blur region placed over a SurfaceView.
+ */
+data class BlurRegionSpec(
+    val id: String,
+    val boundsInSurface: RectF,
+    val cornerRadiusPx: Float,
+    val blurRadiusPx: Float = 50f,
+    val alpha: Float = 1.0f,
+)
+
+/**
+ * Helper to manage SurfaceView#setBlurRegions platform API.
+ */
+object SurfaceViewBlurHelper {
+    private const val TAG = "SurfaceViewBlurHelper"
+
+    /**
+     * Applies a list of blur regions to the given SurfaceView.
+     */
+    fun applyBlurRegions(surfaceView: SurfaceView?, regions: List<BlurRegionSpec>) {
+        if (surfaceView == null) return
+        try {
+            if (Build.VERSION.SDK_INT >= 37) {
+                applyBlurRegionsInternal(surfaceView, regions)
+            }
+        } catch (e: Throwable) {
+            Log.w(TAG, "Failed to apply blur regions to SurfaceView", e)
+        }
+    }
+
+    /**
+     * Clears all blur regions on the given SurfaceView.
+     */
+    fun clearBlurRegions(surfaceView: SurfaceView?) {
+        applyBlurRegions(surfaceView, emptyList())
+    }
+
+    @RequiresApi(37)
+    private fun applyBlurRegionsInternal(surfaceView: SurfaceView, regions: List<BlurRegionSpec>) {
+        if (regions.isEmpty()) {
+            surfaceView.setBlurRegions(emptyList())
+            return
+        }
+
+        val blurRegions = ArrayList<BlurRegion>(regions.size)
+        for (spec in regions) {
+            if (spec.boundsInSurface.width() <= 0f || spec.boundsInSurface.height() <= 0f) continue
+            val roundedRectRegion = RoundedRectBlurRegion().apply {
+                bounds = spec.boundsInSurface
+                setCornerRadii(spec.cornerRadiusPx.coerceAtLeast(0f))
+                alpha = spec.alpha.coerceIn(0f, 1f)
+                blurRadius = spec.blurRadiusPx.coerceAtLeast(0f)
+            }
+            blurRegions.add(roundedRectRegion)
+        }
+        surfaceView.setBlurRegions(blurRegions)
+    }
+}
+
+/**
+ * Modifier to register and track a control's bounding box relative to the underlying SurfaceView,
+ * enabling SurfaceView#setBlurRegions to blur the region underneath this control.
+ * This modifier doesn't do blurring itself.
+ */
+@Composable
+fun Modifier.registerBlurRegion(
+    id: String,
+    surfaceCoordinates: LayoutCoordinates?,
+    cornerRadius: Dp,
+    blurRadius: Dp = 20.dp,
+    alpha: Float = 1.0f,
+    onUpdateRegion: (BlurRegionSpec) -> Unit,
+    onRemoveRegion: (String) -> Unit,
+): Modifier {
+    val density = LocalDensity.current
+    val cornerRadiusPx = with(density) { cornerRadius.toPx() }
+    val blurRadiusPx = with(density) { blurRadius.toPx() }
+
+    DisposableEffect(id) {
+        onDispose {
+            onRemoveRegion(id)
+        }
+    }
+
+    return this.onLayoutRectChanged(throttleMillis = 0, debounceMillis = 0) { bounds: RelativeLayoutBounds ->
+        if (surfaceCoordinates != null && surfaceCoordinates.isAttached) {
+            val surfacePosInWindow = surfaceCoordinates.positionInWindow()
+            val surfaceW = surfaceCoordinates.size.width.toFloat()
+            val surfaceH = surfaceCoordinates.size.height.toFloat()
+
+            val boxInWindow = bounds.boundsInWindow
+            val left = (boxInWindow.left - surfacePosInWindow.x).coerceIn(0f, surfaceW)
+            val top = (boxInWindow.top - surfacePosInWindow.y).coerceIn(0f, surfaceH)
+            val right = (boxInWindow.right - surfacePosInWindow.x).coerceIn(0f, surfaceW)
+            val bottom = (boxInWindow.bottom - surfacePosInWindow.y).coerceIn(0f, surfaceH)
+
+            if (right > left && bottom > top) {
+                onUpdateRegion(
+                    BlurRegionSpec(
+                        id = id,
+                        boundsInSurface = RectF(left, top, right, bottom),
+                        cornerRadiusPx = cornerRadiusPx,
+                        blurRadiusPx = blurRadiusPx,
+                        alpha = alpha,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/SurfaceViewBlur.kt
@@ -31,9 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onLayoutRectChanged
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.spatial.RelativeLayoutBounds
 import androidx.compose.ui.unit.Dp
@@ -117,7 +115,6 @@ object SurfaceViewBlurHelper {
 @Composable
 fun Modifier.registerBlurRegion(
     id: String,
-    surfaceCoordinates: LayoutCoordinates? = null,
     cornerRadius: Dp,
     blurRadius: Dp = 20.dp,
     alpha: Float = 1.0f,
@@ -145,22 +142,9 @@ fun Modifier.registerBlurRegion(
             val prev = lastBounds
             if (prev == null || prev != boxInWindow) {
                 lastBounds = boxInWindow
-                val boundsInSurface = if (surfaceCoordinates != null && surfaceCoordinates.isAttached) {
-                    val surfacePos = surfaceCoordinates.positionInWindow()
-                    val surfaceW = surfaceCoordinates.size.width.toFloat()
-                    val surfaceH = surfaceCoordinates.size.height.toFloat()
-                    val left = (boxInWindow.left.toFloat() - surfacePos.x).coerceIn(0f, surfaceW)
-                    val top = (boxInWindow.top.toFloat() - surfacePos.y).coerceIn(0f, surfaceH)
-                    val right = (boxInWindow.right.toFloat() - surfacePos.x).coerceIn(0f, surfaceW)
-                    val bottom = (boxInWindow.bottom.toFloat() - surfacePos.y).coerceIn(0f, surfaceH)
-                    RectF(left, top, right, bottom)
-                } else {
-                    RectF()
-                }
                 currentOnUpdateRegion(
                     BlurRegionSpec(
                         id = id,
-                        boundsInSurface = boundsInSurface,
                         boundsInWindow = boxInWindow,
                         cornerRadiusPx = cornerRadiusPx,
                         blurRadiusPx = blurRadiusPx,

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
@@ -169,7 +169,7 @@ fun UserInput(
     val sendMessage = {
         val currentVideoUri = attachedVideoUri
         if (currentVideoUri != null) {
-            onVideoMessageSent(currentVideoUri, textState.text)
+            onVideoMessageSent(currentVideoUri, textState.text.trim())
             attachedVideoUri = null
         } else if (textState.text.isNotBlank()) {
             onMessageSent(textState.text)

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
@@ -16,7 +16,10 @@
 
 package com.example.compose.jetchat.conversation
 
+import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -27,9 +30,11 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -109,6 +114,7 @@ import kotlin.math.absoluteValue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 enum class InputSelector {
     NONE,
@@ -132,7 +138,12 @@ fun UserInputPreview() {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun UserInput(onMessageSent: (String) -> Unit, modifier: Modifier = Modifier, resetScroll: () -> Unit = {}) {
+fun UserInput(
+    onMessageSent: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    resetScroll: () -> Unit = {},
+    onVideoMessageSent: (videoUri: String, caption: String) -> Unit = { _, _ -> },
+) {
     var currentInputSelector by rememberSaveable { mutableStateOf(InputSelector.NONE) }
     val dismissKeyboard = { currentInputSelector = InputSelector.NONE }
 
@@ -145,11 +156,47 @@ fun UserInput(onMessageSent: (String) -> Unit, modifier: Modifier = Modifier, re
         mutableStateOf(TextFieldValue())
     }
 
+    var attachedVideoUri by rememberSaveable { mutableStateOf<String?>(null) }
+
+    val videoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+    ) { uri: Uri? ->
+        uri?.let {
+            attachedVideoUri = it.toString()
+        }
+    }
+
+    val sendMessage = {
+        val currentVideoUri = attachedVideoUri
+        if (currentVideoUri != null) {
+            onVideoMessageSent(currentVideoUri, textState.text)
+            attachedVideoUri = null
+        } else if (textState.text.isNotBlank()) {
+            onMessageSent(textState.text)
+        }
+        textState = TextFieldValue()
+        resetScroll()
+        dismissKeyboard()
+    }
+
     // Used to decide if the keyboard should be shown
     var textFieldFocusState by remember { mutableStateOf(false) }
 
     Surface(tonalElevation = 2.dp, contentColor = MaterialTheme.colorScheme.secondary) {
         Column(modifier = modifier) {
+            AnimatedVisibility(
+                visible = attachedVideoUri != null,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                attachedVideoUri?.let { videoUri ->
+                    AttachedVideoPreview(
+                        videoUri = videoUri,
+                        onRemove = { attachedVideoUri = null },
+                    )
+                }
+            }
+
             UserInputText(
                 textFieldValue = textState,
                 onTextChanged = { textState = it },
@@ -163,32 +210,61 @@ fun UserInput(onMessageSent: (String) -> Unit, modifier: Modifier = Modifier, re
                     }
                     textFieldFocusState = focused
                 },
-                onMessageSent = {
-                    onMessageSent(textState.text)
-                    // Reset text field and close keyboard
-                    textState = TextFieldValue()
-                    // Move scroll to bottom
-                    resetScroll()
-                },
+                onMessageSent = { sendMessage() },
                 focusState = textFieldFocusState,
             )
             UserInputSelector(
                 onSelectorChange = { currentInputSelector = it },
-                sendMessageEnabled = textState.text.isNotBlank(),
-                onMessageSent = {
-                    onMessageSent(textState.text)
-                    // Reset text field and close keyboard
-                    textState = TextFieldValue()
-                    // Move scroll to bottom
-                    resetScroll()
-                    dismissKeyboard()
-                },
+                sendMessageEnabled = textState.text.isNotBlank() || attachedVideoUri != null,
+                onMessageSent = sendMessage,
                 currentInputSelector = currentInputSelector,
+                onVideoClick = {
+                    currentInputSelector = InputSelector.NONE
+                    videoPickerLauncher.launch("video/*")
+                },
             )
             SelectorExpanded(
                 onCloseRequested = dismissKeyboard,
                 onTextAdded = { textState = textState.addText(it) },
                 currentSelector = currentInputSelector,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AttachedVideoPreview(videoUri: String, onRemove: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 4.dp),
+    ) {
+        VideoPlayer(
+            videoUri = videoUri,
+            autoPlay = false,
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(180.dp)
+                .clip(RoundedCornerShape(12.dp)),
+        )
+
+        IconButton(
+            onClick = onRemove,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(8.dp)
+                .size(32.dp)
+                .background(
+                    color = Color.Black.copy(alpha = 0.65f),
+                    shape = CircleShape,
+                ),
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_close),
+                contentDescription = stringResource(id = R.string.remove_attached_video),
+                tint = Color.White,
+                modifier = Modifier.size(18.dp),
             )
         }
     }
@@ -268,6 +344,7 @@ private fun UserInputSelector(
     onMessageSent: () -> Unit,
     currentInputSelector: InputSelector,
     modifier: Modifier = Modifier,
+    onVideoClick: () -> Unit = {},
 ) {
     Row(
         modifier = modifier
@@ -301,9 +378,9 @@ private fun UserInputSelector(
             description = stringResource(id = R.string.map_selector_desc),
         )
         InputSelectorButton(
-            onClick = { onSelectorChange(InputSelector.PHONE) },
+            onClick = onVideoClick,
             icon = painterResource(id = R.drawable.ic_duo),
-            selected = currentInputSelector == InputSelector.PHONE,
+            selected = false,
             description = stringResource(id = R.string.videochat_desc),
         )
 
@@ -506,7 +583,7 @@ private fun RecordingIndicator(swipeOffset: () -> Float) {
     var duration by remember { mutableStateOf(Duration.ZERO) }
     LaunchedEffect(Unit) {
         while (true) {
-            delay(1000)
+            delay(1000.milliseconds)
             duration += 1.seconds
         }
     }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
@@ -112,9 +112,9 @@ import com.example.compose.jetchat.FunctionalityNotAvailablePopup
 import com.example.compose.jetchat.R
 import kotlin.math.absoluteValue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
-import kotlin.time.Duration.Companion.milliseconds
 
 enum class InputSelector {
     NONE,

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -221,6 +221,8 @@ private fun VideoPlayerSurface(
                 val bottom = if (extendsPastBase) surfaceH else boxBottom.coerceIn(0f, surfaceH)
 
                 if (right > left && bottom > top) {
+                    // The region overlaps outside the SurfaceView, so the corner radius
+                    // shouldn't be applied in this case
                     val cornerRadius = if (isFullRectangle) 0f else spec.cornerRadiusPx
                     spec.copy(
                         boundsInSurface = RectF(left, top, right, bottom),
@@ -260,7 +262,7 @@ private fun VideoPlayerSurface(
         }
     }
 
-    BoxWithConstraints(
+    Box(
         modifier = modifier
             .clip(shape)
             .background(Color.Black)
@@ -273,19 +275,8 @@ private fun VideoPlayerSurface(
             },
         contentAlignment = Alignment.Center,
     ) {
-        val containerWidth = maxWidth
-        val containerHeight = maxHeight
-        val hasBoundedWidth = containerWidth.isSpecified && containerWidth > 0.dp && containerWidth != Dp.Infinity
-        val hasBoundedHeight = containerHeight.isSpecified && containerHeight > 0.dp && containerHeight != Dp.Infinity
-
-        val matchHeight = if (hasBoundedWidth && hasBoundedHeight) {
-            (containerWidth.value / containerHeight.value) > videoAspectRatio
-        } else {
-            hasBoundedHeight && !hasBoundedWidth
-        }
-
         Box(
-            modifier = Modifier.aspectRatio(videoAspectRatio, matchHeightConstraintsFirst = matchHeight),
+            modifier = Modifier.aspectRatio(videoAspectRatio, matchHeightConstraintsFirst = true),
             contentAlignment = Alignment.Center,
         ) {
             // SurfaceView rendering the video directly from ExoPlayer

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -247,11 +247,11 @@ fun FullScreenVideoPlayer(videoUri: String, onDismiss: () -> Unit, modifier: Mod
 
                 val left = boxLeft.coerceIn(0f, surfaceW)
                 val top = boxTop.coerceIn(0f, surfaceH)
-                val right =  boxRight.coerceIn(0f, surfaceW)
+                val right = boxRight.coerceIn(0f, surfaceW)
                 val bottom = boxBottom.coerceIn(0f, surfaceH)
 
                 if (right > left && bottom > top) {
-                    val cornerRadius =  spec.cornerRadiusPx
+                    val cornerRadius = spec.cornerRadiusPx
                     spec.copy(
                         boundsInSurface = RectF(left, top, right, bottom),
                         cornerRadiusPx = cornerRadius,

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.jetchat.conversation
+
+import android.net.Uri
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import androidx.annotation.OptIn
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.compose.state.rememberMuteButtonState
+import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
+import androidx.media3.ui.compose.state.rememberPresentationState
+import androidx.media3.ui.compose.state.rememberProgressStateWithTickInterval
+import com.example.compose.jetchat.R
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+import androidx.core.net.toUri
+
+const val DEFAULT_VIDEO_URL =
+    "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_5MB.mp4"
+
+/**
+ * Composable video player utilizing SurfaceView and the platform setBlurRegions API
+ * to blur regions directly underneath the overlay controls.
+ *
+ * Hoists a single ExoPlayer instance, eliminating redundant boolean flags and state
+ * duplication between inline and fullscreen playback.
+ */
+@Composable
+fun VideoPlayer(
+    videoUri: String,
+    modifier: Modifier = Modifier,
+    autoPlay: Boolean = false,
+    shape: Shape = RoundedCornerShape(16.dp),
+) {
+    val context = LocalContext.current
+    val resolvedUri = remember(videoUri) { resolveVideoUri(videoUri) }
+
+    // Single ExoPlayer instance shared seamlessly between inline and fullscreen views
+    val exoPlayer = remember(context, resolvedUri) {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(MediaItem.fromUri(resolvedUri))
+            repeatMode = Player.REPEAT_MODE_ALL
+            playWhenReady = autoPlay
+            prepare()
+        }
+    }
+    DisposableEffect(exoPlayer) {
+        onDispose {
+            exoPlayer.release()
+        }
+    }
+
+    var isFullscreen by rememberSaveable { mutableStateOf(false) }
+
+    if (isFullscreen) {
+        Dialog(
+            onDismissRequest = { isFullscreen = false },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false,
+            ),
+        ) {
+            ImmersiveDialogEffect()
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black),
+                contentAlignment = Alignment.Center,
+            ) {
+                VideoPlayerSurface(
+                    exoPlayer = exoPlayer,
+                    modifier = Modifier.fillMaxSize(),
+                    shape = RoundedCornerShape(0.dp),
+                    isFullscreen = true,
+                    onToggleFullscreen = { isFullscreen = false },
+                )
+            }
+        }
+
+        Box(
+            modifier = modifier
+                .clip(shape)
+                .background(Color.Black),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.fullscreen_video),
+                color = Color.White.copy(alpha = 0.7f),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+    } else {
+        VideoPlayerSurface(
+            exoPlayer = exoPlayer,
+            modifier = modifier,
+            shape = shape,
+            isFullscreen = false,
+            onToggleFullscreen = { isFullscreen = true },
+        )
+    }
+}
+
+@OptIn(UnstableApi::class)
+@Composable
+private fun VideoPlayerSurface(
+    exoPlayer: ExoPlayer,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(16.dp),
+    isFullscreen: Boolean = false,
+    onToggleFullscreen: () -> Unit = {},
+) {
+    // Read state from Media3 UI Compose state holders
+    val playPauseButtonState = rememberPlayPauseButtonState(exoPlayer)
+    val presentationState = rememberPresentationState(exoPlayer)
+    val muteButtonState = rememberMuteButtonState(exoPlayer)
+    val progressState = rememberProgressStateWithTickInterval(exoPlayer, tickIntervalMs = 200L)
+
+    var controlsVisible by remember { mutableStateOf(true) }
+    var userInteractedTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
+
+    var surfaceViewRef by remember { mutableStateOf<SurfaceView?>(null) }
+    var surfaceCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    val blurRegionSpecs = remember { mutableStateMapOf<String, BlurRegionSpec>() }
+
+    fun updateBlurRegions() {
+        val sv = surfaceViewRef ?: return
+        if (controlsVisible) {
+            SurfaceViewBlurHelper.applyBlurRegions(sv, blurRegionSpecs.values.toList())
+        } else {
+            SurfaceViewBlurHelper.clearBlurRegions(sv)
+        }
+    }
+
+    LaunchedEffect(controlsVisible, blurRegionSpecs.size) {
+        updateBlurRegions()
+    }
+
+    // Auto-hide controls after a period of playback inactivity
+    val isPlaying = !playPauseButtonState.showPlay
+    LaunchedEffect(controlsVisible, isPlaying, userInteractedTime) {
+        if (controlsVisible && isPlaying) {
+            delay(5000.milliseconds)
+            controlsVisible = false
+        }
+    }
+
+    val videoAspectRatio = remember(presentationState.videoSizeDp) {
+        val size = presentationState.videoSizeDp
+        if (size != null && size.width > 0f && size.height > 0f) {
+            val rawRatio = size.width / size.height
+            @Suppress("DEPRECATION")
+            val rotation = exoPlayer.videoSize.unappliedRotationDegrees
+            if (rotation == 90 || rotation == 270) {
+                if (rawRatio > 0f) 1f / rawRatio else 16f / 9f
+            } else {
+                rawRatio
+            }
+        } else {
+            16f / 9f
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .clip(shape)
+            .background(Color.Black)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) {
+                userInteractedTime = System.currentTimeMillis()
+                controlsVisible = !controlsVisible
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        val containerWidth = maxWidth
+        val containerHeight = maxHeight
+        val hasBoundedWidth = containerWidth.isSpecified && containerWidth > 0.dp && containerWidth != Dp.Infinity
+        val hasBoundedHeight = containerHeight.isSpecified && containerHeight > 0.dp && containerHeight != Dp.Infinity
+
+        val matchHeight = if (hasBoundedWidth && hasBoundedHeight) {
+            (containerWidth.value / containerHeight.value) > videoAspectRatio
+        } else {
+            hasBoundedHeight && !hasBoundedWidth
+        }
+
+        Box(
+            modifier = Modifier.aspectRatio(videoAspectRatio, matchHeightConstraintsFirst = matchHeight),
+            contentAlignment = Alignment.Center,
+        ) {
+            // SurfaceView rendering the video directly from ExoPlayer
+            AndroidView(
+                factory = { ctx ->
+                    SurfaceView(ctx).apply {
+                        surfaceViewRef = this
+                        exoPlayer.setVideoSurfaceView(this)
+                        holder.addCallback(
+                            object : SurfaceHolder.Callback {
+                                override fun surfaceCreated(holder: SurfaceHolder) {
+                                    updateBlurRegions()
+                                }
+
+                                override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+                                    updateBlurRegions()
+                                }
+
+                                override fun surfaceDestroyed(holder: SurfaceHolder) {
+                                    SurfaceViewBlurHelper.clearBlurRegions(this@apply)
+                                }
+                            },
+                        )
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onGloballyPositioned { coords ->
+                        surfaceCoordinates = coords
+                        updateBlurRegions()
+                    },
+                update = { sv ->
+                    surfaceViewRef = sv
+                    exoPlayer.setVideoSurfaceView(sv)
+                },
+            )
+
+            // Placeholder shutter while video is loading / resetting
+            if (presentationState.coverSurface) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black),
+                )
+            }
+        }
+
+        // Overlay controls that blur the regions underneath using SurfaceView#setBlurRegions
+        AnimatedVisibility(
+            visible = controlsVisible,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            VideoPlayerOverlayControls(
+                playPauseButtonState = playPauseButtonState,
+                muteButtonState = muteButtonState,
+                progressState = progressState,
+                isFullscreen = isFullscreen,
+                surfaceCoordinates = surfaceCoordinates,
+                blurRegionSpecs = blurRegionSpecs,
+                onUserInteraction = {
+                    userInteractedTime = System.currentTimeMillis()
+                },
+                onSeekTo = { progressFraction ->
+                    val duration = progressState.durationMs
+                    if (duration > 0) {
+                        exoPlayer.seekTo((progressFraction * duration).toLong())
+                    }
+                },
+                onToggleFullscreen = onToggleFullscreen,
+                onUpdateBlurRegions = { updateBlurRegions() },
+            )
+        }
+    }
+}
+
+private fun resolveVideoUri(videoUri: String): Uri {
+    return if (videoUri.isNotBlank()) {
+        videoUri.toUri()
+    } else {
+        DEFAULT_VIDEO_URL.toUri()
+    }
+}

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
@@ -67,9 +68,8 @@ import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
 import androidx.media3.ui.compose.state.rememberPresentationState
 import androidx.media3.ui.compose.state.rememberProgressStateWithTickInterval
 import com.example.compose.jetchat.R
-import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
-import androidx.core.net.toUri
+import kotlinx.coroutines.delay
 
 const val DEFAULT_VIDEO_URL =
     "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_5MB.mp4"
@@ -82,12 +82,7 @@ const val DEFAULT_VIDEO_URL =
  * duplication between inline and fullscreen playback.
  */
 @Composable
-fun VideoPlayer(
-    videoUri: String,
-    modifier: Modifier = Modifier,
-    autoPlay: Boolean = false,
-    shape: Shape = RoundedCornerShape(16.dp),
-) {
+fun VideoPlayer(videoUri: String, modifier: Modifier = Modifier, autoPlay: Boolean = false, shape: Shape = RoundedCornerShape(16.dp)) {
     val context = LocalContext.current
     val resolvedUri = remember(videoUri) { resolveVideoUri(videoUri) }
 
@@ -206,14 +201,7 @@ private fun VideoPlayerSurface(
     val videoAspectRatio = remember(presentationState.videoSizeDp) {
         val size = presentationState.videoSizeDp
         if (size != null && size.width > 0f && size.height > 0f) {
-            val rawRatio = size.width / size.height
-            @Suppress("DEPRECATION")
-            val rotation = exoPlayer.videoSize.unappliedRotationDegrees
-            if (rotation == 90 || rotation == 270) {
-                if (rawRatio > 0f) 1f / rawRatio else 16f / 9f
-            } else {
-                rawRatio
-            }
+            size.width / size.height
         } else {
             16f / 9f
         }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -245,22 +245,13 @@ fun FullScreenVideoPlayer(videoUri: String, onDismiss: () -> Unit, modifier: Mod
                 val boxRight = box.right.toFloat() - surfacePos.x
                 val boxBottom = box.bottom.toFloat() - surfacePos.y
 
-                val extendsPastBase = boxBottom >= surfaceH - 4f
-                val extendsPastTop = boxTop <= 4f
-                val extendsAcrossWidth = (boxLeft <= 4f || boxLeft <= surfaceW * 0.05f) &&
-                    (boxRight >= surfaceW - 4f || boxRight >= surfaceW * 0.95f)
-
-                // Only treat as full-bleed flat rectangle if it extends across the entire width
-                // AND touches/extends past an edge of the SurfaceView
-                val isFullBleedAtEdge = extendsAcrossWidth && (extendsPastBase || extendsPastTop)
-
-                val left = if (isFullBleedAtEdge) 0f else boxLeft.coerceIn(0f, surfaceW)
+                val left = boxLeft.coerceIn(0f, surfaceW)
                 val top = boxTop.coerceIn(0f, surfaceH)
-                val right = if (isFullBleedAtEdge) surfaceW else boxRight.coerceIn(0f, surfaceW)
-                val bottom = if (extendsPastBase) surfaceH else boxBottom.coerceIn(0f, surfaceH)
+                val right =  boxRight.coerceIn(0f, surfaceW)
+                val bottom = boxBottom.coerceIn(0f, surfaceH)
 
                 if (right > left && bottom > top) {
-                    val cornerRadius = if (isFullBleedAtEdge) 0f else spec.cornerRadiusPx
+                    val cornerRadius =  spec.cornerRadiusPx
                     spec.copy(
                         boundsInSurface = RectF(left, top, right, bottom),
                         cornerRadiusPx = cornerRadius,

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -16,6 +16,7 @@
 
 package com.example.compose.jetchat.conversation
 
+import android.graphics.RectF
 import android.net.Uri
 import android.view.SurfaceHolder
 import android.view.SurfaceView
@@ -27,6 +28,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -46,13 +49,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -68,7 +71,6 @@ import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
 import androidx.media3.ui.compose.state.rememberPresentationState
 import androidx.media3.ui.compose.state.rememberProgressStateWithTickInterval
 import com.example.compose.jetchat.R
-import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 
@@ -186,11 +188,54 @@ private fun VideoPlayerSurface(
 
     fun updateBlurRegions() {
         val sv = surfaceViewRef ?: return
-        if (controlsVisible) {
-            SurfaceViewBlurHelper.applyBlurRegions(sv, blurRegionSpecs.values)
-        } else {
+        if (!controlsVisible) {
             SurfaceViewBlurHelper.clearBlurRegions(sv)
+            return
         }
+        val coords = surfaceCoordinates
+        if (coords == null || !coords.isAttached) {
+            return
+        }
+        val surfacePos = coords.positionInWindow()
+        val surfaceW = coords.size.width.toFloat()
+        val surfaceH = coords.size.height.toFloat()
+        if (surfaceW <= 0f || surfaceH <= 0f) return
+
+        val resolvedRegions = blurRegionSpecs.values.mapNotNull { spec ->
+            val box = spec.boundsInWindow
+            if (box.width > 0 && box.height > 0) {
+                val boxLeft = box.left.toFloat() - surfacePos.x
+                val boxTop = box.top.toFloat() - surfacePos.y
+                val boxRight = box.right.toFloat() - surfacePos.x
+                val boxBottom = box.bottom.toFloat() - surfacePos.y
+
+                val extendsPastBase = boxBottom >= surfaceH - 4f
+                val extendsAcrossWidth = (boxLeft <= 24f || boxLeft <= surfaceW * 0.1f) &&
+                    (boxRight >= surfaceW - 24f || boxRight >= surfaceW * 0.9f)
+
+                val isFullRectangle = extendsPastBase || extendsAcrossWidth
+
+                val left = if (extendsAcrossWidth) 0f else boxLeft.coerceIn(0f, surfaceW)
+                val top = boxTop.coerceIn(0f, surfaceH)
+                val right = if (extendsAcrossWidth) surfaceW else boxRight.coerceIn(0f, surfaceW)
+                val bottom = if (extendsPastBase) surfaceH else boxBottom.coerceIn(0f, surfaceH)
+
+                if (right > left && bottom > top) {
+                    val cornerRadius = if (isFullRectangle) 0f else spec.cornerRadiusPx
+                    spec.copy(
+                        boundsInSurface = RectF(left, top, right, bottom),
+                        cornerRadiusPx = cornerRadius,
+                    )
+                } else {
+                    null
+                }
+            } else if (spec.boundsInSurface.width() > 0f && spec.boundsInSurface.height() > 0f) {
+                spec
+            } else {
+                null
+            }
+        }
+        SurfaceViewBlurHelper.applyBlurRegions(sv, resolvedRegions)
     }
 
     LaunchedEffect(controlsVisible) {
@@ -215,7 +260,7 @@ private fun VideoPlayerSurface(
         }
     }
 
-    Box(
+    BoxWithConstraints(
         modifier = modifier
             .clip(shape)
             .background(Color.Black)
@@ -228,8 +273,19 @@ private fun VideoPlayerSurface(
             },
         contentAlignment = Alignment.Center,
     ) {
+        val containerWidth = maxWidth
+        val containerHeight = maxHeight
+        val hasBoundedWidth = containerWidth.isSpecified && containerWidth > 0.dp && containerWidth != Dp.Infinity
+        val hasBoundedHeight = containerHeight.isSpecified && containerHeight > 0.dp && containerHeight != Dp.Infinity
+
+        val matchHeight = if (hasBoundedWidth && hasBoundedHeight) {
+            (containerWidth.value / containerHeight.value) > videoAspectRatio
+        } else {
+            hasBoundedHeight && !hasBoundedWidth
+        }
+
         Box(
-            modifier = Modifier.aspectRatioFit(videoAspectRatio),
+            modifier = Modifier.aspectRatio(videoAspectRatio, matchHeightConstraintsFirst = matchHeight),
             contentAlignment = Alignment.Center,
         ) {
             // SurfaceView rendering the video directly from ExoPlayer
@@ -258,16 +314,12 @@ private fun VideoPlayerSurface(
                 modifier = Modifier
                     .fillMaxSize()
                     .onGloballyPositioned { coords ->
-                        val prev = surfaceCoordinates
-                        if (prev == null || !prev.isAttached || prev.size != coords.size ||
-                            prev.positionInWindow() != coords.positionInWindow()
-                        ) {
-                            surfaceCoordinates = coords
-                            updateBlurRegions()
-                        }
+                        surfaceCoordinates = coords
+                        updateBlurRegions()
                     },
                 update = { sv ->
                     surfaceViewRef = sv
+                    updateBlurRegions()
                 },
             )
 
@@ -316,44 +368,5 @@ private fun resolveVideoUri(videoUri: String): Uri {
         videoUri.toUri()
     } else {
         DEFAULT_VIDEO_URL.toUri()
-    }
-}
-
-/**
- * Constrains and sizes the element to maintain the target [aspectRatio] while fitting within
- * the incoming layout constraints without requiring [BoxWithConstraints] subcomposition.
- */
-private fun Modifier.aspectRatioFit(aspectRatio: Float): Modifier = this.layout { measurable, constraints ->
-    val hasBoundedWidth = constraints.hasBoundedWidth
-    val hasBoundedHeight = constraints.hasBoundedHeight
-
-    val (targetWidth, targetHeight) = if (hasBoundedWidth && hasBoundedHeight && aspectRatio > 0f) {
-        val containerWidth = constraints.maxWidth
-        val containerHeight = constraints.maxHeight
-        val containerRatio = containerWidth.toFloat() / containerHeight.toFloat()
-        if (containerRatio > aspectRatio) {
-            val height = containerHeight
-            val width = (height * aspectRatio).roundToInt().coerceIn(constraints.minWidth, constraints.maxWidth)
-            width to height
-        } else {
-            val width = containerWidth
-            val height = (width / aspectRatio).roundToInt().coerceIn(constraints.minHeight, constraints.maxHeight)
-            width to height
-        }
-    } else if (hasBoundedWidth && aspectRatio > 0f) {
-        val width = constraints.maxWidth
-        val height = (width / aspectRatio).roundToInt().coerceIn(constraints.minHeight, constraints.maxHeight)
-        width to height
-    } else if (hasBoundedHeight && aspectRatio > 0f) {
-        val height = constraints.maxHeight
-        val width = (height * aspectRatio).roundToInt().coerceIn(constraints.minWidth, constraints.maxWidth)
-        width to height
-    } else {
-        constraints.minWidth to constraints.minHeight
-    }
-
-    val placeable = measurable.measure(Constraints.fixed(targetWidth, targetHeight))
-    layout(placeable.width, placeable.height) {
-        placeable.placeRelative(0, 0)
     }
 }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -16,85 +16,179 @@
 
 package com.example.compose.jetchat.conversation
 
+import android.graphics.Bitmap
 import android.graphics.RectF
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.view.SurfaceHolder
 import android.view.SurfaceView
+import androidx.activity.compose.BackHandler
 import androidx.annotation.OptIn
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.compose.modifiers.resizeWithContentScale
 import androidx.media3.ui.compose.state.rememberMuteButtonState
 import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
 import androidx.media3.ui.compose.state.rememberPresentationState
 import androidx.media3.ui.compose.state.rememberProgressStateWithTickInterval
 import com.example.compose.jetchat.R
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 const val DEFAULT_VIDEO_URL =
     "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_5MB.mp4"
 
 /**
- * Composable video player utilizing SurfaceView and the platform setBlurRegions API
- * to blur regions directly underneath the overlay controls.
- *
- * Hoists a single ExoPlayer instance, eliminating redundant boolean flags and state
- * duplication between inline and fullscreen playback.
+ * Lightweight video thumbnail displayed inside scrollable lists (LazyColumn).
+ * Shows an extracted video frame or styled gradient placeholder with a centered play icon.
+ * Clicking triggers [onClick] to navigate to the full-screen video player screen.
  */
 @Composable
-fun VideoPlayer(videoUri: String, modifier: Modifier = Modifier, autoPlay: Boolean = false, shape: Shape = RoundedCornerShape(16.dp)) {
+fun VideoThumbnail(videoUri: String, onClick: () -> Unit, modifier: Modifier = Modifier, shape: Shape = RoundedCornerShape(16.dp)) {
     val context = LocalContext.current
     val resolvedUri = remember(videoUri) { resolveVideoUri(videoUri) }
 
-    // Single ExoPlayer instance shared seamlessly between inline and fullscreen views
+    val thumbnailBitmap by produceState<Bitmap?>(initialValue = null, resolvedUri) {
+        withContext(Dispatchers.IO) {
+            try {
+                val retriever = MediaMetadataRetriever()
+                val uriString = resolvedUri.toString()
+                if (uriString.startsWith("http://") || uriString.startsWith("https://")) {
+                    retriever.setDataSource(uriString, HashMap<String, String>())
+                } else {
+                    retriever.setDataSource(context, resolvedUri)
+                }
+                val bitmap = retriever.getFrameAtTime(1_000_000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+                    ?: retriever.frameAtTime
+                retriever.release()
+                value = bitmap
+            } catch (e: Throwable) {
+                // Fallback to stylized dark gradient placeholder on network/codec error
+            }
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        Color(0xFF262638),
+                        Color(0xFF14141E),
+                    ),
+                ),
+            )
+            .clickable(
+                role = Role.Button,
+                onClickLabel = stringResource(R.string.play_video),
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (thumbnailBitmap != null) {
+            Image(
+                bitmap = thumbnailBitmap!!.asImageBitmap(),
+                contentDescription = stringResource(R.string.play_video),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.25f)),
+            )
+        }
+
+        // Circular frosted play button
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(56.dp)
+                .background(
+                    color = Color.Black.copy(alpha = 0.55f),
+                    shape = CircleShape,
+                )
+                .border(
+                    width = 1.5.dp,
+                    color = Color.White.copy(alpha = 0.6f),
+                    shape = CircleShape,
+                ),
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_play_arrow),
+                contentDescription = stringResource(R.string.play_video),
+                tint = Color.White,
+                modifier = Modifier.size(32.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Fullscreen video player screen where the SurfaceView extends across the whole surface of the screen,
+ * and controls are free to extend across the whole screen.
+ */
+@OptIn(UnstableApi::class)
+@Composable
+fun FullScreenVideoPlayer(videoUri: String, onDismiss: () -> Unit, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val resolvedUri = remember(videoUri) { resolveVideoUri(videoUri) }
+
     val exoPlayer = remember(context, resolvedUri) {
         ExoPlayer.Builder(context).build().apply {
             setMediaItem(MediaItem.fromUri(resolvedUri))
             repeatMode = Player.REPEAT_MODE_ALL
-            playWhenReady = autoPlay
+            playWhenReady = true
             prepare()
         }
     }
@@ -111,69 +205,11 @@ fun VideoPlayer(videoUri: String, modifier: Modifier = Modifier, autoPlay: Boole
         exoPlayer.pause()
     }
 
-    var isFullscreen by rememberSaveable { mutableStateOf(false) }
+    BackHandler(onBack = onDismiss)
 
-    if (isFullscreen) {
-        Dialog(
-            onDismissRequest = { isFullscreen = false },
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                decorFitsSystemWindows = false,
-                dismissOnBackPress = true,
-                dismissOnClickOutside = false,
-            ),
-        ) {
-            ImmersiveDialogEffect()
+    // Hide system status and navigation bars for immersive edge-to-edge playback
+    ImmersiveSystemBarsEffect()
 
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black),
-                contentAlignment = Alignment.Center,
-            ) {
-                VideoPlayerSurface(
-                    exoPlayer = exoPlayer,
-                    modifier = Modifier.fillMaxSize(),
-                    shape = RoundedCornerShape(0.dp),
-                    isFullscreen = true,
-                    onToggleFullscreen = { isFullscreen = false },
-                )
-            }
-        }
-
-        Box(
-            modifier = modifier
-                .clip(shape)
-                .background(Color.Black),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = stringResource(R.string.fullscreen_video),
-                color = Color.White.copy(alpha = 0.7f),
-                style = MaterialTheme.typography.labelMedium,
-            )
-        }
-    } else {
-        VideoPlayerSurface(
-            exoPlayer = exoPlayer,
-            modifier = modifier,
-            shape = shape,
-            isFullscreen = false,
-            onToggleFullscreen = { isFullscreen = true },
-        )
-    }
-}
-
-@OptIn(UnstableApi::class)
-@Composable
-private fun VideoPlayerSurface(
-    exoPlayer: ExoPlayer,
-    modifier: Modifier = Modifier,
-    shape: Shape = RoundedCornerShape(16.dp),
-    isFullscreen: Boolean = false,
-    onToggleFullscreen: () -> Unit = {},
-) {
-    // Read state from Media3 UI Compose state holders
     val playPauseButtonState = rememberPlayPauseButtonState(exoPlayer)
     val presentationState = rememberPresentationState(exoPlayer)
     val muteButtonState = rememberMuteButtonState(exoPlayer)
@@ -210,20 +246,21 @@ private fun VideoPlayerSurface(
                 val boxBottom = box.bottom.toFloat() - surfacePos.y
 
                 val extendsPastBase = boxBottom >= surfaceH - 4f
-                val extendsAcrossWidth = (boxLeft <= 24f || boxLeft <= surfaceW * 0.1f) &&
-                    (boxRight >= surfaceW - 24f || boxRight >= surfaceW * 0.9f)
+                val extendsPastTop = boxTop <= 4f
+                val extendsAcrossWidth = (boxLeft <= 4f || boxLeft <= surfaceW * 0.05f) &&
+                    (boxRight >= surfaceW - 4f || boxRight >= surfaceW * 0.95f)
 
-                val isFullRectangle = extendsPastBase || extendsAcrossWidth
+                // Only treat as full-bleed flat rectangle if it extends across the entire width
+                // AND touches/extends past an edge of the SurfaceView
+                val isFullBleedAtEdge = extendsAcrossWidth && (extendsPastBase || extendsPastTop)
 
-                val left = if (extendsAcrossWidth) 0f else boxLeft.coerceIn(0f, surfaceW)
+                val left = if (isFullBleedAtEdge) 0f else boxLeft.coerceIn(0f, surfaceW)
                 val top = boxTop.coerceIn(0f, surfaceH)
-                val right = if (extendsAcrossWidth) surfaceW else boxRight.coerceIn(0f, surfaceW)
+                val right = if (isFullBleedAtEdge) surfaceW else boxRight.coerceIn(0f, surfaceW)
                 val bottom = if (extendsPastBase) surfaceH else boxBottom.coerceIn(0f, surfaceH)
 
                 if (right > left && bottom > top) {
-                    // The region overlaps outside the SurfaceView, so the corner radius
-                    // shouldn't be applied in this case
-                    val cornerRadius = if (isFullRectangle) 0f else spec.cornerRadiusPx
+                    val cornerRadius = if (isFullBleedAtEdge) 0f else spec.cornerRadiusPx
                     spec.copy(
                         boundsInSurface = RectF(left, top, right, bottom),
                         cornerRadiusPx = cornerRadius,
@@ -231,8 +268,6 @@ private fun VideoPlayerSurface(
                 } else {
                     null
                 }
-            } else if (spec.boundsInSurface.width() > 0f && spec.boundsInSurface.height() > 0f) {
-                spec
             } else {
                 null
             }
@@ -240,11 +275,21 @@ private fun VideoPlayerSurface(
         SurfaceViewBlurHelper.applyBlurRegions(sv, resolvedRegions)
     }
 
+    DisposableEffect(Unit) {
+        onDispose {
+            surfaceViewRef?.let { sv ->
+                exoPlayer.clearVideoSurface()
+                SurfaceViewBlurHelper.clearBlurRegions(sv)
+            }
+            surfaceViewRef = null
+        }
+    }
+
     LaunchedEffect(controlsVisible) {
         updateBlurRegions()
     }
 
-    // Auto-hide controls after a period of playback inactivity
+    // Auto-hide controls after playback inactivity
     val isPlaying = !playPauseButtonState.showPlay
     LaunchedEffect(controlsVisible, isPlaying, userInteractedTime) {
         if (controlsVisible && isPlaying) {
@@ -253,18 +298,9 @@ private fun VideoPlayerSurface(
         }
     }
 
-    val videoAspectRatio = remember(presentationState.videoSizeDp) {
-        val size = presentationState.videoSizeDp
-        if (size != null && size.width > 0f && size.height > 0f) {
-            size.width / size.height
-        } else {
-            16f / 9f
-        }
-    }
-
     Box(
         modifier = modifier
-            .clip(shape)
+            .fillMaxSize()
             .background(Color.Black)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -275,56 +311,56 @@ private fun VideoPlayerSurface(
             },
         contentAlignment = Alignment.Center,
     ) {
-        Box(
-            modifier = Modifier.aspectRatio(videoAspectRatio, matchHeightConstraintsFirst = true),
-            contentAlignment = Alignment.Center,
-        ) {
-            // SurfaceView rendering the video directly from ExoPlayer
-            AndroidView(
-                factory = { ctx ->
-                    SurfaceView(ctx).apply {
-                        surfaceViewRef = this
-                        exoPlayer.setVideoSurfaceView(this)
-                        holder.addCallback(
-                            object : SurfaceHolder.Callback {
-                                override fun surfaceCreated(holder: SurfaceHolder) {
-                                    updateBlurRegions()
-                                }
+        // SurfaceView sized to fit video aspect ratio using Media3's resizeWithContentScale
+        AndroidView(
+            factory = { ctx ->
+                SurfaceView(ctx).apply {
+                    surfaceViewRef = this
+                    exoPlayer.setVideoSurfaceView(this)
+                    holder.addCallback(
+                        object : SurfaceHolder.Callback {
+                            override fun surfaceCreated(holder: SurfaceHolder) {
+                                updateBlurRegions()
+                            }
 
-                                override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
-                                    updateBlurRegions()
-                                }
+                            override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+                                updateBlurRegions()
+                            }
 
-                                override fun surfaceDestroyed(holder: SurfaceHolder) {
-                                    SurfaceViewBlurHelper.clearBlurRegions(this@apply)
-                                }
-                            },
-                        )
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxSize()
-                    .onGloballyPositioned { coords ->
-                        surfaceCoordinates = coords
-                        updateBlurRegions()
-                    },
-                update = { sv ->
-                    surfaceViewRef = sv
+                            override fun surfaceDestroyed(holder: SurfaceHolder) {
+                                SurfaceViewBlurHelper.clearBlurRegions(this@apply)
+                            }
+                        },
+                    )
+                }
+            },
+            modifier = Modifier
+                .resizeWithContentScale(ContentScale.Fit, presentationState.videoSizeDp)
+                .onGloballyPositioned { coords ->
+                    surfaceCoordinates = coords
                     updateBlurRegions()
                 },
-            )
+            update = { sv ->
+                surfaceViewRef = sv
+                updateBlurRegions()
+            },
+            onRelease = { sv ->
+                exoPlayer.clearVideoSurfaceView(sv)
+                SurfaceViewBlurHelper.clearBlurRegions(sv)
+                surfaceViewRef = null
+            },
+        )
 
-            // Placeholder shutter while video is loading / resetting
-            if (presentationState.coverSurface) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Color.Black),
-                )
-            }
+        // Shutter while video is loading
+        if (presentationState.coverSurface) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black),
+            )
         }
 
-        // Overlay controls that blur the regions underneath using SurfaceView#setBlurRegions
+        // Overlay controls allowed to extend to the whole surface of the screen
         AnimatedVisibility(
             visible = controlsVisible,
             enter = fadeIn(),
@@ -335,8 +371,7 @@ private fun VideoPlayerSurface(
                 playPauseButtonState = playPauseButtonState,
                 muteButtonState = muteButtonState,
                 progressState = progressState,
-                isFullscreen = isFullscreen,
-                surfaceCoordinates = surfaceCoordinates,
+                isFullscreen = true,
                 blurRegionSpecs = blurRegionSpecs,
                 onUserInteraction = {
                     userInteractedTime = System.currentTimeMillis()
@@ -347,10 +382,34 @@ private fun VideoPlayerSurface(
                         exoPlayer.seekTo((progressFraction * duration).toLong())
                     }
                 },
-                onToggleFullscreen = onToggleFullscreen,
+                onToggleFullscreen = onDismiss,
                 onUpdateBlurRegions = { updateBlurRegions() },
+                modifier = Modifier.fillMaxSize(),
             )
         }
+    }
+}
+
+/**
+ * Drop-in backward-compatible composable for displaying video.
+ * Displays a thumbnail in place and launches the fullscreen player screen when tapped.
+ */
+@Composable
+fun VideoPlayer(videoUri: String, modifier: Modifier = Modifier, autoPlay: Boolean = false, shape: Shape = RoundedCornerShape(16.dp)) {
+    var isPlayerOpen by rememberSaveable { mutableStateOf(autoPlay) }
+
+    if (isPlayerOpen) {
+        FullScreenVideoPlayer(
+            videoUri = videoUri,
+            onDismiss = { isPlayerOpen = false },
+        )
+    } else {
+        VideoThumbnail(
+            videoUri = videoUri,
+            onClick = { isPlayerOpen = true },
+            shape = shape,
+            modifier = modifier,
+        )
     }
 }
 

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -27,8 +27,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -38,7 +36,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -49,12 +46,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -70,6 +68,7 @@ import androidx.media3.ui.compose.state.rememberPlayPauseButtonState
 import androidx.media3.ui.compose.state.rememberPresentationState
 import androidx.media3.ui.compose.state.rememberProgressStateWithTickInterval
 import com.example.compose.jetchat.R
+import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 
@@ -183,18 +182,18 @@ private fun VideoPlayerSurface(
 
     var surfaceViewRef by remember { mutableStateOf<SurfaceView?>(null) }
     var surfaceCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
-    val blurRegionSpecs = remember { mutableStateMapOf<String, BlurRegionSpec>() }
+    val blurRegionSpecs = remember { mutableMapOf<String, BlurRegionSpec>() }
 
     fun updateBlurRegions() {
         val sv = surfaceViewRef ?: return
         if (controlsVisible) {
-            SurfaceViewBlurHelper.applyBlurRegions(sv, blurRegionSpecs.values.toList())
+            SurfaceViewBlurHelper.applyBlurRegions(sv, blurRegionSpecs.values)
         } else {
             SurfaceViewBlurHelper.clearBlurRegions(sv)
         }
     }
 
-    LaunchedEffect(controlsVisible, blurRegionSpecs.size) {
+    LaunchedEffect(controlsVisible) {
         updateBlurRegions()
     }
 
@@ -216,7 +215,7 @@ private fun VideoPlayerSurface(
         }
     }
 
-    BoxWithConstraints(
+    Box(
         modifier = modifier
             .clip(shape)
             .background(Color.Black)
@@ -229,19 +228,8 @@ private fun VideoPlayerSurface(
             },
         contentAlignment = Alignment.Center,
     ) {
-        val containerWidth = maxWidth
-        val containerHeight = maxHeight
-        val hasBoundedWidth = containerWidth.isSpecified && containerWidth > 0.dp && containerWidth != Dp.Infinity
-        val hasBoundedHeight = containerHeight.isSpecified && containerHeight > 0.dp && containerHeight != Dp.Infinity
-
-        val matchHeight = if (hasBoundedWidth && hasBoundedHeight) {
-            (containerWidth.value / containerHeight.value) > videoAspectRatio
-        } else {
-            hasBoundedHeight && !hasBoundedWidth
-        }
-
         Box(
-            modifier = Modifier.aspectRatio(videoAspectRatio, matchHeightConstraintsFirst = matchHeight),
+            modifier = Modifier.aspectRatioFit(videoAspectRatio),
             contentAlignment = Alignment.Center,
         ) {
             // SurfaceView rendering the video directly from ExoPlayer
@@ -270,12 +258,16 @@ private fun VideoPlayerSurface(
                 modifier = Modifier
                     .fillMaxSize()
                     .onGloballyPositioned { coords ->
-                        surfaceCoordinates = coords
-                        updateBlurRegions()
+                        val prev = surfaceCoordinates
+                        if (prev == null || !prev.isAttached || prev.size != coords.size ||
+                            prev.positionInWindow() != coords.positionInWindow()
+                        ) {
+                            surfaceCoordinates = coords
+                            updateBlurRegions()
+                        }
                     },
                 update = { sv ->
                     surfaceViewRef = sv
-                    exoPlayer.setVideoSurfaceView(sv)
                 },
             )
 
@@ -324,5 +316,44 @@ private fun resolveVideoUri(videoUri: String): Uri {
         videoUri.toUri()
     } else {
         DEFAULT_VIDEO_URL.toUri()
+    }
+}
+
+/**
+ * Constrains and sizes the element to maintain the target [aspectRatio] while fitting within
+ * the incoming layout constraints without requiring [BoxWithConstraints] subcomposition.
+ */
+private fun Modifier.aspectRatioFit(aspectRatio: Float): Modifier = this.layout { measurable, constraints ->
+    val hasBoundedWidth = constraints.hasBoundedWidth
+    val hasBoundedHeight = constraints.hasBoundedHeight
+
+    val (targetWidth, targetHeight) = if (hasBoundedWidth && hasBoundedHeight && aspectRatio > 0f) {
+        val containerWidth = constraints.maxWidth
+        val containerHeight = constraints.maxHeight
+        val containerRatio = containerWidth.toFloat() / containerHeight.toFloat()
+        if (containerRatio > aspectRatio) {
+            val height = containerHeight
+            val width = (height * aspectRatio).roundToInt().coerceIn(constraints.minWidth, constraints.maxWidth)
+            width to height
+        } else {
+            val width = containerWidth
+            val height = (width / aspectRatio).roundToInt().coerceIn(constraints.minHeight, constraints.maxHeight)
+            width to height
+        }
+    } else if (hasBoundedWidth && aspectRatio > 0f) {
+        val width = constraints.maxWidth
+        val height = (width / aspectRatio).roundToInt().coerceIn(constraints.minHeight, constraints.maxHeight)
+        width to height
+    } else if (hasBoundedHeight && aspectRatio > 0f) {
+        val height = constraints.maxHeight
+        val width = (height * aspectRatio).roundToInt().coerceIn(constraints.minWidth, constraints.maxWidth)
+        width to height
+    } else {
+        constraints.minWidth to constraints.minHeight
+    }
+
+    val placeable = measurable.measure(Constraints.fixed(targetWidth, targetHeight))
+    layout(placeable.width, placeable.height) {
+        placeable.placeRelative(0, 0)
     }
 }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayer.kt
@@ -59,6 +59,8 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
@@ -99,6 +101,13 @@ fun VideoPlayer(videoUri: String, modifier: Modifier = Modifier, autoPlay: Boole
         onDispose {
             exoPlayer.release()
         }
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
+        exoPlayer.pause()
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        exoPlayer.pause()
     }
 
     var isFullscreen by rememberSaveable { mutableStateOf(false) }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
@@ -188,6 +188,7 @@ private fun VideoPlayerCenterPlayButton(
 ) {
     val showPlay = playPauseButtonState.showPlay
     val playDesc = stringResource(if (showPlay) R.string.play_video else R.string.pause_video)
+    val rippleIndication = remember { ripple(bounded = true, radius = 36.dp) }
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
@@ -212,7 +213,7 @@ private fun VideoPlayerCenterPlayButton(
             .clickable(
                 enabled = playPauseButtonState.isEnabled,
                 interactionSource = remember { MutableInteractionSource() },
-                indication = ripple(bounded = true, radius = 36.dp),
+                indication = rippleIndication,
                 role = Role.Button,
             ) {
                 onUserInteraction()
@@ -232,6 +233,8 @@ private fun VideoPlayerCenterPlayButton(
         )
     }
 }
+
+private val BottomBarShape = RoundedCornerShape(16.dp)
 
 @OptIn(UnstableApi::class)
 @Composable
@@ -271,12 +274,12 @@ private fun VideoPlayerBottomBar(
             )
             .background(
                 color = Color(0x33000000),
-                shape = RoundedCornerShape(16.dp),
+                shape = BottomBarShape,
             )
             .border(
                 width = 1.dp,
                 color = Color(0x33FFFFFF),
-                shape = RoundedCornerShape(16.dp),
+                shape = BottomBarShape,
             )
             .padding(horizontal = 8.dp, vertical = 4.dp),
     ) {
@@ -299,40 +302,12 @@ private fun VideoPlayerBottomBar(
             )
         }
 
-        // Timestamp text (e.g. 00:04 / 00:10)
-        val currentPositionMs = progressState.currentPositionMs.coerceAtLeast(0L).toInt()
-        val durationMs = progressState.durationMs.coerceAtLeast(1L).toInt()
-        val formattedTime = remember(currentPositionMs, durationMs) {
-            "${formatTime(currentPositionMs)} / ${formatTime(durationMs)}"
-        }
-        Text(
-            text = formattedTime,
-            color = Color.White,
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(horizontal = 4.dp),
-        )
-
-        // Scrub slider
-        val progressFraction = if (durationMs > 0) {
-            (currentPositionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
-        } else {
-            0f
-        }
-        Slider(
-            value = progressFraction,
-            onValueChange = { progress ->
-                onUserInteraction()
-                onSeekTo(progress)
-            },
-            colors = SliderDefaults.colors(
-                thumbColor = Color.White,
-                activeTrackColor = Color.White,
-                inactiveTrackColor = Color.White.copy(alpha = 0.3f),
-            ),
-            modifier = Modifier
-                .weight(1f)
-                .height(24.dp)
-                .padding(horizontal = 6.dp),
+        // Isolated progress slider: reads fast-changing position state without recomposing the entire bottom bar
+        VideoPlayerProgressSlider(
+            progressState = progressState,
+            onUserInteraction = onUserInteraction,
+            onSeekTo = onSeekTo,
+            modifier = Modifier.weight(1f),
         )
 
         // Mute / Unmute icon button
@@ -372,6 +347,48 @@ private fun VideoPlayerBottomBar(
             )
         }
     }
+}
+
+@OptIn(UnstableApi::class)
+@Composable
+private fun VideoPlayerProgressSlider(
+    progressState: ProgressStateWithTickInterval,
+    onUserInteraction: () -> Unit,
+    onSeekTo: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val currentPositionMs = progressState.currentPositionMs.coerceAtLeast(0L).toInt()
+    val durationMs = progressState.durationMs.coerceAtLeast(1L).toInt()
+    val formattedTime = remember(currentPositionMs, durationMs) {
+        "${formatTime(currentPositionMs)} / ${formatTime(durationMs)}"
+    }
+    Text(
+        text = formattedTime,
+        color = Color.White,
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.padding(horizontal = 4.dp),
+    )
+
+    val progressFraction = if (durationMs > 0) {
+        (currentPositionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    Slider(
+        value = progressFraction,
+        onValueChange = { progress ->
+            onUserInteraction()
+            onSeekTo(progress)
+        },
+        colors = SliderDefaults.colors(
+            thumbColor = Color.White,
+            activeTrackColor = Color.White,
+            inactiveTrackColor = Color.White.copy(alpha = 0.3f),
+        ),
+        modifier = modifier
+            .height(24.dp)
+            .padding(horizontal = 6.dp),
+    )
 }
 
 fun formatTime(millis: Int): String {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
@@ -24,11 +24,14 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -44,7 +47,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -67,8 +69,7 @@ fun VideoPlayerOverlayControls(
     playPauseButtonState: PlayPauseButtonState,
     muteButtonState: MuteButtonState,
     progressState: ProgressStateWithTickInterval,
-    isFullscreen: Boolean,
-    surfaceCoordinates: LayoutCoordinates?,
+    isFullscreen: Boolean = true,
     blurRegionSpecs: MutableMap<String, BlurRegionSpec>,
     onUserInteraction: () -> Unit,
     onSeekTo: (Float) -> Unit,
@@ -76,11 +77,12 @@ fun VideoPlayerOverlayControls(
     onUpdateBlurRegions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+    ) {
         // Top-End Exit Fullscreen Button (fullscreen only)
         if (isFullscreen) {
             VideoPlayerExitFullscreenButton(
-                surfaceCoordinates = surfaceCoordinates,
                 onClick = {
                     onUserInteraction()
                     onToggleFullscreen()
@@ -100,7 +102,6 @@ fun VideoPlayerOverlayControls(
         // Center Play/Pause Floating Circular Button
         VideoPlayerCenterPlayButton(
             playPauseButtonState = playPauseButtonState,
-            surfaceCoordinates = surfaceCoordinates,
             onUserInteraction = onUserInteraction,
             onUpdateRegion = { spec ->
                 blurRegionSpecs[spec.id] = spec
@@ -119,7 +120,6 @@ fun VideoPlayerOverlayControls(
             muteButtonState = muteButtonState,
             progressState = progressState,
             isFullscreen = isFullscreen,
-            surfaceCoordinates = surfaceCoordinates,
             onUserInteraction = onUserInteraction,
             onSeekTo = onSeekTo,
             onToggleFullscreen = onToggleFullscreen,
@@ -131,14 +131,17 @@ fun VideoPlayerOverlayControls(
                 blurRegionSpecs.remove(id)
                 onUpdateBlurRegions()
             },
-            modifier = Modifier.align(Alignment.BottomCenter),
+            modifier = Modifier.align(Alignment.BottomCenter).then(
+                if (isFullscreen)
+                    Modifier.windowInsetsPadding(WindowInsets.safeContent)
+                else Modifier,
+            ),
         )
     }
 }
 
 @Composable
 private fun VideoPlayerExitFullscreenButton(
-    surfaceCoordinates: LayoutCoordinates?,
     onClick: () -> Unit,
     onUpdateRegion: (BlurRegionSpec) -> Unit,
     onRemoveRegion: (String) -> Unit,
@@ -152,7 +155,6 @@ private fun VideoPlayerExitFullscreenButton(
             .size(36.dp)
             .registerBlurRegion(
                 id = "top_close",
-                surfaceCoordinates = surfaceCoordinates,
                 cornerRadius = 18.dp,
                 onUpdateRegion = onUpdateRegion,
                 onRemoveRegion = onRemoveRegion,
@@ -180,7 +182,6 @@ private fun VideoPlayerExitFullscreenButton(
 @Composable
 private fun VideoPlayerCenterPlayButton(
     playPauseButtonState: PlayPauseButtonState,
-    surfaceCoordinates: LayoutCoordinates?,
     onUserInteraction: () -> Unit,
     onUpdateRegion: (BlurRegionSpec) -> Unit,
     onRemoveRegion: (String) -> Unit,
@@ -195,7 +196,6 @@ private fun VideoPlayerCenterPlayButton(
             .size(72.dp)
             .registerBlurRegion(
                 id = "center_play",
-                surfaceCoordinates = surfaceCoordinates,
                 cornerRadius = 36.dp,
                 onUpdateRegion = onUpdateRegion,
                 onRemoveRegion = onRemoveRegion,
@@ -243,7 +243,6 @@ private fun VideoPlayerBottomBar(
     muteButtonState: MuteButtonState,
     progressState: ProgressStateWithTickInterval,
     isFullscreen: Boolean,
-    surfaceCoordinates: LayoutCoordinates?,
     onUserInteraction: () -> Unit,
     onSeekTo: (Float) -> Unit,
     onToggleFullscreen: () -> Unit,
@@ -267,7 +266,6 @@ private fun VideoPlayerBottomBar(
             .padding(horizontal = 8.dp, vertical = 16.dp)
             .registerBlurRegion(
                 id = "bottom_bar",
-                surfaceCoordinates = surfaceCoordinates,
                 cornerRadius = 16.dp,
                 onUpdateRegion = onUpdateRegion,
                 onRemoveRegion = onRemoveRegion,
@@ -391,7 +389,7 @@ private fun VideoPlayerProgressSlider(
     )
 }
 
-fun formatTime(millis: Int): String {
+private fun formatTime(millis: Int): String {
     val totalSeconds = millis / 1000
     val minutes = totalSeconds / 60
     val seconds = totalSeconds % 60

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.jetchat.conversation
+
+import androidx.annotation.OptIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.compose.state.MuteButtonState
+import androidx.media3.ui.compose.state.PlayPauseButtonState
+import androidx.media3.ui.compose.state.ProgressStateWithTickInterval
+import com.example.compose.jetchat.R
+import java.util.Locale
+
+/**
+ * Overlay controls for VideoPlayer with frosted glass styling and blur underneath.
+ */
+@OptIn(UnstableApi::class)
+@Composable
+fun VideoPlayerOverlayControls(
+    playPauseButtonState: PlayPauseButtonState,
+    muteButtonState: MuteButtonState,
+    progressState: ProgressStateWithTickInterval,
+    isFullscreen: Boolean,
+    surfaceCoordinates: LayoutCoordinates?,
+    blurRegionSpecs: MutableMap<String, BlurRegionSpec>,
+    onUserInteraction: () -> Unit,
+    onSeekTo: (Float) -> Unit,
+    onToggleFullscreen: () -> Unit,
+    onUpdateBlurRegions: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        // Top-End Exit Fullscreen Button (fullscreen only)
+        if (isFullscreen) {
+            VideoPlayerExitFullscreenButton(
+                surfaceCoordinates = surfaceCoordinates,
+                onClick = {
+                    onUserInteraction()
+                    onToggleFullscreen()
+                },
+                onUpdateRegion = { spec ->
+                    blurRegionSpecs[spec.id] = spec
+                    onUpdateBlurRegions()
+                },
+                onRemoveRegion = { id ->
+                    blurRegionSpecs.remove(id)
+                    onUpdateBlurRegions()
+                },
+                modifier = Modifier.align(Alignment.TopEnd).padding(8.dp),
+            )
+        }
+
+        // Center Play/Pause Floating Circular Button
+        VideoPlayerCenterPlayButton(
+            playPauseButtonState = playPauseButtonState,
+            surfaceCoordinates = surfaceCoordinates,
+            onUserInteraction = onUserInteraction,
+            onUpdateRegion = { spec ->
+                blurRegionSpecs[spec.id] = spec
+                onUpdateBlurRegions()
+            },
+            onRemoveRegion = { id ->
+                blurRegionSpecs.remove(id)
+                onUpdateBlurRegions()
+            },
+            modifier = Modifier.align(Alignment.Center),
+        )
+
+        // Bottom Control Bar Pill
+        VideoPlayerBottomBar(
+            playPauseButtonState = playPauseButtonState,
+            muteButtonState = muteButtonState,
+            progressState = progressState,
+            isFullscreen = isFullscreen,
+            surfaceCoordinates = surfaceCoordinates,
+            onUserInteraction = onUserInteraction,
+            onSeekTo = onSeekTo,
+            onToggleFullscreen = onToggleFullscreen,
+            onUpdateRegion = { spec ->
+                blurRegionSpecs[spec.id] = spec
+                onUpdateBlurRegions()
+            },
+            onRemoveRegion = { id ->
+                blurRegionSpecs.remove(id)
+                onUpdateBlurRegions()
+            },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun VideoPlayerExitFullscreenButton(
+    surfaceCoordinates: LayoutCoordinates?,
+    onClick: () -> Unit,
+    onUpdateRegion: (BlurRegionSpec) -> Unit,
+    onRemoveRegion: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val exitFullscreenDesc = stringResource(R.string.exit_fullscreen_video)
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .padding(8.dp)
+            .size(36.dp)
+            .registerBlurRegion(
+                id = "top_close",
+                surfaceCoordinates = surfaceCoordinates,
+                cornerRadius = 18.dp,
+                onUpdateRegion = onUpdateRegion,
+                onRemoveRegion = onRemoveRegion,
+            )
+            .background(
+                color = Color(0x33000000),
+                shape = CircleShape,
+            )
+            .border(
+                width = 1.dp,
+                color = Color(0x33FFFFFF),
+                shape = CircleShape,
+            ),
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_close),
+            contentDescription = exitFullscreenDesc,
+            tint = Color.White,
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+@OptIn(UnstableApi::class)
+@Composable
+private fun VideoPlayerCenterPlayButton(
+    playPauseButtonState: PlayPauseButtonState,
+    surfaceCoordinates: LayoutCoordinates?,
+    onUserInteraction: () -> Unit,
+    onUpdateRegion: (BlurRegionSpec) -> Unit,
+    onRemoveRegion: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val showPlay = playPauseButtonState.showPlay
+    val playDesc = stringResource(if (showPlay) R.string.play_video else R.string.pause_video)
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .size(84.dp)
+            .registerBlurRegion(
+                id = "center_play",
+                surfaceCoordinates = surfaceCoordinates,
+                cornerRadius = 42.dp,
+                onUpdateRegion = onUpdateRegion,
+                onRemoveRegion = onRemoveRegion,
+            )
+            .clip(CircleShape)
+            .background(
+                color = Color(0x33000000),
+                shape = CircleShape,
+            )
+            .border(
+                width = 1.dp,
+                color = Color(0x4DFFFFFF),
+                shape = CircleShape,
+            )
+            .clickable(
+                enabled = playPauseButtonState.isEnabled,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(bounded = true, radius = 56.dp),
+                role = Role.Button,
+            ) {
+                onUserInteraction()
+                playPauseButtonState.onClick()
+            }
+            .semantics {
+                contentDescription = playDesc
+            },
+    ) {
+        Icon(
+            painter = painterResource(
+                id = if (showPlay) R.drawable.ic_play_arrow else R.drawable.ic_pause,
+            ),
+            contentDescription = playDesc,
+            tint = Color.White,
+            modifier = Modifier.size(30.dp),
+        )
+    }
+}
+
+@OptIn(UnstableApi::class)
+@Composable
+private fun VideoPlayerBottomBar(
+    playPauseButtonState: PlayPauseButtonState,
+    muteButtonState: MuteButtonState,
+    progressState: ProgressStateWithTickInterval,
+    isFullscreen: Boolean,
+    surfaceCoordinates: LayoutCoordinates?,
+    onUserInteraction: () -> Unit,
+    onSeekTo: (Float) -> Unit,
+    onToggleFullscreen: () -> Unit,
+    onUpdateRegion: (BlurRegionSpec) -> Unit,
+    onRemoveRegion: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val showPlay = playPauseButtonState.showPlay
+    val playDesc = stringResource(if (showPlay) R.string.play_video else R.string.pause_video)
+    val showMuted = muteButtonState.showMuted
+    val muteDesc = stringResource(if (showMuted) R.string.unmute_video else R.string.mute_video)
+    val fullscreenDesc = stringResource(
+        if (isFullscreen) R.string.exit_fullscreen_video else R.string.fullscreen_video,
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 16.dp)
+            .registerBlurRegion(
+                id = "bottom_bar",
+                surfaceCoordinates = surfaceCoordinates,
+                cornerRadius = 24.dp,
+                onUpdateRegion = onUpdateRegion,
+                onRemoveRegion = onRemoveRegion,
+            )
+            .background(
+                color = Color(0x33000000),
+                shape = RoundedCornerShape(16.dp),
+            )
+            .border(
+                width = 1.dp,
+                color = Color(0x33FFFFFF),
+                shape = RoundedCornerShape(16.dp),
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        // Play/pause icon button
+        IconButton(
+            onClick = {
+                onUserInteraction()
+                playPauseButtonState.onClick()
+            },
+            enabled = playPauseButtonState.isEnabled,
+            modifier = Modifier.size(32.dp),
+        ) {
+            Icon(
+                painter = painterResource(
+                    id = if (showPlay) R.drawable.ic_play_arrow else R.drawable.ic_pause,
+                ),
+                contentDescription = playDesc,
+                tint = Color.White,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+
+        // Timestamp text (e.g. 00:04 / 00:10)
+        val currentPositionMs = progressState.currentPositionMs.coerceAtLeast(0L).toInt()
+        val durationMs = progressState.durationMs.coerceAtLeast(1L).toInt()
+        val formattedTime = remember(currentPositionMs, durationMs) {
+            "${formatTime(currentPositionMs)} / ${formatTime(durationMs)}"
+        }
+        Text(
+            text = formattedTime,
+            color = Color.White,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
+        // Scrub slider
+        val progressFraction = if (durationMs > 0) {
+            (currentPositionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+        Slider(
+            value = progressFraction,
+            onValueChange = { progress ->
+                onUserInteraction()
+                onSeekTo(progress)
+            },
+            colors = SliderDefaults.colors(
+                thumbColor = Color.White,
+                activeTrackColor = Color.White,
+                inactiveTrackColor = Color.White.copy(alpha = 0.3f),
+            ),
+            modifier = Modifier
+                .weight(1f)
+                .height(24.dp)
+                .padding(horizontal = 6.dp),
+        )
+
+        // Mute / Unmute icon button
+        IconButton(
+            onClick = {
+                onUserInteraction()
+                muteButtonState.onClick()
+            },
+            enabled = muteButtonState.isEnabled,
+            modifier = Modifier.size(32.dp),
+        ) {
+            Icon(
+                painter = painterResource(
+                    id = if (showMuted) R.drawable.ic_volume_off else R.drawable.ic_volume_up,
+                ),
+                contentDescription = muteDesc,
+                tint = Color.White,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+
+        // Fullscreen toggle icon button
+        IconButton(
+            onClick = {
+                onUserInteraction()
+                onToggleFullscreen()
+            },
+            modifier = Modifier.size(32.dp),
+        ) {
+            Icon(
+                painter = painterResource(
+                    id = if (isFullscreen) R.drawable.ic_fullscreen_exit else R.drawable.ic_fullscreen,
+                ),
+                contentDescription = fullscreenDesc,
+                tint = Color.White,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+fun formatTime(millis: Int): String {
+    val totalSeconds = millis / 1000
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+}

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
@@ -191,11 +191,11 @@ private fun VideoPlayerCenterPlayButton(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .size(84.dp)
+            .size(72.dp)
             .registerBlurRegion(
                 id = "center_play",
                 surfaceCoordinates = surfaceCoordinates,
-                cornerRadius = 42.dp,
+                cornerRadius = 36.dp,
                 onUpdateRegion = onUpdateRegion,
                 onRemoveRegion = onRemoveRegion,
             )
@@ -212,7 +212,7 @@ private fun VideoPlayerCenterPlayButton(
             .clickable(
                 enabled = playPauseButtonState.isEnabled,
                 interactionSource = remember { MutableInteractionSource() },
-                indication = ripple(bounded = true, radius = 56.dp),
+                indication = ripple(bounded = true, radius = 36.dp),
                 role = Role.Button,
             ) {
                 onUserInteraction()

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
@@ -266,7 +266,7 @@ private fun VideoPlayerBottomBar(
             .padding(horizontal = 8.dp, vertical = 16.dp)
             .registerBlurRegion(
                 id = "bottom_bar",
-                cornerRadius = 16.dp,
+                cornerRadius = 0.dp,
                 onUpdateRegion = onUpdateRegion,
                 onRemoveRegion = onRemoveRegion,
             )

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerControls.kt
@@ -268,7 +268,7 @@ private fun VideoPlayerBottomBar(
             .registerBlurRegion(
                 id = "bottom_bar",
                 surfaceCoordinates = surfaceCoordinates,
-                cornerRadius = 24.dp,
+                cornerRadius = 16.dp,
                 onUpdateRegion = onUpdateRegion,
                 onRemoveRegion = onRemoveRegion,
             )

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerWindowHelper.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerWindowHelper.kt
@@ -16,54 +16,47 @@
 
 package com.example.compose.jetchat.conversation
 
-import android.graphics.drawable.ColorDrawable
-import android.os.Build
-import android.view.Window
-import android.view.WindowManager
+import android.app.Activity
+import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.window.DialogWindowProvider
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 
 /**
- * Hides system status and navigation bars for the fullscreen video dialog (immersive mode)
- * and allows the dialog window to draw into camera cutout areas.
- *
- * Edge-to-edge layout is handled natively by DialogProperties(decorFitsSystemWindows = false).
+ * Hides system status and navigation bars for in-window fullscreen video playback (immersive mode)
+ * and restores them when disposed.
  */
 @Composable
-fun ImmersiveDialogEffect() {
+fun ImmersiveSystemBarsEffect() {
     val view = LocalView.current
-
-    DisposableEffect(view) {
-        var parent = view.parent
-        var dialogWindow: Window? = null
-        while (parent != null) {
-            if (parent is DialogWindowProvider) {
-                dialogWindow = parent.window
-                break
-            }
-            parent = parent.parent
+    var context = view.context
+    var activity: Activity? = null
+    while (context is ContextWrapper) {
+        if (context is Activity) {
+            activity = context
+            break
         }
+        context = context.baseContext
+    }
 
-        if (dialogWindow != null) {
-            dialogWindow.setBackgroundDrawable(android.graphics.Color.BLACK.toDrawable())
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                dialogWindow.attributes.layoutInDisplayCutoutMode =
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-            }
-
-            val insetsController = WindowCompat.getInsetsController(dialogWindow, dialogWindow.decorView)
+    DisposableEffect(activity, view) {
+        val window = activity?.window
+        if (window != null) {
+            val insetsController = WindowCompat.getInsetsController(window, window.decorView)
+            val prevBehavior = insetsController.systemBarsBehavior
             insetsController.systemBarsBehavior =
                 WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
             insetsController.hide(WindowInsetsCompat.Type.systemBars())
-        }
-        onDispose {
+
+            onDispose {
+                insetsController.systemBarsBehavior = prevBehavior
+                insetsController.show(WindowInsetsCompat.Type.systemBars())
+            }
+        } else {
+            onDispose { }
         }
     }
 }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerWindowHelper.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerWindowHelper.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.jetchat.conversation
+
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import android.view.Window
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.graphics.drawable.toDrawable
+
+/**
+ * Hides system status and navigation bars for the fullscreen video dialog (immersive mode)
+ * and allows the dialog window to draw into camera cutout areas.
+ *
+ * Edge-to-edge layout is handled natively by DialogProperties(decorFitsSystemWindows = false).
+ */
+@Composable
+fun ImmersiveDialogEffect() {
+    val view = LocalView.current
+
+    DisposableEffect(view) {
+        var parent = view.parent
+        var dialogWindow: Window? = null
+        while (parent != null) {
+            if (parent is DialogWindowProvider) {
+                dialogWindow = parent.window
+                break
+            }
+            parent = parent.parent
+        }
+
+        if (dialogWindow != null) {
+            dialogWindow.setBackgroundDrawable(android.graphics.Color.BLACK.toDrawable())
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                dialogWindow.attributes.layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            }
+
+            val insetsController = WindowCompat.getInsetsController(dialogWindow, dialogWindow.decorView)
+            insetsController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            insetsController.hide(WindowInsetsCompat.Type.systemBars())
+        }
+        onDispose {
+
+        }
+    }
+}

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerWindowHelper.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/VideoPlayerWindowHelper.kt
@@ -24,10 +24,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.core.graphics.drawable.toDrawable
 
 /**
  * Hides system status and navigation bars for the fullscreen video dialog (immersive mode)
@@ -64,7 +64,6 @@ fun ImmersiveDialogEffect() {
             insetsController.hide(WindowInsetsCompat.Type.systemBars())
         }
         onDispose {
-
         }
     }
 }

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/data/FakeData.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/data/FakeData.kt
@@ -33,6 +33,12 @@ val initialMessages = listOf(
         "8:07 PM",
     ),
     Message(
+        "Taylor Brooks",
+        "Here's a demo of the new blur regions feature in action! 🎥",
+        "8:06 PM",
+        videoUri = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8",
+    ),
+    Message(
         "me",
         "Thank you!$EMOJI_PINK_HEART",
         "8:06 PM",

--- a/Jetchat/app/src/main/res/drawable/ic_close.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/Jetchat/app/src/main/res/drawable/ic_fullscreen.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_fullscreen.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M7,14H5v5h5v-2H7v-3zm-2,-4h2V7h3V5H5v5zm12,7h-3v2h5v-5h-2v3zM14,5v2h3v3h2V5h-5z"/>
+</vector>

--- a/Jetchat/app/src/main/res/drawable/ic_fullscreen_exit.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_fullscreen_exit.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M5,16h3v3h2v-5H5v2zm3,-8H5v2h5V5H8v3zm6,11h2v-3h3v-2h-5v5zm2,-11V5h-2v5h5V8h-3z"/>
+</vector>

--- a/Jetchat/app/src/main/res/drawable/ic_pause.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_pause.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M6,19h4V5H6v14zm8,-14v14h4V5h-4z"/>
+</vector>

--- a/Jetchat/app/src/main/res/drawable/ic_play_arrow.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_play_arrow.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M8,5v14l11,-7z"/>
+</vector>

--- a/Jetchat/app/src/main/res/drawable/ic_send.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_send.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z"/>
+</vector>

--- a/Jetchat/app/src/main/res/drawable/ic_volume_off.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_volume_off.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v2.21l2.45,2.45c0.03,-0.2 0.05,-0.41 0.05,-0.63zm2.5,0c0,0.94 -0.2,1.82 -0.54,2.64l1.51,1.51C20.63,14.91 21,13.5 21,12c0,-4.28 -2.99,-7.86 -7,-8.77v2.06c2.89,0.86 5,3.54 5,6.71zM4.27,3L3,4.27l4.46,4.46H3v6h4l5,5v-6.73l4.25,4.25c-0.67,0.52 -1.42,0.93 -2.25,1.18v2.06c1.38,-0.31 2.63,-0.95 3.69,-1.81L19.73,21 21,19.73l-9,-9L4.27,3zM12,4L9.91,6.09 12,8.18V4z"/>
+</vector>

--- a/Jetchat/app/src/main/res/drawable/ic_volume_up.xml
+++ b/Jetchat/app/src/main/res/drawable/ic_volume_up.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M3,9v6h4l5,5V4L7,9H3zm13.5,3c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z"/>
+</vector>

--- a/Jetchat/app/src/main/res/values/strings.xml
+++ b/Jetchat/app/src/main/res/values/strings.xml
@@ -70,4 +70,17 @@
     <string name="messages_widget_title">JetChat unread messages</string>
     <string name="add_widget_to_home_page">Add Widget to Home Page</string>
 
+    <string name="video_message">Video message</string>
+    <string name="send_video_message">Send video message</string>
+    <string name="choose_video_from_device">Choose from device</string>
+    <string name="sample_video">Sample video</string>
+    <string name="video_caption_hint">Add a caption…</string>
+    <string name="play_video">Play video</string>
+    <string name="pause_video">Pause video</string>
+    <string name="mute_video">Mute video</string>
+    <string name="unmute_video">Unmute video</string>
+    <string name="fullscreen_video">Full screen</string>
+    <string name="exit_fullscreen_video">Exit full screen</string>
+    <string name="remove_attached_video">Remove attached video</string>
+
 </resources>

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -45,6 +45,9 @@ kotlinx_immutable = "0.5.1"
 ksp = "2.3.11"
 maps-compose = "8.4.0"
 # @keep
+media3Exoplayer = "1.11.0"
+media3ExoplayerHls = "1.11.0"
+media3UiCompose = "1.11.0"
 minSdk = "23"
 okhttp = "5.4.0"
 play-services-wearable = "20.0.1"
@@ -103,6 +106,9 @@ androidx-lifecycle-viewModelCompose = { module = "androidx.lifecycle:lifecycle-v
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-compose" }
 androidx-lifecycle-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle-compose" }
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
+androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "media3ExoplayerHls" }
+androidx-media3-ui-compose = { module = "androidx.media3:media3-ui-compose", version.ref = "media3UiCompose" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }


### PR DESCRIPTION
- **Core Playback:** Integrated `androidx.media3` (ExoPlayer) and implemented a custom `VideoPlayer` composable using `SurfaceView` to showcase SurfaceView.setBlurRegions. 
- **UI State:** Updated the `Message` data model to support an optional `videoUri`.
- **User Input:** Enhanced `UserInput` with a video picker and an `AttachedVideoPreview` component for reviewing videos before sending.
- **Advanced Visuals:** Added `SurfaceViewBlurHelper` and `registerBlurRegion` modifier to utilize the platform's `setBlurRegions` API (SDK 37+) for frosted-glass control overlays.
- **Fullscreen Mode:** Implemented immersive fullscreen playback using a `Dialog` with custom window insets handling.